### PR TITLE
Fix for non-textured stripes in WebGL mode.

### DIFF
--- a/cortex/webgl/resources/js/shaderlib.js
+++ b/cortex/webgl/resources/js/shaderlib.js
@@ -85,7 +85,7 @@ var Shaderlib = (function() {
 
         samplers: [
             "vec2 make_uv_x(vec2 coord, float slice) {",
-                "vec2 pos = vec2(mod(slice, mosaic[0].x), slice / mosaic[0].x);",
+                "vec2 pos = vec2(mod(slice+.5, mosaic[0].x), (slice+.5) / mosaic[0].x);",
                 "vec2 offset = (floor(pos) * (dshape[0]+1.)) + 1.;",
                 "vec2 imsize = (mosaic[0] * (dshape[0]+1.)) + 1.;",
                 "return (2.*(offset+coord)+1.) / (2.*imsize);",
@@ -106,8 +106,8 @@ var Shaderlib = (function() {
             "}",
 
             "vec2 make_uv_y(vec2 coord, float slice) {",
-                "vec2 pos = vec2(mod(slice, mosaic[1].x), floor(slice / mosaic[1].x));",
-                "vec2 offset = (pos * (dshape[1]+1.)) + 1.;",
+                "vec2 pos = vec2(mod(slice+.5, mosaic[1].x), (slice+.5) / mosaic[1].x);",
+                "vec2 offset = (floor(pos) * (dshape[1]+1.)) + 1.;",
                 "vec2 imsize = (mosaic[1] * (dshape[1]+1.)) + 1.;",
                 "return (2.*(offset+coord)+1.) / (2.*imsize);",
             "}",


### PR DESCRIPTION
Added 0.5 to the slice coordinate before mod() and floor() operations. This workaround avoids the problem caused by lower numerical accuracy on GPUs (e.g., non-textured stripes in the slice direction).

Original:
![wiredstripes](https://user-images.githubusercontent.com/8694099/36592624-e12da3e4-18d9-11e8-811d-b2d472d443d2.jpg)

Fixed:
![debugged](https://user-images.githubusercontent.com/8694099/36592630-e9e3fbdc-18d9-11e8-9548-4647c1ffe681.jpg)
