### PR TITLE
give flag ensure_ascii=False to dumps when communicating with webgl

### DIFF
--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -48,7 +48,7 @@ class NPEncode(json.JSONEncoder):
                 __class__="NParray",
                 dtype=obj.dtype.descr[0][1], 
                 shape=obj.shape, 
-                data=binascii.b2a_base64(obj.tostring()))
+                data=binascii.b2a_base64(obj.tostring()).decode('utf-8'))
         elif isinstance(obj, (np.int64, np.int32, np.int16, np.int8,
                               np.uint64, np.uint32, np.uint16, np.uint8)):
             return int(obj)
@@ -318,7 +318,7 @@ class WebApp(threading.Thread):
 
     def send(self, **msg):
         if not isinstance(msg, str):
-            msg = json.dumps(msg, cls=NPEncode)
+            msg = json.dumps(msg, cls=NPEncode, ensure_ascii=False)
 
         for sock in self.sockets:
             sock.write_message(msg)


### PR DESCRIPTION
Fixed bug in python3. When using the `setData` function to pass new data to a volume, python3 `json` package does some weird stuff and can't make sense of the volume data. A default flag for `json.dumps` is `ensure_ascii=True`, which makes everything bytes. Setting that to `false` and making encoding the data as `utf-8` fixes it. This suggested fix does not break the feature in python2.