### PR TITLE
fixed css relative path to minicolors sprite

### DIFF
--- a/cortex/webgl/resources/css/jquery.miniColors.css
+++ b/cortex/webgl/resources/css/jquery.miniColors.css
@@ -7,7 +7,7 @@
 }
 
 .minicolors-no-data-uris .minicolors-sprite {
-	background-image: url(jquery.minicolors.png);
+	background-image: url(../images/colors.png);
 }
 
 .minicolors-swatch {


### PR DESCRIPTION
Hi Guys,

I'm working with @chrisfilo on [NeuroVault](https://github.com/NeuroVault/NeuroVault), and I've been doing some updates on our utilization of pycortex.

While upgrading our branch, I noticed this broken css path to the color picker sprite.  The file name seems to changed, which broke the relative paths used in webgl.make_static().  I think it only affects the statically generated views.

Thanks for the great tool. :+1: 

Cheers,
Gabriel
