### PR TITLE
Enable passing an ax in quick flatmap: quickshow(fig=ax)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,7 @@ nosetests.xml
 # vim temp files
 *~
 
+# vscode
+.vscode
+
 *.nfs*

--- a/cortex/quickflat/composite.py
+++ b/cortex/quickflat/composite.py
@@ -3,12 +3,9 @@ import numpy as np
 from .. import dataset
 from ..database import db
 from ..options import config
-from ..svgoverlay import get_overlay
-from ..utils import get_shared_voxels, get_mapper
 from .utils import _get_height, _get_extents, _convert_svg_kwargs, _has_cmap, _get_images, _parse_defaults
-from .utils import make_flatmap_image, _make_hatch_image, _return_pixel_pairs, get_flatmask, get_flatcache
+from .utils import make_flatmap_image, _make_hatch_image, get_flatmask, get_flatcache
 
-import time
 
 """ --- Individual compositing functions --- """
 
@@ -161,7 +158,7 @@ def add_data(fig, braindata, height=1024, thick=32, depth=0.5, pixelwise=True,
         raise TypeError('Please provide a Dataview, not a Dataset')
     # Generate image (2D array, maybe 3D array)
     im, extents = make_flatmap_image(dataview, recache=recache, pixelwise=pixelwise, sampler=sampler,
-                       height=height, thick=thick, depth=depth)
+                                     height=height, thick=thick, depth=depth)
     # Check whether dataview has a cmap instance
     cmapdict = _has_cmap(dataview)
     # Plot
@@ -201,7 +198,6 @@ def add_rois(fig, dataview, extents=None, height=None, with_labels=True, roi_lis
     img : matplotlib.image.AxesImage
         matplotlib axes image object for plotted data
     """
-    from ..svgoverlay import get_overlay
     if extents is None:
         extents = _get_extents(fig)
     if height is None:
@@ -249,7 +245,6 @@ def add_sulci(fig, dataview, extents=None, height=None, with_labels=True, **kwar
     img : matplotlib.image.AxesImage
         matplotlib axes image object for plotted data
     """
-    from ..svgoverlay import get_overlay
     svgobject = db.get_overlay(dataview.subject)
     svg_kws = _convert_svg_kwargs(kwargs)
     layer_kws = _parse_defaults('sulci_paths')
@@ -268,7 +263,7 @@ def add_sulci(fig, dataview, extents=None, height=None, with_labels=True, **kwar
 
 
 def add_hatch(fig, hatch_data, extents=None, height=None, hatch_space=4,
-    hatch_color=(0, 0, 0), sampler='nearest', recache=False):
+              hatch_color=(0, 0, 0), sampler='nearest', recache=False):
     """Add hatching to figure at locations specified in hatch_data
 
     Parameters
@@ -303,13 +298,12 @@ def add_hatch(fig, hatch_data, extents=None, height=None, hatch_space=4,
     -----
     Possibly to add: add hatch_width, hatch_offset arguments.
     """
-    from ..svgoverlay import get_overlay
     if extents is None:
         extents = _get_extents(fig)
     if height is None:
         height = _get_height(fig)
     hatchim = _make_hatch_image(hatch_data, height, sampler, recache=recache, 
-        hatch_space=hatch_space)
+                                hatch_space=hatch_space)
     hatchim[:,:,0] = hatch_color[0]
     hatchim[:,:,1] = hatch_color[1]
     hatchim[:,:,2] = hatch_color[2]
@@ -325,7 +319,7 @@ def add_hatch(fig, hatch_data, extents=None, height=None, hatch_space=4,
 
 
 def add_colorbar(fig, cimg, colorbar_ticks=None, colorbar_location=(0.4, 0.07, 0.2, 0.04), 
-    orientation='horizontal'):
+                 orientation='horizontal'):
     """Add a colorbar to a flatmap plot
 
     Parameters
@@ -349,7 +343,7 @@ def add_colorbar(fig, cimg, colorbar_ticks=None, colorbar_location=(0.4, 0.07, 0
 
 
 def add_colorbar_2d(fig, cmap_name, colorbar_ticks,
-    colorbar_location=(0.425, 0.02, 0.15, 0.15), fontsize=12):
+                    colorbar_location=(0.425, 0.02, 0.15, 0.15), fontsize=12):
     """Add a 2D colorbar to a flatmap plot
 
     Parameters
@@ -381,7 +375,7 @@ def add_colorbar_2d(fig, cmap_name, colorbar_ticks,
     return cbar
 
 def add_custom(fig, dataview, svgfile, layer, extents=None, height=None, with_labels=False, 
-    shape_list=None, **kwargs):
+               shape_list=None, **kwargs):
     """Add a custom data layer
 
     Parameters
@@ -562,13 +556,12 @@ def add_cutout(fig, name, dataview, layers=None, height=None, extents=None):
         extents of figure. None defaults to previously specified extents.
         [unclear if it's worth it to keep this input.]
     """
-    from ..svgoverlay import get_overlay
     if layers is None:
         layers = _get_images(fig)
     if height is None:
         height = _get_height(fig)
     if extents is None:
-        extents  = _get_extents(fig)
+        extents = _get_extents(fig)
     svgobject = db.get_overlay(dataview.subject)
     # Set other cutouts to be invisible
     for co_name, co_shape in svgobject.cutouts.shapes.items():

--- a/cortex/quickflat/utils.py
+++ b/cortex/quickflat/utils.py
@@ -237,10 +237,23 @@ def _parse_defaults(section):
             defaults[k] = '{}, {}'.format(*defaults[k])
     return defaults
 
