### PR TITLE
Picker updates

### DIFF
--- a/cortex/blender/__init__.py
+++ b/cortex/blender/__init__.py
@@ -37,7 +37,7 @@ def _call_blender(filename, code, blender_path=default_blender):
 
         tf.write((startcode+code+endcode).encode())
         tf.flush()
-        sp.call([w.encode() for w in shlex.split(cmd)])
+        sp.check_call([w.encode() for w in shlex.split(cmd)],)
 
 def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh="hemi"):
     """Add data as vertex colors to blender mesh

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -36,9 +36,13 @@ class SVGOverlay(object):
         filestore
     coords : array-like
         (Unclear...)
+    overlays_available : list or tuple
+        list of layers of svg file to extract. If None, extracts all overlay layers 
+        (i.e. all layers that do not contain images)
     """
-    def __init__(self, svgfile, coords=None):
+    def __init__(self, svgfile, coords=None, overlays_available=None):
         self.svgfile = svgfile
+        self.overlays_available = overlays_available
         self.reload()
         if coords is not None:
             self.set_coords(coords)
@@ -48,13 +52,14 @@ class SVGOverlay(object):
 
         Strips out `data` layer of svg file, saves only layers consisting of vector paths.
         """
-        self.svg = scrub(self.svgfile)
+        self.svg = scrub(self.svgfile, overlays_available=self.overlays_available)
         w = float(self.svg.getroot().get("width"))
         h = float(self.svg.getroot().get("height"))
         self.svgshape = w, h
 
         # Grab relevant layers
         self.layers = dict()
+        
         for layer in self.svg.getroot().findall("{%s}g"%svgns):
             layer = Overlay(self, layer)
             self.layers[layer.name] = layer
@@ -336,7 +341,7 @@ class Labels(object):
         for shape in self.overlay.shapes.values():
             self.elements[shape.name] = shape.get_labelpos() 
 
-        #match up existing labels with their respective paths
+        # match up existing labels with their respective paths
         def close(pt, x, y):
             return np.sqrt((pt[0] - x)**2 + (pt[1]-y)**2) < 250
         for text in self.layer.findall(".//{%s}text"%svgns):
@@ -347,7 +352,7 @@ class Labels(object):
                 if text.text == name:
                     for i, pos in enumerate(self.elements[name]):
                         if close(pos, x, y):
-                            self.elements[key][i] = text
+                            self.elements[name][i] = text
 
         #add missing elements
         self.override = []
@@ -454,6 +459,11 @@ class Shape(object):
 ###################################################################################
 # SVG Helper functions
 ###################################################################################
+def _find_layer_names(svg):
+    layers = svg.findall("{%s}g[@{%s}label]"%(svgns, inkns))
+    layer_names = [l.get("{%s}label"%inkns) for l in layers]
+    return layer_names
+
 def _find_layer(svg, label):
     layers = [l for l in svg.findall("{%s}g[@{%s}label]"%(svgns, inkns)) if l.get("{%s}label"%inkns) == label]
     if len(layers) < 1:
@@ -532,15 +542,20 @@ def _split_multipath(pathstr):
         # Need further parsing of multi-path strings? perhaps no.
         yield (header + subpath).strip()
 
-def scrub(svgfile):
+def scrub(svgfile, overlays_available=None):
     """Remove data layers from an svg object prior to rendering
 
     Returns etree-parsed svg object
     """
     svg = etree.parse(svgfile, parser=parser)
     try:
-        rmnode = _find_layer(svg, "data")
-        rmnode.getparent().remove(rmnode)
+        layers_to_remove = ['data']
+        if overlays_available is not None:
+            overlays_to_remove = [x for x in _find_layer_names(svg) if x not in overlays_available]
+            layers_to_remove += overlays_to_remove
+        for layer in overlays_to_remove:
+            rmnode = _find_layer(svg, layer)
+            rmnode.getparent().remove(rmnode)
     except ValueError:
         pass
     svgtag = svg.getroot()
@@ -577,7 +592,11 @@ def make_svg(pts, polys):
 
     return svg
 
-def get_overlay(subject, svgfile, pts, polys, remove_medial=False, **kwargs):
+def get_overlay(subject, svgfile, pts, polys, remove_medial=False, 
+                overlays_available=None, **kwargs):
+    """Return a python represent of the overlays present in `svgfile`
+
+    """
     cullpts = pts[:,:2]
     if remove_medial:
         valid = np.unique(polys)
@@ -585,6 +604,9 @@ def get_overlay(subject, svgfile, pts, polys, remove_medial=False, **kwargs):
 
     if not os.path.exists(svgfile):
         # Overlay file does not exist yet! We need to create and populate it
+        # I think this should be an entirely separate function, and it should
+        # be made clear when this file is created - opening a git issue on 
+        # this soon...ML
         with open(svgfile, "wb") as fp:
             fp.write(make_svg(pts.copy(), polys))
 
@@ -605,12 +627,20 @@ def get_overlay(subject, svgfile, pts, polys, remove_medial=False, **kwargs):
         svg.rois.add_shape('curvature', binascii.b2a_base64(fp.read()).decode('utf-8'), False)
 
     else:
-        svg = SVGOverlay(svgfile, coords=cullpts, **kwargs)
+        svg = SVGOverlay(svgfile, 
+                         coords=cullpts, 
+                         overlays_available=overlays_available,
+                         **kwargs)
     
-    # Assure all layers are present
-    for layer in ['sulci', 'cutouts', 'display']:
-        if layer not in svg.layers:
-            svg.add_layer(layer)
+    
+    if overlays_available is None:
+        # Assure all layers are present
+        # (only if some set of overlays is not specified)
+        # NOTE: this actually modifies the svg file. Do we
+        # want this in all cases? (e.g. w/ external svgs?)
+        for layer in ['sulci', 'cutouts', 'display']:
+            if layer not in svg.layers:
+                svg.add_layer(layer)
 
     if remove_medial:
         return svg, valid

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -608,7 +608,6 @@ def get_overlay(subject, svgfile, pts, polys, remove_medial=False,
         # I think this should be an entirely separate function, and it should
         # be made clear when this file is created - opening a git issue on 
         # this soon...ML
-        print("WHAIIIII")
         with open(svgfile, "wb") as fp:
             fp.write(make_svg(pts.copy(), polys))
 

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -552,11 +552,12 @@ def scrub(svgfile, overlays_available=None):
         layers_to_remove = ['data']
         if overlays_available is not None:
             overlays_to_remove = [x for x in _find_layer_names(svg) if x not in overlays_available]
-            layers_to_remove += overlays_to_remove
+            layers_to_remove = overlays_to_remove
         for layer in layers_to_remove:
             rmnode = _find_layer(svg, layer)
             rmnode.getparent().remove(rmnode)
     except ValueError:
+        # Seems sketch - should catch this? 
         pass
     svgtag = svg.getroot()
     svgtag.attrib['id'] = "svgoverlay"
@@ -607,6 +608,7 @@ def get_overlay(subject, svgfile, pts, polys, remove_medial=False,
         # I think this should be an entirely separate function, and it should
         # be made clear when this file is created - opening a git issue on 
         # this soon...ML
+        print("WHAIIIII")
         with open(svgfile, "wb") as fp:
             fp.write(make_svg(pts.copy(), polys))
 

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -553,7 +553,7 @@ def scrub(svgfile, overlays_available=None):
         if overlays_available is not None:
             overlays_to_remove = [x for x in _find_layer_names(svg) if x not in overlays_available]
             layers_to_remove += overlays_to_remove
-        for layer in overlays_to_remove:
+        for layer in layers_to_remove:
             rmnode = _find_layer(svg, layer)
             rmnode.getparent().remove(rmnode)
     except ValueError:

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -236,10 +236,9 @@ class SVGOverlay(object):
             png = tempfile.NamedTemporaryFile(suffix=".png")
             pngfile = png.name
 
-        # Old command: (Using ImageMagick function `convert`)
-        #cmd = "convert -background none -density {dpi} SVG:- PNG{bits}:{outfile}"
-        cmd = "inkscape -z -h {height} -e {outfile} /dev/stdin"
-        cmd = cmd.format(height=height, outfile=pngfile) #, bits=bits)
+        inkscape_cmd = config.get('dependency_paths', 'inkscape')
+        cmd = "{inkscape_cmd} -z -h {height} -e {outfile} /dev/stdin"
+        cmd = cmd.format(inkscape_cmd=inkscape_cmd, height=height, outfile=pngfile)
         proc = sp.Popen(shlex.split(cmd), stdin=sp.PIPE, stdout=sp.PIPE)
         proc.communicate(etree.tostring(self.svg))
 

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -35,7 +35,8 @@ def get_roipack(*args, **kwargs):
 get_mapper = DocLoader("get_mapper", ".mapper", "cortex")
 
 def get_ctmpack(subject, types=("inflated",), method="raw", level=0, recache=False,
-                decimate=False):
+                decimate=False, external_svg=None,
+                overlays_available=None):
     """Creates ctm file for the specified input arguments.
 
     This is a cached file that specifies (1) the surfaces between which
