### PR TITLE
docs: make print functions instead of print statements

### DIFF
--- a/cortex/brainctm.py
+++ b/cortex/brainctm.py
@@ -205,7 +205,7 @@ class Hemi(object):
         attrib = np.hstack([rnorm, np.zeros((len(rnorm),1))])
         self.surfs[name] = attrib
         self.ctm.addAttrib(attrib, name)
-        print name
+        print(name)
 
     def setFlat(self, pts):
         self.ctm.addUV(pts[:,:2].astype(float), 'uv')

--- a/cortex/rois.py
+++ b/cortex/rois.py
@@ -100,7 +100,7 @@ class ROIpack(object):
         # Construct polygon adjacency graph for each surface
         polygraphs = [lsurf.poly_graph, rsurf.poly_graph]
         for roi in self.rois.keys():
-            print "Adding %s.." % roi
+            print("Adding %s.." % roi)
             masks = self.rois[roi].left, self.rois[roi].right
             mmpts = svgmpts[:len(masks[0])], svgmpts[len(masks[0]):]
             roilayer = _make_layer(_find_layer(svg, "rois"), roi)

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -345,8 +345,8 @@ def get_roi_masks(subject, xfmname, roi_list=None, dst=2, fail_for_missing_rois=
             #roi_idx_sub1 = rois.get_roi(roi) # substitution index 1 (in valid vertex space) # OLD
             roi_idx_sub1 = get_roi_verts(subject, roi=roi)[roi] # NEW
             # New
-            print n_valid_vertices
-            print n_verts
+            print(n_valid_vertices)
+            print(n_verts)
             1/0
             roi_idx_bin1 = np.zeros((n_valid_vertices,),np.bool) # binary index 1
 


### PR DESCRIPTION
need to do this for travis auto generated docs to work. shouldn't break python2.7 if you have recent version of 2.7