### PR TITLE
added 'sname=cx_name' to the segment_cut function 

### DIFF
--- a/cortex/segment.py
+++ b/cortex/segment.py
@@ -142,7 +142,7 @@ def cut_surface(cx_subject, hemi, name='flatten', fs_subject=None, data=None, fr
     other = freesurfer.get_paths(fs_subject, "lh" if hemi == "rh" else "rh", 
                                  freesurfer_subject_dir=freesurfer_subject_dir).format(name=name+".flat")
     if os.path.exists(other):
-        freesurfer.import_flat(fs_subject, name, freesurfer_subject_dir=freesurfer_subject_dir)
+        freesurfer.import_flat(fs_subject, name, sname=cx_subject, freesurfer_subject_dir=freesurfer_subject_dir)
 
 def _cycle_surf(subject, surf):
     status = mp.Value('b', 1)


### PR DESCRIPTION
added 'sname=cx_name' to the segment_cut function so import_flat knows what to work with. This fixes the error I was getting when trying to flatten a subject with differing freesurfer and pycortex names.