@@ -49,13 +50,22 @@ def get_ctmpack(subject, types=("inflated",), method="raw", level=0, recache=Fal
     types : tuple
         Surfaces between which to interpolate.
     method : str
-
-    level :
-
+        string specifying method of how inverse transforms for
+        labels are computed (determines how labels are displayed
+        on 3D viewer) one of ['mg2','raw']
     recache : bool
-        Recache intermediate files? Can resolve some errors but is slower.
-
+        Whether to re-generate .ctm files. Can resolve some errors 
+        but takes more time to re-generate cached files.
     decimate : bool
+        whether to decimate the mesh geometry of the hemispheres
+        to reduce file size
+    external_svg : str or None
+        file string for .svg file containing alternative overlays 
+        for brain viewer. If None, the `overlays.svg` file for this
+        subject (in the pycortex_store folder for the subejct) is used.
+    overlays_available: tuple or None
+        Which overlays in the svg file to include in the viewer. If
+        None, all layers in the relevant svg file are included.
 
     Returns
     -------
@@ -79,7 +89,9 @@ def get_ctmpack(subject, types=("inflated",), method="raw", level=0, recache=Fal
                                types=types,
                                method=method,
                                level=level,
-                               decimate=decimate)
+                               decimate=decimate,
+                               external_svg=external_svg,
+                               overlays_available=overlays_available)
     return ctmfile
 
 def get_ctmmap(subject, **kwargs):

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -254,7 +254,8 @@ def add_roi(data, name="new_roi", open_inkscape=True, add_path=True, **kwargs):
     svg.rois.add_shape(name, binascii.b2a_base64(fp.read()).decode('utf-8'), add_path)
 
     if open_inkscape:
