### PR TITLE
fix saving overlays with text elements other than data-ptidx

### DIFF
--- a/cortex/brainctm.py
+++ b/cortex/brainctm.py
@@ -170,13 +170,14 @@ class BrainCTM(object):
             # assign coordinates in left hemisphere negative values
             with open(svgname, "wb") as fp:
                 for element in svg.svg.findall(".//{http://www.w3.org/2000/svg}text"):
-                    idx = int(element.attrib["data-ptidx"])
-                    if idx < len(inverse[0]):
-                        idx = inverse[0][idx]
-                    else:
-                        idx -= len(inverse[0])
-                        idx = inverse[1][idx] + len(inverse[0])
-                    element.attrib["data-ptidx"] = str(idx)
+                    if 'data-ptidx' in element.attrib:
+                        idx = int(element.attrib["data-ptidx"])
+                        if idx < len(inverse[0]):
+                            idx = inverse[0][idx]
+                        else:
+                            idx -= len(inverse[0])
+                            idx = inverse[1][idx] + len(inverse[0])
+                        element.attrib["data-ptidx"] = str(idx)
                 fp.write(svg.toxml())
         return ptmap
 


### PR DESCRIPTION
There's a small bug when generating the overlay for example the example S1_retinotopy subject. The code naively assumes that all text elements in the SVG file contains the `data-ptidx` attribute. This is not the case. This PR adds an if-statement that fixes this.