### PR TITLE
improve ability to parse path in overlays file

### DIFF
--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -708,8 +708,12 @@ def _parse_svg_pts(datastr):
             offset = np.array(list([float(x) for x in [data.pop(0), data.pop(0)]]))
         elif mode == "h":
             offset += list([float(x) for x in [data.pop(0), 0]])
+        elif mode == 'H':
+            offset = np.array(list([float(x) for x in [data.pop(0), 0]]))
         elif mode == "v":
             offset += list([float(x) for x in [0, data.pop(0)]])
+        elif mode == "V":
+            offset = np.array(list([float(x) for x in [0, data.pop(0)]]))
         elif mode == "c":
             data = data[4:]
             offset += list([float(x) for x in [data.pop(0), data.pop(0)]])


### PR DESCRIPTION
I added four lines of code to improve the ability to parse paths in the overlays file. The previous recent update to this ( #311) failed to fully solve the problem with the h and v commands, it couldn't handle the upper case version of h and v. This should fully solve the problem (#288). 