### PR TITLE
Fix the mouse control weird behavior at unfold > 0.5

### DIFF
--- a/cortex/webgl/resources/js/movement.js
+++ b/cortex/webgl/resources/js/movement.js
@@ -218,8 +218,10 @@ var jsplot = (function (module) {
 		var mix = this.mix;
 		if (mix < 1) {
 			this._foldedtarget.set(xyz[0], xyz[1], xyz[2]);
+			this.target.set(xyz[0], xyz[1], xyz[2]);
 		} else if (mix == 1) {
 			this._flattarget.set(xyz[0], xyz[1], 0);
+			this.target.set(xyz[0], xyz[1], 0);
 		}
 		// this.target.set(this._foldedtarget.x * (1-mix) + mix*this._flattarget.x,
 		//                 this._foldedtarget.y * (1-mix) + mix*this._flattarget.y,

--- a/cortex/webgl/resources/js/movement.js
+++ b/cortex/webgl/resources/js/movement.js
@@ -142,14 +142,7 @@ var jsplot = (function (module) {
 		if (az === undefined)
 			return this.azimuth;
 
-		if (this.mix > 0 && false) { // THIS IS DISABLED, NO AZIMUTH LIMITS
-			var azlim = this.mix * 180;
-			if (azlim > az || az > (360 - azlim)) {
-				var d1 = azlim - az;
-				var d2 = 360 - azlim - az;
-				az = Math.abs(d1) > Math.abs(d2) ? 360-azlim : azlim;
-			}
-		}
+		az = az < 0 ? az + 360 : az % 360;
 		this._foldedazimuth = this.mix * this._foldedazimuth + (1 - this.mix) * az;
 		// this._flatazimuth = (1 - this.mix) * this._flatazimuth + this.mix * az;
 		if ( this.mix == 1.0 ) {
@@ -160,26 +153,11 @@ var jsplot = (function (module) {
 
 			this._flatazimuth = az;
 		}
-		// if (this.mix == 0) {
-		// 	this._foldedazimuth = az;
-		// } else if (this.mix == 1) {
-		// 	this._flatazimuth = az;
-		// }
-
-		// az = (1 - this.mix) * this._foldedazimuth + this.mix * this._flatazimuth;
-
-		this.azimuth = az < 0 ? az + 360 : az % 360;
+		this.azimuth = az;
 	}
 	module.LandscapeControls.prototype.setAltitude = function(alt) {
 		if (alt === undefined)
 			return this.altitude;
-
-		// var altlim = this.mix * 90;
-		// var altlim = 0; // THIS IS DISABLED, NO ALTITUDE LIMITS
-		// alt = alt > 179.9999-altlim ? 179.9999-altlim : alt;
-		// this.altitude = alt < 0.0001+altlim ? 0.0001+altlim : alt;
-		// this._basealtitude = Math.min(Math.max(alt, 0.1), 179.9);
-		// this.altitude = Math.max(this._basealtitude - 90 * this.mix, 0.1);
 
 		this._foldedaltitude = this.mix * this._foldedaltitude + (1 - this.mix) * alt;
 		// this._flataltitude = (1 - this.mix) * this._flataltitude + this.mix * alt;
@@ -190,20 +168,13 @@ var jsplot = (function (module) {
 				this.disable2Dbutton();
 			
 			this._flataltitude = alt;
-			
 		}
 
 		this._flataltitude = Math.min(Math.max(this._flataltitude, 0.1), 75);
-
-		// if (this.mix == 0) {
-		// 	this._foldedaltitude = alt;
-		// } else if (this.mix == 1) {
-		// 	this._flataltitude = alt;
-		// }
-		// alt = (1 - this.mix) * this._foldedaltitude + this.mix * this._flataltitude;
-		// alt = (1 - this.mix) * this._foldedaltitude + this.mix * this._flataltitude;
+		this._foldedaltitude = Math.min(Math.max(this._foldedaltitude, 0.1), 179.9);
 		this.altitude = Math.min(Math.max(alt, 0.1), 179.9);
 	}
+
 	module.LandscapeControls.prototype.setRadius = function(rad) {
 		if (rad === undefined)
 			return this.radius;
@@ -215,17 +186,13 @@ var jsplot = (function (module) {
 		if (!(xyz instanceof Array))
 			return [this.target.x, this.target.y, this.target.z];
 
-		var mix = this.mix;
-		if (mix < 1) {
+		if (this.mix < 1) {
 			this._foldedtarget.set(xyz[0], xyz[1], xyz[2]);
 			this.target.set(xyz[0], xyz[1], xyz[2]);
-		} else if (mix == 1) {
+		} else{
 			this._flattarget.set(xyz[0], xyz[1], 0);
 			this.target.set(xyz[0], xyz[1], 0);
 		}
-		// this.target.set(this._foldedtarget.x * (1-mix) + mix*this._flattarget.x,
-		//                 this._foldedtarget.y * (1-mix) + mix*this._flattarget.y,
-		//                 this._foldedtarget.z * (1-mix) + mix*this._flattarget.z);
 	}
 
 	module.LandscapeControls.prototype.enable2Dbutton = function() {

--- a/cortex/webgl/resources/js/movement.js
+++ b/cortex/webgl/resources/js/movement.js
@@ -166,7 +166,7 @@ var jsplot = (function (module) {
 		// 	this._flatazimuth = az;
 		// }
 
-		az = (1 - this.mix) * this._foldedazimuth + this.mix * this._flatazimuth;
+		// az = (1 - this.mix) * this._foldedazimuth + this.mix * this._flatazimuth;
 
 		this.azimuth = az < 0 ? az + 360 : az % 360;
 	}
@@ -200,7 +200,7 @@ var jsplot = (function (module) {
 		// } else if (this.mix == 1) {
 		// 	this._flataltitude = alt;
 		// }
-		alt = (1 - this.mix) * this._foldedaltitude + this.mix * this._flataltitude;
+		// alt = (1 - this.mix) * this._foldedaltitude + this.mix * this._flataltitude;
 		// alt = (1 - this.mix) * this._foldedaltitude + this.mix * this._flataltitude;
 		this.altitude = Math.min(Math.max(alt, 0.1), 179.9);
 	}
@@ -221,9 +221,9 @@ var jsplot = (function (module) {
 		} else if (mix == 1) {
 			this._flattarget.set(xyz[0], xyz[1], 0);
 		}
-		this.target.set(this._foldedtarget.x * (1-mix) + mix*this._flattarget.x,
-		                this._foldedtarget.y * (1-mix) + mix*this._flattarget.y,
-		                this._foldedtarget.z * (1-mix) + mix*this._flattarget.z);
+		// this.target.set(this._foldedtarget.x * (1-mix) + mix*this._flattarget.x,
+		//                 this._foldedtarget.y * (1-mix) + mix*this._flattarget.y,
+		//                 this._foldedtarget.z * (1-mix) + mix*this._flattarget.z);
 	}
 
 	module.LandscapeControls.prototype.enable2Dbutton = function() {

--- a/cortex/webgl/resources/js/movement.js
+++ b/cortex/webgl/resources/js/movement.js
@@ -133,9 +133,7 @@ var jsplot = (function (module) {
 			this.setTarget(this.target.toArray());
 		}
 
-		if ( mix < 1 ) {
-			this.twodbutton.hide();
-		}
+		this.update2Dbutton();
 	}
 
 	module.LandscapeControls.prototype.setAzimuth = function(az) {
@@ -144,34 +142,26 @@ var jsplot = (function (module) {
 
 		az = az < 0 ? az + 360 : az % 360;
 		
-		if ( this.mix == 1.0 ) {
-			if ( az != 180 )
-				this.enable2Dbutton();
-			else
-				this.disable2Dbutton();
-
+		if ( this.mix == 1.0 )
 			this._flatazimuth = az;
-		}
 		else
 			this._foldedazimuth = az;
 		this.azimuth = az;
+		this.update2Dbutton();
 	}
 	module.LandscapeControls.prototype.setAltitude = function(alt) {
 		if (alt === undefined)
 			return this.altitude;
 
 		if ( this.mix == 1.0 ) {
-			if ( alt != 0.1 )
-				this.enable2Dbutton();
-			else
-				this.disable2Dbutton();
-			
 			this._flataltitude = Math.min(Math.max(alt, 0.1), 75);
 			this.altitude = this._flataltitude
 		}
-		else
+		else {
 			this._foldedaltitude = Math.min(Math.max(alt, 0.1), 179.9);
 			this.altitude = this._foldedaltitude;
+		}
+		this.update2Dbutton();
 	}
 
 	module.LandscapeControls.prototype.setRadius = function(rad) {
@@ -194,6 +184,17 @@ var jsplot = (function (module) {
 		}
 	}
 
+	module.LandscapeControls.prototype.update2Dbutton = function() {
+		if ( this.mix == 1.0 ){
+			if ( this.altitude > 0.1  ||  this.azimuth != 180 )
+				this.enable2Dbutton();
+			else
+				this.disable2Dbutton();
+		}
+		else
+			this.disable2Dbutton();
+			
+	}
 	module.LandscapeControls.prototype.enable2Dbutton = function() {
 		// this.twodbutton.prop('disabled', false);
 		this.twodbutton.show();

--- a/cortex/webgl/resources/js/movement.js
+++ b/cortex/webgl/resources/js/movement.js
@@ -143,8 +143,7 @@ var jsplot = (function (module) {
 			return this.azimuth;
 
 		az = az < 0 ? az + 360 : az % 360;
-		this._foldedazimuth = this.mix * this._foldedazimuth + (1 - this.mix) * az;
-		// this._flatazimuth = (1 - this.mix) * this._flatazimuth + this.mix * az;
+		
 		if ( this.mix == 1.0 ) {
 			if ( az != 180 )
 				this.enable2Dbutton();
@@ -153,26 +152,26 @@ var jsplot = (function (module) {
 
 			this._flatazimuth = az;
 		}
+		else
+			this._foldedazimuth = az;
 		this.azimuth = az;
 	}
 	module.LandscapeControls.prototype.setAltitude = function(alt) {
 		if (alt === undefined)
 			return this.altitude;
 
-		this._foldedaltitude = this.mix * this._foldedaltitude + (1 - this.mix) * alt;
-		// this._flataltitude = (1 - this.mix) * this._flataltitude + this.mix * alt;
 		if ( this.mix == 1.0 ) {
 			if ( alt != 0.1 )
 				this.enable2Dbutton();
 			else
 				this.disable2Dbutton();
 			
-			this._flataltitude = alt;
+			this._flataltitude = Math.min(Math.max(alt, 0.1), 75);
+			this.altitude = this._flataltitude
 		}
-
-		this._flataltitude = Math.min(Math.max(this._flataltitude, 0.1), 75);
-		this._foldedaltitude = Math.min(Math.max(this._foldedaltitude, 0.1), 179.9);
-		this.altitude = Math.min(Math.max(alt, 0.1), 179.9);
+		else
+			this._foldedaltitude = Math.min(Math.max(alt, 0.1), 179.9);
+			this.altitude = this._foldedaltitude;
 	}
 
 	module.LandscapeControls.prototype.setRadius = function(rad) {


### PR DESCRIPTION
This PR affects the azimuth/altitude/target controls of the viewer i.e. the parameters changing the camera. We can change them with the mouse (clic and drag), the cursors, or indirectly while changing the `unfold` parameter (performing a smooth camera view interpolation).

From what I understand, the desired interpolation between the folded view and the flat view is performed [here](https://github.com/TomDLT/pycortex/blob/c7bcf2e6a0396899c9755b155932382ad64915b1/cortex/webgl/resources/js/movement.js#L125-L129).

However, the commented lines in this PR perform another (unwanted ?) interpolation during mouse control of the camera view. Commenting them fixes the weird mouse control issue when `unfold > 0.5`.

Lines were added in a8ebc87760225a4b2ba9798ce29a5ce5e4b.

I am willing to clean up these functions more if you think we should remove these unnecessary interpolations.