### PR TITLE
Added code to parse paths with h or v commands

### DIFF
--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -706,6 +706,10 @@ def _parse_svg_pts(datastr):
             offset += list([float(x) for x in [data.pop(0), data.pop(0)]])
         elif mode == "L":
             offset = np.array(list([float(x) for x in [data.pop(0), data.pop(0)]]))
+        elif mode == "h":
+            offset += list([float(x) for x in [data.pop(0), 0]])
+        elif mode == "v":
+            offset += list([float(x) for x in [0, data.pop(0)]])
         elif mode == "c":
             data = data[4:]
             offset += list([float(x) for x in [data.pop(0), data.pop(0)]])
@@ -773,7 +777,7 @@ def import_roi(roifile, outfile):
             svgo.add_layer(new_layer)
 
 def gen_path(path):
-    mdict = dict(m=Path.MOVETO, l=Path.LINETO)
+    mdict = dict(m=Path.MOVETO, l=Path.LINETO, h=Path.LINETO, v=Path.LINETO)
     verts, codes = [], []
     mode, pen = None, np.array([0.,0.])
 
@@ -805,7 +809,12 @@ def gen_path(path):
                 codes.append(Path.CURVE4)
                 codes.append(Path.CURVE4)
             else:
-                val = [float(cc) for cc in cmd.split(',')]
+                if mode.lower() == 'h':
+                    val = [float(cmd), 0]
+                elif mode.lower() == 'v':
+                    val = [0, float(cmd)]
+                else:
+                    val = [float(cc) for cc in cmd.split(',')]
                 codes.append(mdict[mode.lower()])
                 if mode.lower() == mode:
                     pen += val


### PR DESCRIPTION
These additions solve issue #288 "svg parser can't handle paths with h or v commands".

I ran into a problem with the handling of path commands when I attempted to make a ROI mask via `cortex.utils.get_roi_masks` as currently the code in svgoverlay.py lacks a way to handle h/v commands. I added code to both the `gen_path` function and the `_parse_svg_pts` function (used by the deprecated `get_roi_mask`) that registers the h/v command and handles the corresponding amount of movement specified in the path. In both functions, I handle h/v almost exactly the way the regular line (lowercase L) command is handled, and the new code just specifies whether the value following the command in the path is x or y movement and sets the other dx/dy value to 0.

I tested the code by plotting several ROIs (both their outlines and which voxels were in the mask), and I had no issues.

Just as a side note, in `gen_path`, I followed the existing convention of assuming values in the path represent the amount of change from one point to the next (except of course for the initial values that identify where the path should begin). `_parse_svg_pts` has separate commands for uppercase L, C, and M, but since there wasn't already code for handling uppercase commands in `gen_path`, I didn't add any for H/V.