### PR TITLE
Convenience function to use identity matrix

### DIFF
--- a/cortex/xfm.py
+++ b/cortex/xfm.py
@@ -10,6 +10,10 @@ class Transform(object):
     magnet space to epi file space.
     '''
     def __init__(self, xfm, reference):
+
+        if xfm == 'ident':
+            xfm = np.identity(4)
+
         self.xfm = xfm
         self.reference = None
 


### PR DESCRIPTION
As you have probably seen by the other two pull requests, I like to use fmriprep (and my own pipelines) as input data, where the anatomical and functional data are by definition in the same space. The Transform should thus be the identity matrix. I think this would be a nice shortcut. Let me know what you think.