+def _get_fig_and_ax(fig):
+    """Get figure and current ax. Input can be either a figure or an ax."""
+    import matplotlib.pyplot as plt
+    if isinstance(fig, plt.Axes):
+        ax = fig
+        fig = ax.figure
+    elif isinstance(fig, plt.Figure):
+        ax = fig.gca()
+    else:
+        raise ValueError("fig should be a matplotlib Figure or Axes instance.")
+
+    return fig, ax
+
 def _get_images(fig):
     """Get all images in a given matplotlib axis"""
     from matplotlib.image import AxesImage
-    ax = fig.gca()
+    _, ax = _get_fig_and_ax(fig)
     images = dict((x.get_label(), x) for x in ax.get_children() if isinstance(x, AxesImage))
     return images
 

--- a/cortex/quickflat/view.py
+++ b/cortex/quickflat/view.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from .. import utils
 from .. import dataset
-from . import utils as qutils
 from .utils import make_flatmap_image
 from . import composite
 
@@ -103,7 +102,7 @@ def make_figure(braindata, recache=False, pixelwise=True, thick=32, sampler='nea
     ax = fig.add_axes((0, 0, 1, 1))
     # Add data
     data_im, extents = composite.add_data(fig, dataview, pixelwise=pixelwise, thick=thick, sampler=sampler,
-                       height=height, depth=depth, recache=recache)
+                                          height=height, depth=depth, recache=recache)
 
     layers = dict(data=data_im)
     # Add curvature
@@ -112,8 +111,8 @@ def make_figure(braindata, recache=False, pixelwise=True, thick=32, sampler='nea
         if any([x in kwargs for x in ['cvmin', 'cvmax', 'cvthr']]):
             import warnings
             warnings.warn(("Use of `cvmin`, `cvmax`, and `cvthr` is deprecated! Please use \n"
-                             "`curvature_brightness`, `curvature_contrast`, and `curvature_threshold`\n"
-                             "to set appearance of background curvature."))
+                           "`curvature_brightness`, `curvature_contrast`, and `curvature_threshold`\n"
+                           "to set appearance of background curvature."))
             legacy_mode = True
             if ('cvmin' in kwargs) and ('cvmax' in kwargs):
                 # Assumes that if one is specified, both are; weird case where only one is
@@ -143,33 +142,34 @@ def make_figure(braindata, recache=False, pixelwise=True, thick=32, sampler='nea
             dropout_power = 20 if with_dropout is True else with_dropout
         if hatch_data is None:
             hatch_data = utils.get_dropout(dataview.subject, dataview.xfmname,
-                                         power=dropout_power)
+                                           power=dropout_power)
 
         drop_im = composite.add_hatch(fig, hatch_data, extents=extents, height=height,
-            sampler=sampler)
+                                      sampler=sampler)
         layers['dropout'] = drop_im
     # Add extra hatching
     if extra_hatch is not None:
         hatch_data2, hatch_color = extra_hatch
         hatch_im = composite.add_hatch(fig, hatch_data2, extents=extents, height=height,
-            sampler=sampler)
+                                       sampler=sampler)
         layers['hatch'] = hatch_im
     # Add rois
     if with_rois:
         roi_im = composite.add_rois(fig, dataview, extents=extents, height=height, linewidth=linewidth, linecolor=linecolor,
-             roifill=roifill, shadow=shadow, labelsize=labelsize, labelcolor=labelcolor, with_labels=with_labels)
+                                    roifill=roifill, shadow=shadow, labelsize=labelsize, labelcolor=labelcolor,
+                                    with_labels=with_labels)
         layers['rois'] = roi_im
     # Add sulci
     if with_sulci:
         sulc_im = composite.add_sulci(fig, dataview, extents=extents, height=height, linewidth=linewidth, linecolor=linecolor,
-             shadow=shadow, labelsize=labelsize, labelcolor=labelcolor, with_labels=with_labels)
+                                      shadow=shadow, labelsize=labelsize, labelcolor=labelcolor, with_labels=with_labels)
         layers['sulci'] = sulc_im
     # Add custom
     if extra_disp is not None:
         svgfile, layer = extra_disp
         custom_im = composite.add_custom(fig, dataview, svgfile, layer, height=height, extents=extents,
-            linewidth=linewidth, linecolor=linecolor, shadow=shadow, labelsize=labelsize, labelcolor=labelcolor,
-            with_labels=with_labels)
+                                         linewidth=linewidth, linecolor=linecolor, shadow=shadow, labelsize=labelsize,
+                                         labelcolor=labelcolor, with_labels=with_labels)
         layers['custom'] = custom_im
     # Add connector lines btw connected vertices
     if with_connected_vertices:
@@ -191,7 +191,7 @@ def make_figure(braindata, recache=False, pixelwise=True, thick=32, sampler='nea
         # Allow 2D colorbars:
         if isinstance(dataview, dataset.view2D.Dataview2D):
             colorbar = composite.add_colorbar_2d(fig, dataview.cmap,
-                [dataview.vmin, dataview.vmax, dataview.vmin2, dataview.vmax2])
+                                                 [dataview.vmin, dataview.vmax, dataview.vmin2, dataview.vmax2])
         else:
             colorbar = composite.add_colorbar(fig, data_im)
         # Reset axis to main figure axis


### PR DESCRIPTION
This PR enables plotting a flatmap in a matplotlib Axes, so you can plot multiple flatmaps in the same Figure.

The changes are in 5b9c548681cc46056d02665824887aa54b5af55e.
The other commit 18971a446d7055165f8311b77eca1d052a696de4 is only removing unused imports and doing some pep8 alignments.

Example: 
![save](https://user-images.githubusercontent.com/11065596/55583129-021dac80-56d6-11e9-8503-a48e8426f022.png)

