### PR TITLE
Volume-based stratification of the cortical surface

### DIFF
--- a/cortex/freesurfer.py
+++ b/cortex/freesurfer.py
@@ -99,15 +99,22 @@ def flatten(subject, hemi, patch, freesurfer_subject_dir=None):
     else:
         print("Not going to flatten...")
 
-def import_subj(subject, sname=None, freesurfer_subject_dir=None):
+def import_subj(subject, sname=None, freesurfer_subject_dir=None, whitematter_surf='smoothwm'):
     """Imports a subject from freesurfer
     
     Parameters
     ----------
     subject : string
         Freesurfer subject name
-    sname : string
-        Pycortex subject name (These variable names should be changed)
+    sname : string, optional
+        Pycortex subject name (These variable names should be changed). By default uses
+        the same name as the freesurfer subject.
+    freesurfer_subject_dir : string, optional
+        Freesurfer subject directory to pull data from. By default uses the directory
+        given by the environment variable $SUBJECTS_DIR.
+    whitematter_surf : string, optional
+        Which whitematter surface to import as 'wm'. By default uses 'smoothwm', but that
+        surface is smoothed and may not be appropriate. A good alternative is 'white'.
     """
     if sname is None:
         sname = subject
@@ -138,7 +145,7 @@ def import_subj(subject, sname=None, freesurfer_subject_dir=None):
 
     from . import formats
     #import surfaces
-    for fsname, name in [('smoothwm',"wm"), ('pial',"pia"), ('inflated',"inflated")]:
+    for fsname, name in [(whitematter_surf,"wm"), ('pial',"pia"), ('inflated',"inflated")]:
         for hemi in ("lh", "rh"):
             pts, polys, _ = get_surf(subject, hemi, fsname, freesurfer_subject_dir=freesurfer_subject_dir)
             fname = str(surfs.format(subj=sname, name=name, hemi=hemi))

