### PR TITLE
Added fmriprep import functionality

### DIFF
--- a/cortex/fmriprep.py
+++ b/cortex/fmriprep.py
@@ -7,7 +7,9 @@ import numpy as np
 def import_subj(subject,
                 source_dir,
                 session=None,
-                sname=None):
+                dataset=None,
+                sname=None,
+                old_fmriprep=False):
     """Imports a subject from fmriprep-output.
     See https://fmriprep.readthedocs.io/en/stable/
     
@@ -20,12 +22,21 @@ def import_subj(subject,
     session : string, optional
        BIDS session that contains the anatomical data (leave to default if
        not a specific session)
+    dataset : string, optional
+       If you have multiple fmriprep outputs from different datasets, use this attribute
+       to add a prefix to every subject id ('ds01.01' rather than '01')
     sname : string, optional
         Pycortex subject name (These variable names should be changed). By default uses
         the same name as the freesurfer subject.
+    old_fmriprep : boolean, optional
+        Fmriprep < 1.2.0 used a different naming scheme from more recent releases.
+        Flip this switch when you're using an older version of fmriprep
        """
     if sname is None:
         sname = subject
+
+    if dataset:
+        sname = '{}.{}'.format(dataset, sname)
 
     database.db.make_subj(sname)
 
@@ -43,8 +54,12 @@ def import_subj(subject,
     # import anatomical data
     fmriprep_dir = op.join(fmriprep_dir, 'sub-{subject}', 'anat')
 
-    t1w = op.join(fmriprep_dir, 'sub-{subject}{session_str}_T1w_preproc.nii.gz')
-    aseg = op.join(fmriprep_dir, 'sub-{subject}{session_str}_T1w_label-aseg_roi.nii.gz')
+    if old_fmriprep:
+        t1w = op.join(fmriprep_dir, 'sub-{subject}{session_str}_T1w_preproc.nii.gz')
+        aseg = op.join(fmriprep_dir, 'sub-{subject}{session_str}_T1w_label-aseg_roi.nii.gz')
+    else:
+        t1w = op.join(fmriprep_dir, 'sub-{subject}{session_str}_desc-preproc_T1w.nii.gz')
+        aseg = op.join(fmriprep_dir, 'sub-{subject}{session_str}_desc-aseg_dseg.nii.gz')
 
     for fmp_fn, out_fn in zip([t1w.format(subject=subject, session_str=session_str),
                                aseg.format(subject=subject, session_str=session_str)],
@@ -54,10 +69,16 @@ def import_subj(subject,
 
     
     #import surfaces
-    fmpsurf = op.join(fmriprep_dir, 
-                      'sub-{subject}{session_str}_T1w_').format(subject=subject,
-                                                                session_str=session_str)
-    fmpsurf = fmpsurf + '{fmpname}.{fmphemi}.surf.gii'
+    if old_fmriprep:
+        fmpsurf = op.join(fmriprep_dir, 
+                          'sub-{subject}{session_str}_T1w_').format(subject=subject,
+                                                                    session_str=session_str)
+        fmpsurf = fmpsurf + '{fmpname}.{fmphemi}.surf.gii'
+    else:
+        fmpsurf = op.join(fmriprep_dir, 
+                          'sub-{subject}{session_str}_').format(subject=subject,
+                                                                    session_str=session_str)
+        fmpsurf = fmpsurf + 'hemi-{fmphemi}_{fmpname}.surf.gii'
 
     for fmpname, name in zip(['smoothwm', 'pial', 'midthickness', 'inflated'],
                              ['wm', 'pia', 'fiducial', 'inflated']):


### PR DESCRIPTION
Heya,

There was an issue with fmriprep data with fmriprep >1.2.0, since [they changed the names of the output files](https://fmriprep.readthedocs.io/en/stable/changes.html#october-31-2018). This branch can now deal with that.

Furthermore, I ran into the same issue as @anwarnunez in issue https://github.com/gallantlab/pycortex/issues/304. I guess you want your subject names to depend on the dataset you're using. I made a little argument for that as well.