### PR TITLE
refactor loading user and default configuration

### DIFF
--- a/cortex/options.py
+++ b/cortex/options.py
@@ -1,30 +1,78 @@
 import os
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+
+from six.moves import configparser
+import six
+
+if six.PY2:
+  ConfigParser = configparser.SafeConfigParser
+else:
+  ConfigParser = configparser.ConfigParser
+
 from . import appdirs
 
+def add_defaults(config, defaults):
+    """Adds default values to a configuration
+
+    Checks all entries of a default configuration and adds them to another
+    configuration if it does not have a value for that entry.
+
+    Parameters
+    ----------
+    config : configparser.ConfigParser
+    defaults : configparser.ConfigParser
+
+    Returns
+    -------
+    Boolean indicating whether or not configuration was changed.
+    """
+    updated = False
+    for section in defaults.sections():
+        if not config.has_section(section):
+            updated = True
+            config.add_section(section)
+
+        for item, default in defaults.items(section):
+            try:
+                value = config.get(section, item)
+            except (configparser.NoOptionError):
+                updated = True
+                config.set(section, item, default)
+
+    return updated
+
 cwd = os.path.split(os.path.abspath(__file__))[0]
-userdir = appdirs.user_data_dir("pycortex", "JamesGao")
-usercfg = os.path.join(userdir, "options.cfg")
 
-# Read defaults from pycortex repo
-config = configparser.ConfigParser()
-config.read(os.path.join(cwd, 'defaults.cfg'))
+# read default options
+default_path = os.path.join(cwd, 'defaults.cfg')
+defaults = ConfigParser()
+_ = defaults.read(default_path)
 
-# Update defaults with user-sepecifed values in user config
-files_successfully_read = config.read(usercfg)
+# read user options
+config_dir = appdirs.user_data_dir("pycortex", "JamesGao")
+config_path = os.path.join(config_dir, "options.cfg")
+config = ConfigParser()
 
-# If user config doesn't exist, create it
-if len(files_successfully_read) == 0:
-    os.makedirs(userdir)
-    with open(usercfg, 'w') as fp:
-        config.write(fp)
-        
-#set default path in case the module is imported from the source code directory
+if os.path.exists(config_path):
+    _ = config.read(config_path)
+else:
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
+
+# overwrite defaults with user values
+updated = add_defaults(config, defaults)
+
+if updated:
+    print ('updating user configuration file at {}'.format(config_path))
+    # write updated configuration to user config file
+    with open(config_path, 'w') as config_file:
+        config.write(config_file)
+
+# set default path in case the module is imported from the source code
+# directory
 if not config.has_option("basic", "filestore"):
-    config.set("basic", "filestore", os.path.join(cwd, os.pardir, "filestore/db"))
+    config.set("basic", "filestore",
+               os.path.join(cwd, os.pardir, "filestore/db"))
 
 if not config.has_option("webgl", "colormaps"):
-    config.set("webgl", "colormaps", os.path.join(cwd, os.pardir, "filestore/colormaps"))
+    config.set("webgl", "colormaps",
+               os.path.join(cwd, os.pardir, "filestore/colormaps"))

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -48,7 +48,7 @@ You can check the location of the filestore after installing by running::
 And you can check the location of the config file by running::
 
     import cortex
-    cortex.options.usercfg
+    cortex.options.config_path
 
 If you want to move the filestore, you need to update the config file::
 


### PR DESCRIPTION
Addresses #177 and #207.

Load config values from the user config file and add any default values (from `defaults.cfg`) that are not present in the user file. If any changes are needed to the user file (defaults that are not there), overwrite the user file with defaults.

python2.7 `ConfigParser.SafeConfigParser` is supposed to be equivalent to python3 `configparser.ConfigParser` but it doesn't have an `.update` module, (!!) so we have to write our own. Charming.