### PR TITLE
Docs update to reflect broken pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,29 @@ Pycortex is a software that allows you to visualize fMRI or other volumetric map
 
 Quickstart
 ----------
-The easiest way to get pycortex is to use the [Anaconda python distribution](https://store.continuum.io/cshop/anaconda/). Download and install anaconda, then run the following commands:
+UPDATE 2015.11.24: Unfortunately, the pip install of pycortex is out of date and broken. The pip installation will thus not work. We apologize for any frustration or inconvenience this may have caused. We will eventually update the version stored on pip, but for now please see below for instructions on how to install pycortex directly from the git repository. 
+
+The easiest way to configure your local python environment to suport pycortex is to use the [Anaconda python distribution](https://store.continuum.io/cshop/anaconda/). Download and install anaconda, then run the following command to install one non-standard library (nibabel) for reading and writing fMRI data:
 
 ```
-$ sudo pip install nibabel
-$ sudo pip install pycortex
+$ sudo pip install nibabel 
 ```
 
-If you are using [Ubuntu](http://ubuntu.com), using [Neurodebian](http://neuro.debian.net/) is highly recommended. The following command will install all python prerequisites:
+This should work on Mac or Linux PCs. If you using Ubuntu, you can skip Anaconda and use the following command instead, which will install all python prerequisites for pycortex.
 
 ```
 $ sudo apt-get install python-pip python-dev python-numpy python-scipy python-matplotlib python-h5py python-nibabel python-lxml python-shapely python-html5lib mayavi2 inkscape blender
-$ sudo pip install pycortex
 ```
+
+To install from the github repository, call the following commands. For both commands, replace `<your_directory>` with the folder where you would like to store the pycortex source code.
+
+```
+$ git clone http://github.com/gallantlab/pycortex <your_directory> 
+$ cd <your_directory>
+$ sudo python setup.py install
+```
+
+This last command installs pycortex into the site-packages folder in your local python installation. This means that you will not need to change your PYTHONPATH variable (don't worry if you have no idea what that means). If you are working in a python terminal, do not try to import pycortex from inside the source code directory, or the import will fail. 
 
 Demo
 ----
@@ -33,7 +43,7 @@ In [3]: cortex.webshow(ds)
 
 Documentation
 -------------
-Please find more complete documentation for pycortex at http://gallantlab.org/pycortex/docs/. The documentation for pycortex is currently incomplete, but will be improved in the coming days.
+Please find more complete documentation for pycortex at http://gallantlab.org/pycortex/docs/. The documentation for pycortex is currently incomplete, but will be improved in the coming days, weeks, or months.
 
 Citation
 --------


### PR DESCRIPTION
Changing README to reflect the fact that pip is currently broken, adding instructions for installing from the git repo.