### PR TITLE
ENH: allow HTML title to be set via make_static kwargs.

### DIFF
--- a/cortex/webgl/simple.html
+++ b/cortex/webgl/simple.html
@@ -10,7 +10,7 @@ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, TH
 -->
 
 <html>
-<title>Brain</title>
+<title>{{ title }}</title>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">

--- a/cortex/webgl/template.html
+++ b/cortex/webgl/template.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
-<title>Brain</title>
+<title>{{ title }}</title>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">

--- a/cortex/webgl/view.py
+++ b/cortex/webgl/view.py
@@ -36,7 +36,8 @@ colormaps = glob.glob(os.path.join(cmapdir, "*.png"))
 colormaps = [(os.path.splitext(os.path.split(cm)[1])[0], serve.make_base64(cm))
              for cm in sorted(colormaps)]
 
-viewopts = dict(voxlines="false", voxline_color="#FFFFFF", voxline_width='.01' )
+viewopts = dict(voxlines="false", voxline_color="#FFFFFF",
+                voxline_width='.01', title="Brain")
 
 def make_static(outpath, data, types=("inflated",), recache=False, cmap="RdBu_r",
                 template="static.html", layout=None, anonymize=False,
@@ -184,7 +185,8 @@ def make_static(outpath, data, types=("inflated",), recache=False, cmap="RdBu_r"
     print(disp_layers)
     loader = FallbackLoader(rootdirs)
     tpl = loader.load(templatefile)
-    kwargs.update(viewopts)
+    tpl_args = copy.deepcopy(viewopts)
+    tpl_args.update(kwargs)  # override viewopts with kwargs
     html = tpl.generate(data=json.dumps(metadata),
                         colormaps=colormaps,
                         default_cmap=cmap,
@@ -193,7 +195,7 @@ def make_static(outpath, data, types=("inflated",), recache=False, cmap="RdBu_r"
                         subjects=json.dumps(ctms),
                         disp_layers=disp_layers,
                         disp_defaults=_make_disp_defaults(disp_layers),
-                        **kwargs)
+                        **tpl_args)
     desthtml = os.path.join(outpath, "index.html")
     if html_embed:
         htmlembed.embed(html, desthtml, rootdirs)


### PR DESCRIPTION
Currently, the HTML title of rendered output is hard-coded as `Brain`. This allows the `title` to be set via `kwargs` to `make_static`, with a default to `Brain`.

If accepted, this would allow, for example, NeuroVault to display the title of the image displayed to users (see https://github.com/NeuroVault/NeuroVault/issues/398)