### PR TITLE
changes that make the gallery examples python3 compatible (for doc autogeneration with doctr/travis CI)

### DIFF
--- a/cortex/mni.py
+++ b/cortex/mni.py
@@ -147,7 +147,7 @@ def transform_surface_to_mni(subject, surfname):
 
     # Transform anatomical space points to MNI space
     mni_lpts, mni_rpts = [np.dot(mni_xfm, np.hstack([p, np.ones((p.shape[0],1))]).T).T[:,:3]
-                          for p in anat_lpts, anat_rpts]
+                          for p in (anat_lpts, anat_rpts)]
 
     return [(mni_lpts, lpolys), (mni_rpts, rpolys)]
 

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -7,7 +7,7 @@ import tempfile
 import itertools
 import numpy as np
 import subprocess as sp
-from svgsplines import LineSpline, QuadBezSpline, CubBezSpline, ArcSpline
+from .svgsplines import LineSpline, QuadBezSpline, CubBezSpline, ArcSpline
 
 from scipy.spatial import cKDTree
 


### PR DESCRIPTION
Autogeneration of docs through Travis CI and `doctr` requires that all of the gallery code be compatible with python3. The goal of this PR is to bring python3 compatibility to just those parts of pycortex that the gallery code uses.