-        return sp.call(["inkscape", '-f', svg.svgfile])
+        inkscape_cmd = config.get('dependency_paths', 'inkscape')
+        return sp.call([inkscape_cmd, '-f', svg.svgfile])
 
 def get_roi_verts(subject, roi=None, mask=False):
     """Return vertices for the given ROIs, or all ROIs if none are given.

--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -282,6 +282,8 @@ var mriview = (function(module) {
         }
         this.active.loaded.done(function() {
             this.active.set();
+            // Register event for dataset switching
+            this.dispatchEvent({type:"setData", name:this.active.name});            
         }.bind(this));
 
         // var surf, scene, grid = grid_shapes[this.active.data.length];

--- a/cortex/webgl/resources/js/svgoverlay.js
+++ b/cortex/webgl/resources/js/svgoverlay.js
@@ -262,6 +262,12 @@ var svgoverlay = (function(module) {
     THREE.EventDispatcher.prototype.apply(module.Overlay.prototype);
     module.Overlay.prototype.set = function(options) {
         for (var name in this.shapes) {
+            var locked = 'sodipodi:insensitive' // Make this general w/ variable for sodipodi namespace?
+            if (this.shapes[name].hasAttribute(locked)){
+                if (this.shapes[name].getAttribute(locked) == 'true'){
+                    continue
+                }
+            }
             var paths = this.shapes[name].getElementsByTagNameNS(svgns, "path");
             for (var i = 0; i < paths.length; i++) {
                 for (var css in options)

--- a/cortex/webgl/resources/js/three.js
+++ b/cortex/webgl/resources/js/three.js
@@ -4153,7 +4153,7 @@ THREE.Matrix3.prototype = {
 	},
 
 	multiplyVector3: function ( vector ) {
-		//OMG STFU THREEJS
+		//BE SILENT THREEJS
 		//console.warn( 'THREE.Matrix3: .multiplyVector3() has been removed. Use vector.applyMatrix3( matrix ) instead.' );
 		return vector.applyMatrix3( this );
 
@@ -4775,7 +4775,7 @@ THREE.Matrix4.prototype = {
 	},
 
 	multiplyVector3: function ( vector ) {
-		//OMG STFU THREEJS
+		//BE SILENT THREEJS
 		//console.warn( 'THREE.Matrix4: .multiplyVector3() has been removed. Use vector.applyMatrix4( matrix ) or vector.applyProjection( matrix ) instead.' );
 		return vector.applyProjection( this );
 
@@ -24706,7 +24706,7 @@ THREE.WebGLShader = ( function () {
 		if ( gl.getShaderInfoLog( shader ) !== '' ) {
 
 			console.warn( 'THREE.WebGLShader: gl.getShaderInfoLog()', gl.getShaderInfoLog( shader ) );
-			//OMG STFU THREEJS
+			//BE SILENT THREEJS
 			//console.warn( addLineNumbers( string ) );
 
 		}
@@ -31627,7 +31627,7 @@ THREE.LatheGeometry.prototype = Object.create( THREE.Geometry.prototype );
  */
 
 THREE.PlaneGeometry = function ( width, height, widthSegments, heightSegments ) {
-	//OMG STFU THREEJS
+	//BE SILENT THREEJS
 	//console.info( 'THREE.PlaneGeometry: Consider using THREE.PlaneBufferGeometry for lower memory footprint.' );
 
 	THREE.Geometry.call( this );

--- a/cortex/webgl/view.py
+++ b/cortex/webgl/view.py
@@ -103,12 +103,13 @@ def make_static(outpath, data, types=("inflated",), recache=False, cmap="RdBu_r"
     You will need a real web server to view this, since `file://` paths
     don't handle xsrf correctly
     """
