### PR TITLE
Utility scripts to convert pycortex xfm to FreeSurfer register.dat

### DIFF
--- a/utils/fsreg2xfm
+++ b/utils/fsreg2xfm
@@ -1,0 +1,65 @@
+#!/usr/bin/env tcsh
+
+if ($# != 4) then
+  echo "Usage: $0:t [inFsRegFile] [refEPI] [subjectName] [xfmName]"
+  echo
+  echo "e.g.) $0:t register.dat refEPI.nii AWT1x2 fs_fullhead"
+  echo
+  echo "inFsRegFile  : Input registration file to be converted to pycortex format"
+  echo "               (expected to be in FreeSurfer register.dat format)"
+  echo "refEPI       : Referece volume to be registerd along with the affine matrix"
+  echo "subjectName  : Name of the target subject registered in pycortex database"
+  echo "               (expected to be identical with that for FreeSurfer)"
+  echo "xfmName      : Name of the transform to be newly registered to pycortex DB"
+  exit 1
+endif
+
+## Check command line arguments
+set fsRegFile=$1
+shift
+
+set refFile=$1
+shift
+
+set subjectName=$1
+shift
+
+set xfmName=$1
+shift
+
+## Create a temorary working directory
+set tmpdir=`mktemp -d`
+
+## Set paths
+set anatFile=$SUBJECTS_DIR/$subjectName/mri/orig.mgz
+set fsRegMtx=$tmpdir/fsreg.mtx
+set pycRegMtx=$tmpdir/pycreg.mtx
+
+## Extract the affine matrix from FreeSurfer register.dat file
+head -n 8 $fsRegFile | tail -n 4 > $fsRegMtx
+
+## Convert the transform from FreeSurfer to pycortex format
+cat <<EOF | matlab -nodisplay
+t = MRIread('$anatFile');
+e = MRIread('$refFile');
+t2e_fs = dlmread('$fsRegMtx');
+s2e_pyc = inv(e.tkrvox2ras) * t2e_fs * t.tkrvox2ras * inv(t.vox2ras0);
+dlmwrite('$pycRegMtx',s2e_pyc,'delimiter',' ');
+EOF
+
+## Register the converted transform into pycortex database
+cat <<EOF | python
+from cortex import db
+import numpy as np
+subjectName ="$subjectName"
+xfmName = "$xfmName"
+pycRegMtx = "$pycRegMtx"
+refFile = "$refFile"
+s2e_pyc = np.loadtxt(pycRegMtx)
+db.save_xfm(subjectName,xfmName,s2e_pyc,xfmtype="coord",reference=refFile)
+EOF
+
+## Delete the temporary working directory
+rm -rf $tmpdir
+
+exit 0

--- a/utils/xfm2fsreg
+++ b/utils/xfm2fsreg
@@ -1,0 +1,88 @@
+#!/usr/bin/env tcsh
+
+if (($# < 3) || ($# > 4)) then
+  echo "Usage: $0:t [subjectName] [xfmName] [outFsRegFile] ([refEPI])"
+  echo
+  echo "e.g.) $0:t AWT1x2 fullhead register_pyc.dat refEPI.nii"
+  echo
+  echo "subjectName  : Name of the target subject registered in pycortex database"
+  echo "               (expected to be identical with that for FreeSurfer)"
+  echo "xfmName      : Name of the target pycortex transform (xfm) to be converted"
+  echo "outFsRegFile : Output file (to be written in FreeSufer register.dat format)"
+  echo "refEPI       : Reference volume to be registered along with xfm (optional)"
+  echo
+  exit 1
+endif
+
+## Check command line arguments
+set subjectName=$1
+shift
+
+set xfmName=$1
+shift
+
+set fsRegFile=$1
+shift
+
+set copyRefFile=false
+if ($#) then
+  set refFile=$1
+  set copyRefFile=true
+  shift
+endif
+
+## Create a temporary working directory
+set tmpdir=`mktemp -d`
+
+## Set paths
+set anatFile=$SUBJECTS_DIR/$subjectName/mri/orig.mgz
+set mtxFile=$tmpdir/reg_${subjectName}_${xfmName}.mtx
+if ($copyRefFile != true) then
+  set refFile=$tmpdir/refEPI.nii
+endif
+
+## Create a MATLAB function to generate FreeSufer register.dat format
+cat <<EOF > $tmpdir/write_fs_register.m
+function write_fs_register(filename, subjectName,volres,R)
+    fid = fopen(filename,'w');
+
+    fprintf(fid,'%s\n',subjectName);
+    fprintf(fid,'%.6f\n',volres(1));
+    fprintf(fid,'%.6f\n',volres(3));
+    fprintf(fid,'0.150000\n');
+    for i=1:size(R,1)
+        fprintf(fid,'%.15e ',R(i,:));
+        fprintf(fid,'\n');
+    end
+    fprintf(fid,'round\n');
+
+    fclose(fid);
+end
+EOF
+
+## Load the transform from pycortex DB and converts it into FreeSurfer format
+cat <<EOF | python
+import os
+import numpy as np
+from cortex import db
+subjectName ="$subjectName"
+xfmName = "$xfmName"
+xfm = db.get_xfm(subjectName,xfmName)
+np.savetxt("$mtxFile",xfm.xfm)
+os.system("mri_convert " + xfm.reference.get_filename() + " $refFile")
+EOF
+
+## Write the converted transform to a file in FreeSufer register.dat format
+cat <<EOF | matlab -nodisplay
+addpath $tmpdir
+t = MRIread('$anatFile');
+e = MRIread('$refFile');
+s2e_fsl = dlmread('$mtxFile');
+t2e_fsl = e.tkrvox2ras * s2e_fsl * t.vox2ras0 * inv(t.tkrvox2ras);
+write_fs_register('$fsRegFile','$subjectName',e.volres,t2e_fsl);
+EOF
+
+## Delete the temporary working directory
+rm -rf $tmpdir
+
+exit 0


### PR DESCRIPTION
I have written a utility shell script that exports a functional-anatomical transform obtained by pycortex to FreeSurfer register.dat. Another script performs the exact inverse, importing FreeSurfer register.dat to the pycortex database. Users who want to export / import data to / from FreeSurfer may find them to be useful.