--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -154,6 +154,22 @@ var mriview = (function(module) {
                     delete hemi.attributes[json.names[i]];
                 }
                 //Setup flatmap mix
+		var wmareas = module.computeAreas(hemi.attributes.wm, hemi.attributes.index, hemi.offsets);
+                wmareas = module.iterativelySmoothVertexData(hemi.attributes.wm, hemi.attributes.index, hemi.offsets, wmareas, smoothfactor, smoothiter);
+                hemi.wmareas = wmareas;
+
+		var pialareas = module.computeAreas(hemi.attributes.position, hemi.attributes.index, hemi.offsets);
+                pialareas = module.iterativelySmoothVertexData(hemi.attributes.position, hemi.attributes.index, hemi.offsets, pialareas, smoothfactor, smoothiter);
+                hemi.pialareas = pialareas;
+
+		var pialarea_attr = new THREE.BufferAttribute(pialareas, 1);
+                pialarea_attr.needsUpdate = true;
+                var wmarea_attr = new THREE.BufferAttribute(wmareas, 1);
+                wmarea_attr.needsUpdate = true;
+		
+                hemi.addAttribute('pialarea', pialarea_attr);
+                hemi.addAttribute('wmarea', wmarea_attr);
+
                 if (this.flatlims !== undefined) {
                     var flats = this._makeFlat(hemi.attributes.uv.array, json.flatlims, names[name]);
                     hemi.addAttribute('mixSurfs'+json.names.length, new THREE.BufferAttribute(flats.pos, 4));
@@ -166,14 +182,6 @@ var mriview = (function(module) {
 
                     var smoothfactor = 0.1;
                     var smoothiter = 50;
-
-
-                    var wmareas = module.computeAreas(hemi.attributes.wm, hemi.attributes.index, hemi.offsets);
-                    wmareas = module.iterativelySmoothVertexData(hemi.attributes.wm, hemi.attributes.index, hemi.offsets, wmareas, smoothfactor, smoothiter);
-                    hemi.wmareas = wmareas;
-                    var pialareas = module.computeAreas(hemi.attributes.position, hemi.attributes.index, hemi.offsets);
-                    pialareas = module.iterativelySmoothVertexData(hemi.attributes.position, hemi.attributes.index, hemi.offsets, pialareas, smoothfactor, smoothiter);
-                    hemi.pialareas = pialareas;
 
                     // var flatareas = module.computeAreas(hemi.attributes.mixSurfs1, hemi.culled.index, hemi.culled.offsets);
                     // var flatareascale = flatscale ** 2;
@@ -208,14 +216,6 @@ var mriview = (function(module) {
                     // hemi.addAttribute('flatBumpNorms', flatoff_geom.attributes.normal);
                     hemi.addAttribute('flatheight', flatheights);
                     hemi.addAttribute('flatBumpNorms', module.computeNormal(flat_offset_verts, hemi.attributes.index, hemi.offsets) );
-
-                    var pialarea_attr = new THREE.BufferAttribute(pialareas, 1);
-                    pialarea_attr.needsUpdate = true;
-                    var wmarea_attr = new THREE.BufferAttribute(wmareas, 1);
-                    wmarea_attr.needsUpdate = true;
-
-                    hemi.addAttribute('pialarea', pialarea_attr);
-                    hemi.addAttribute('wmarea', wmarea_attr);
                 } else {
                     // Fill these attributes so the shader doesn't choke, even though
                     // there's no flatmap

--- a/cortex/webgl/resources/js/shaderlib.js
+++ b/cortex/webgl/resources/js/shaderlib.js
@@ -172,7 +172,26 @@ var Shaderlib = (function() {
             "}",
             ].join("\n");
             return glsl;
-        }
+        },
+
+        // thickmixer: header code that loads the uniforms and attributes needed to
+        // do equivolume sampling, for vertex shaders
+        thickmixer: [
+            "uniform float thickmix;",
+            "uniform int equivolume;",
+            "attribute float wmarea;",
+            "attribute float pialarea;",
+        ].join("\n"),
+
+        // thickmixer_main: translates a desired volume fraction into linear mixing
+        // parameter.
+        thickmixer_main: [
+            "#ifdef EQUIVOLUME",
+                "float use_thickmix = 1. - (1. / (pialarea - wmarea) * (-1. * wmarea + sqrt((1. - thickmix) * pialarea * pialarea + thickmix * wmarea * wmarea)));",
+            "#else",
+                "float use_thickmix = thickmix;",
+            "#endif",
+        ].join("\n"),
     }
 
     var module = function() {
@@ -333,11 +352,14 @@ var Shaderlib = (function() {
             }
             if (opts.hasflat)
                 header += "#define HASFLAT\n"
+            if (opts.equivolume)
+                header += "#define EQUIVOLUME\n"
 
             var vertShade =  [
             THREE.ShaderChunk[ "lights_phong_pars_vertex" ],
             "uniform mat4 volxfm[2];",
-            "uniform float thickmix;",
+            // "uniform float thickmix;",
+            utils.thickmixer,
             "uniform int bumpyflat;",
             "float f_bumpyflat = float(bumpyflat);",
 
@@ -356,6 +378,7 @@ var Shaderlib = (function() {
             "varying vec2 vUv;",
             "varying float vCurv;",
             "varying float vMedial;",
+            "varying float vThickmix;",
             // "varying float vDrop;",
 
             "varying vec3 vPos_x[2];",
@@ -366,6 +389,8 @@ var Shaderlib = (function() {
             utils.mixer(morphs),
 
             "void main() {",
+                utils.thickmixer_main,
+                "vThickmix = use_thickmix;",
 
                 "vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
                 "vViewPosition = -mvPosition.xyz;",
@@ -383,8 +408,8 @@ var Shaderlib = (function() {
         "#endif",
 
         "#ifdef CORTSHEET",
-                "vec3 mpos = mix(position, wm.xyz, thickmix);",
-                "vec3 mnorm = mix(normal, wmnorm, thickmix);",
+                "vec3 mpos = mix(position, wm.xyz, use_thickmix);",
+                "vec3 mnorm = mix(normal, wmnorm, use_thickmix);",
         "#else",
                 "vec3 mpos = position;",
                 "vec3 mnorm = normal;",
@@ -405,14 +430,14 @@ var Shaderlib = (function() {
             "#ifdef CORTSHEET",
                 // 
                 "#ifdef HASFLAT",
-                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * mix(1., 0., thickmix) * flatheight * f_bumpyflat;",
+                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * mix(1., 0., use_thickmix) * flatheight * f_bumpyflat;",
                 "#else",
-                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., thickmix);",
+                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., use_thickmix);",
                 "#endif",
             "#endif",
 
                 "#ifdef HASFLAT",
-                    "vNormal = normalMatrix * mix(norm, flatBumpNorms, (1.0 - thickmix) * clamp(surfmix*"+(morphs-1)+". - 1.0, 0., 1.) * f_bumpyflat);",
+                    "vNormal = normalMatrix * mix(norm, flatBumpNorms, (1.0 - use_thickmix) * clamp(surfmix*"+(morphs-1)+". - 1.0, 0., 1.) * f_bumpyflat);",
                 "#else",
                     "vNormal = normalMatrix * norm;",
                 "#endif",
@@ -437,6 +462,7 @@ var Shaderlib = (function() {
         "#endif",
 
             "uniform float thickmix;",
+            // utils.thickmixer,
             "uniform float brightness;",
             "uniform float smoothness;",
             "uniform float contrast;",
@@ -462,6 +488,7 @@ var Shaderlib = (function() {
 
             "varying float vCurv;",
             "varying float vMedial;",
+            "varying float vThickmix;",
             
             utils.standard_frag_vars,
             utils.rand,
@@ -514,9 +541,9 @@ var Shaderlib = (function() {
             } else if (volume == 1) {
                 if (layers == 1 && !dither) {
                     fragMid += [
-                        "coord_x = mix(vPos_x[0], vPos_x[1], thickmix);",
+                        "coord_x = mix(vPos_x[0], vPos_x[1], vThickmix);",
                     "#ifdef TWOD",
-                        "coord_y = mix(vPos_y[0], vPos_y[1], thickmix);",
+                        "coord_y = mix(vPos_y[0], vPos_y[1], vThickmix);",
                     "#endif",
                         sampling,
                         "",
@@ -571,7 +598,7 @@ var Shaderlib = (function() {
 
         "#ifdef VOXLINE",
             "#ifdef CORTSHEET",
-                "vec3 coord = mix(vPos_x[0], vPos_x[1], thickmix);",
+                "vec3 coord = mix(vPos_x[0], vPos_x[1], vThickmix);",
             "#else",
                 "vec3 coord = vPos_x[0];",
             "#endif",
@@ -609,6 +636,8 @@ var Shaderlib = (function() {
                 wm: { type: 'v4', value:null },
                 wmnorm: { type: 'v3', value:null },
                 auxdat: { type: 'v4', value:null },
+                wmarea: { type: 'f', value:null },
+                pialarea: { type: 'f', value:null },
                 // flatBumpNorms: { type: 'v3', value:null },
                 // flatheight: { type: 'f', value:null },
             };
@@ -646,7 +675,8 @@ var Shaderlib = (function() {
             "uniform float vmin[2];",
             "uniform float vmax[2];",
             "uniform float framemix;",
-            "uniform float thickmix;",
+            // "uniform float thickmix;",
+            utils.thickmixer,
 
             "varying vec4 vColor;",
     "#ifdef RGBCOLORS",
@@ -692,8 +722,8 @@ var Shaderlib = (function() {
         "#endif",
 
         "#ifdef CORTSHEET",
-                "vec3 mpos = mix(position, wm.xyz, thickmix);",
-                "vec3 mnorm = mix(normal, wmnorm, thickmix);",
+                "vec3 mpos = mix(position, wm.xyz, use_thickmix);",
+                "vec3 mnorm = mix(normal, wmnorm, use_thickmix);",
         "#else",
                 "vec3 mpos = position;",
                 "vec3 mnorm = normal;",
@@ -709,7 +739,7 @@ var Shaderlib = (function() {
                 "mixfunc(mpos, mnorm, pos, norm);",
 
             "#ifdef CORTSHEET",
-                "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., thickmix);",
+                "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., use_thickmix);",
             "#endif",
 
                 "vNormal = normalMatrix * norm;",
@@ -744,6 +774,7 @@ var Shaderlib = (function() {
             "varying float vCurv;",
             "varying float vMedial;",
             "uniform float thickmix;",
+            // utils.thickmixer,
 
             utils.standard_frag_vars,
 

--- a/cortex/webgl/resources/js/shaderlib.js
+++ b/cortex/webgl/resources/js/shaderlib.js
@@ -668,6 +668,8 @@ var Shaderlib = (function() {
                 header += "#define ROI_RENDER\n";
             if (opts.extratex)
                 header += "#define EXTRATEX\n";
+            if (opts.equivolume)
+                header += "#define EQUIVOLUME\n"
 
             var vertShade =  [
             THREE.ShaderChunk[ "lights_phong_pars_vertex" ],
@@ -704,6 +706,8 @@ var Shaderlib = (function() {
             utils.mixer(morphs),
 
             "void main() {",
+
+                utils.thickmixer_main,
 
                 "vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
                 "vViewPosition = -mvPosition.xyz;",
@@ -826,6 +830,8 @@ var Shaderlib = (function() {
                 wm: { type: 'v4', value:null },
                 wmnorm: { type: 'v3', value:null },
                 auxdat: { type: 'v4', value:null },
+                wmarea: { type: 'f', value:null },
+                pialarea: { type: 'f', value:null },
             };
 
             for (var i = 0; i < 4; i++)
@@ -874,7 +880,8 @@ var Shaderlib = (function() {
                 header += "#define CORTSHEET\n";
 
             var vertShade = [
-                "uniform float thickmix;",
+                // "uniform float thickmix;",
+                utils.thickmixer,
 
                 utils.mixer(morphs),
                 "attribute vec4 wm;",
@@ -884,10 +891,11 @@ var Shaderlib = (function() {
                 "varying vec3 vPos;",
 
                 "void main() {",
+                    utils.thickmixer_main,
 
             "#ifdef CORTSHEET",
-                    "vec3 mpos = mix(position, wm.xyz, thickmix);",
-                    "vec3 mnorm = mix(normal, wmnorm, thickmix);",
+                    "vec3 mpos = mix(position, wm.xyz, use_thickmix);",
+                    "vec3 mnorm = mix(normal, wmnorm, use_thickmix);",
                     "vPos = mix(position, wm.xyz, 0.5);",
             "#else",
                     "vec3 mpos = position;",
@@ -899,7 +907,7 @@ var Shaderlib = (function() {
                     "mixfunc(mpos, mnorm, pos, norm);",
 
                 "#ifdef CORTSHEET",
-                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., thickmix);",
+                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., use_thickmix);",
                 "#endif",
 
                     "gl_Position = projectionMatrix * modelViewMatrix * vec4( pos, 1.0 );",


### PR DESCRIPTION
**This branch is not complete yet, but I created the PR to facilitate discussion about these features and related changes.**

This adds volume-based cortical surface stratification to the webgl viewer. This changes the behavior of the 'depth' slider, so that for a selected depth (e.g. depth=0.5), the resulting surface is not halfway between the pial and white matter surfaces, but is instead a surface that has half of the cortical volume above it and half of the cortical volume below it. This obeys "Bok's principle", and much more accurately matches actual cortical layers than the current method.

In preliminary testing volume-based straficiation seems to have a modest effect on the mapping of high-resolution data, such as T1-weighted volumes, but I haven't tested lower resolution functional data. In particular, I found that the new method yields T1w maps that are less confounded by surface curvature than the old method, which suggests that it is indeed more accurate.

Currently equivolume-mode is disabled by default, and can be enabled in a webgl viewer by checking a box labeled 'equivolume'. In my opinion there is no reason to prefer the old distance-based cortical surfaces to the new volume-based surfaces, so I think the default should probably be that it is on, but that can be discussed.

The equation for determining the location of a cortical surface using volume-based sampling comes from this paper: http://www.sciencedirect.com/science/article/pii/S1053811913003480

More information about this technique can also be found here: http://brainvoyager.com/bv/doc/UsersGuide/HighResDataAnalysis/EquiVolumeDepthModelling.html

Edit: many thanks to @kwagstyl for discussions and help with the theory & equations here.