-    if overlay_file is not None:
-        raise NotImplementedError("External overlay_file not supported yet, sorry!")
     
     outpath = os.path.abspath(os.path.expanduser(outpath)) # To handle ~ expansion
     if not os.path.exists(outpath):
         os.makedirs(outpath)
+    if not os.path.exists(os.path.join(outpath, 'data')):
+        # Don't lump together w/ outpath, because of edge cases
+        # for which outpath exists but not sub-folder `data`
         os.makedirs(os.path.join(outpath, "data"))
 
     data = dataset.normalize(data)
@@ -142,7 +143,12 @@ def make_static(outpath, data, types=("inflated",), recache=False, cmap="RdBu_r"
         ctms[subj] = newfname+".json"
 
         for ext in ['json', 'ctm', 'svg']:
-            srcfile = os.path.join(oldpath, "%s.%s"%(fname, ext))
+            if (ext=='svg') and (overlay_file is not None):
+                1/0
+                # Need to strip / parse SVG file
+                srcfile = overlay_file
+            else:
+                srcfile = os.path.join(oldpath, "%s.%s"%(fname, ext))
             newfile = os.path.join(outpath, "%s.%s"%(newfname, ext))
             if os.path.exists(newfile):
                 os.unlink(newfile)
@@ -286,8 +292,6 @@ def show(data, types=("inflated", ), recache=False, cmap='RdBu_r', layout=None,
         The layout of the viewer subwindows for showing multiple subjects.
         Default None, which selects the layout based on the number of subjects.
     """
-    if overlay_file is not None:
-        raise NotImplementedError("External overlay_file not supported yet, sorry!")
     
     data = dataset.normalize(data)
     if not isinstance(data, dataset.Dataset):
@@ -425,6 +429,7 @@ def show(data, types=("inflated", ), recache=False, cmap='RdBu_r', layout=None,
         def post(self):
             data = self.get_argument("svg", default=None)
             png = self.get_argument("png", default=None)
+            1/0
             with open(post_name.get(), "wb") as svgfile:
                 if png is not None:
                     data = png[22:].strip()


### PR DESCRIPTION
In constructing the viewer for my paper, I made a few updates to the javascript & other code. The biggest two changes are (1) to allow selection of a different dataset to activate a second javascript picker function (Alex did this in his viewer for his Nature paper before the dataset selection code existed in the webgl version of pycortex, so this was necessary), (2) to allow input of external SVG files for customized display layers in a webgl static viewer, and (3) to allow selection of which layers of an overlays svg file are ultimately available in the viewer. For example, one might want to get rid of the cutouts layer, which is used in quickflat but not so useful to include in a webgl display, or to select among a few options for fancy display layers in an external file.

There are a few changes that don't do anything yet, e.g. the allowtilt variable in mriview_surface.js (which is meant to allow / disallow tilting of the flatmap, addressing #286 ) doesn't do anything yet. A harmless addition, tho. Also, I silenced several of the three.js deprecation warnings that totally clog the javascript console and make it difficult to debug javascript issues. A more permanent (ha) solution would be to update the versions of three.js (and potentially other code) that we distribute with pycortex, but James says that is the road to perdition and laughably stupid, because these types of javascript libraries change all the time and are never backward compatible, so I have refrained.