### PR TITLE
ENH add save_3d_views and plot_panels functions

### DIFF
--- a/cortex/__init__.py
+++ b/cortex/__init__.py
@@ -8,6 +8,7 @@ from cortex.database import db
 from cortex.utils import *
 from cortex.quickflat import make_figure as quickshow
 from cortex.volume import mosaic, unmask
+import cortex.export
 
 try:
     from cortex import formats

--- a/cortex/export/__init__.py
+++ b/cortex/export/__init__.py
@@ -1,0 +1,11 @@
+from .export import save_3d_views
+from .panels import plot_panels
+from .panels import params_flatmap_lateral_medial
+from .panels import params_occipital_triple_view
+
+__all__ = [
+    save_3d_views,
+    plot_panels,
+    params_flatmap_lateral_medial,
+    params_occipital_triple_view,
+]

--- a/cortex/export/__init__.py
+++ b/cortex/export/__init__.py
@@ -1,4 +1,4 @@
-from .export import save_3d_views
+from .save_views import save_3d_views
 from .panels import plot_panels
 from .panels import params_flatmap_lateral_medial
 from .panels import params_occipital_triple_view

--- a/cortex/export/export.py
+++ b/cortex/export/export.py
@@ -1,0 +1,202 @@
+import os
+import time
+
+import cortex
+
+file_pattern = "{base}_{view}_{surface}.png"
+
+
+def save_3d_views(volume, base_name='fig', list_angles=['lateral_pivot'],
+                  list_surfaces=['inflated'],
+                  viewer_params=dict(labels_visible=[],
+                                     overlays_visible=['rois']),
+                  size=(1024 * 4, 768 * 4), trim=True, sleep=10):
+    """Saves 3D views of `volume` under multiple specifications.
+
+    Needs to be run on a system with a display (will launch webgl viewer).
+    The best way to get the expected results is to keep the webgl viewer
+    visible during the process.
+
+    Parameters
+    ----------
+    volume: pycortex.Volume
+        Data to be displayed.
+
+    base_name: str
+        Base name for images.
+
+    list_angles: list of str
+        Views to be used. Should be of length one, or of the same length as
+        `list_surfaces`. Choices are:
+            'left', 'right', 'front', 'back', 'top', 'bottom', 'flatmap',
+            'medial_pivot', 'lateral_pivot', 'bottom_pivot',
+            or a custom dictionary of parameters.
+
+    list_surfaces: list of str
+        Surfaces to be used. Should be of length one, or of the same length as
+        `list_angles`. Choices are:
+            'inflated', 'flatmap', 'fiducial', 'inflated_cut',
+            or a custom dictionary of parameters.
+
+    viewer_params: dict
+        Parameters passed to the viewer.
+
+    size: tuple of int
+        Size of produced image (before trimming).
+
+    trim: bool
+        Whether to trim the white borders of the image.
+
+    sleep: float > 0
+        Time in seconds, to let the viewer open.
+
+    Returns
+    -------
+    file_names: list of str
+        Image paths.
+    """
+    msg = "list_angles and list_surfaces should have the same length."
+    assert len(list_angles) == len(list_surfaces), msg
+
+    # Create viewer
+    handle = cortex.webshow(volume, **viewer_params)
+    # Wait for the viewer to be loaded
+    time.sleep(sleep)
+
+    file_names = []
+    for view, surface in zip(list_angles, list_surfaces):
+        if isinstance(view, str):
+            if view == 'flatmap' or surface == 'flatmap':
+                # force flatmap correspondence
+                view = surface = 'flatmap'
+            view = angle_view_params[view]
+        if isinstance(surface, str):
+            surface = unfold_view_params[surface]
+
+        # Combine view parameters
+        this_view_params = default_view_params.copy()
+        this_view_params.update(view)
+        this_view_params.update(surface)
+        print(this_view_params)
+
+        # apply params
+        handle._set_view(**this_view_params)
+
+        # wait for the view to have changed
+        for _ in range(100):
+            for k, v in this_view_params.items():
+                k = k.format(subject=volume.subject) if '{subject}' in k else k
+                if handle.ui.get(k)[0] != v:
+                    print('waiting for', k, handle.ui.get(k)[0], '->', v)
+                    time.sleep(0.1)
+                    continue
+            break
+        time.sleep(0.1)
+
+        # Save image, store file_name
+        file_name = file_pattern.format(base=base_name, view=view,
+                                        surface=surface)
+        file_names.append(file_name)
+        handle.getImage(file_name, size)
+
+        # Wait for browser to dump file, before applying new view parameters
+        while not os.path.exists(file_name):
+            pass
+        time.sleep(0.1)
+
+        # Trim white edges
+        if trim:
+            try:
+                import subprocess
+                subprocess.call(["convert", "-trim", file_name, file_name])
+            except Exception as e:
+                print(str(e))
+                pass
+
+    # Try to close the window
+    try:
+        handle.close()
+        handle.server.stop()
+    except Exception as e:
+        print(str(e))
+        print('Could not close viewer.')
+
+    return file_names
+
+
+default_view_params = {
+    'camera.azimuth': 45,
+    'camera.altitude': 75,
+    'camera.target': [0, 0, 0],
+    'surface.{subject}.unfold': 0,
+    'surface.{subject}.pivot': 0,
+    'surface.{subject}.shift': 0,
+    'surface.{subject}.specularity': 0,
+}
+
+angle_view_params = {
+    'left': {
+        'camera.azimuth': 90,
+        'camera.altitude': 90,
+    },
+    'right': {
+        'camera.azimuth': 270,
+        'camera.altitude': 90,
+    },
+    'front': {
+        'camera.azimuth': 0,
+        'camera.altitude': 90,
+    },
+    'back': {
+        'camera.azimuth': 180,
+        'camera.altitude': 90,
+    },
+    'top': {
+        'camera.azimuth': 180,
+        'camera.altitude': 0,
+    },
+    'bottom': {
+        'camera.azimuth': 0,
+        'camera.altitude': 180,
+    },
+    'flatmap': {
+        'camera.azimuth': 180,
+        'camera.altitude': 0,
+        'surface.{subject}.pivot': 180,
+        'surface.{subject}.shift': 0,
+    },
+    'medial_pivot': {
+        'camera.azimuth': 0,
+        'camera.altitude': 90,
+        'surface.{subject}.pivot': 180,
+        'surface.{subject}.shift': 10,
+    },
+    'lateral_pivot': {
+        'camera.azimuth': 180,
+        'camera.altitude': 90,
+        'surface.{subject}.pivot': 180,
+        'surface.{subject}.shift': 10,
+    },
+    'bottom_pivot': {
+        'camera.azimuth': 180,
+        'camera.altitude': 180,
+        'camera.target': [0, -100, 0],
+        'surface.{subject}.pivot': 180,
+        'surface.{subject}.shift': 10,
+    },
+}
+
+unfold_view_params = {
+    'fiducial': {
+        'surface.{subject}.unfold': 0,
+    },
+    'inflated': {
+        'surface.{subject}.unfold': 0.5,
+    },
+    'inflated_cut': {
+        'surface.{subject}.unfold': 0.501,
+    },
+    'flatmap': {
+        'surface.{subject}.unfold': 1,
+    },
+}

--- a/cortex/export/panels.py
+++ b/cortex/export/panels.py
@@ -1,0 +1,213 @@
+import os
+import errno
+import shutil
+import tempfile
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from .export import save_3d_views
+
+
+def plot_panels(volume, panels, figsize=(16, 9), save_name=None):
+    """Plot on the same figure a number of views, as defined by a list of panel
+
+    Parameters
+    ----------
+    volume : cortex.Volume
+        The data to plot.
+
+    panels : list of dict
+        List of parameters for each panel. An example of panel is:
+            {
+                'extent': [0.000, 0.000, 0.300, 0.300],
+                'view': {
+                    'hemisphere': 'left',
+                    'angle': 'lateral_pivot',
+                    'surface': 'inflated',
+                }
+            }
+        The `extent` and `zoom` entries are ordered as
+        [left, bottom, width, height] with values in [0, 1].
+
+    figsize : tuple of float
+        Size of the figure.
+
+    save_name : str or None
+        Name of the file where the figure is saved. None to not save.
+        Can end with different extensions, such as '.png' of '.pdf'.
+
+    Returns
+    -------
+    fig : matplotlib.Figure
+        Created figure. Can be used for instance for custom save functions.
+
+    Example
+    -------
+    >>> from cortex.export import plot_panels, params_flatmap_lateral_medial
+    >>> plot_panels(volume, **params_flatmap_lateral_medial)
+
+    """
+    # list of couple of angles and surfaces
+    angles_and_surfaces = [(panel['view']['angle'], panel['view']['surface'])
+                           for panel in panels]
+    # remove redundant couples, e.g. left and right
+    angles_and_surfaces = list(set(angles_and_surfaces))
+    list_angles, list_surfaces = list(zip(*angles_and_surfaces))
+
+    # create all images
+    temp_dir = tempfile.mkdtemp()
+    base_name = os.path.join(temp_dir, 'fig')
+    filenames = save_3d_views(volume, base_name, list_angles=list_angles,
+                              list_surfaces=list_surfaces, trim=True,
+                              size=(1600 * 4, 900 * 4))
+
+    fig = plt.figure(figsize=figsize)
+    for panel in panels:
+        
+        # load image
+        angle_and_surface = (panel['view']['angle'], panel['view']['surface'])
+        index = angles_and_surfaces.index(angle_and_surface)
+        image = plt.imread(filenames[index])
+
+        # chose hemisphere
+        if 'hemisphere' in panel['view']:
+            left, right = np.split(image, [image.shape[1] // 2], axis=1)
+            if panel['view']['hemisphere'] == 'left':
+                image = left
+            else:
+                image = right
+
+        # trim white borders
+        image = image[image.sum(axis=1).sum(axis=1) > 0]
+        image = image[:, image.sum(axis=0).sum(axis=1) > 0]
+
+        # zoom
+        if 'zoom' in panel['view']:
+            left, bottom, width, height = panel['view']['zoom']
+            left = int(left * image.shape[1])
+            width = int(width * image.shape[1])
+            bottom = int(bottom * image.shape[0])
+            height = int(height * image.shape[0])
+            image = image[bottom:bottom + height]
+            image = image[:, left:left + width]
+
+        # add ax and image
+        ax = plt.axes(panel['extent'])
+        ax.axis('off')
+        ax.imshow(image)
+
+    # note that you might get a slightly different layout with `plt.show()`
+    # since it might use a different backend
+    if save_name is not None:
+        fig.savefig(save_name, bbox_inches='tight', dpi=100)
+        
+    # delete temporary directory
+    try:
+        shutil.rmtree(temp_dir)
+    except OSError as e:
+        # reraise if the directory has not already been deleted
+        if e.errno != errno.ENOENT:
+            raise
+
+    return fig
+
+
+params_flatmap_lateral_medial = {
+    'figsize': [16, 9],
+    'panels': [
+        {
+            'extent': [0.000, 0.200, 1.000, 0.800],
+            'view': {
+                'angle': 'flatmap',
+                'surface': 'flatmap'
+            },
+        },
+        {
+            'extent': [0.300, 0.000, 0.200, 0.200],
+            'view': {
+                'hemisphere': 'left',
+                'angle': 'medial_pivot',
+                'surface': 'inflated'
+            }
+        },
+        {
+            'extent': [0.500, 0.000, 0.200, 0.200],
+            'view': {
+                'hemisphere': 'right',
+                'angle': 'medial_pivot',
+                'surface': 'inflated'
+            },
+        },
+        {
+            'extent': [0.000, 0.000, 0.300, 0.300],
+            'view': {
+                'hemisphere': 'left',
+                'angle': 'lateral_pivot',
+                'surface': 'inflated'
+            }
+        },
+        {
+            'extent': [0.700, 0.000, 0.300, 0.300],
+            'view': {
+                'hemisphere': 'right',
+                'angle': 'lateral_pivot',
+                'surface': 'inflated'
+            },
+        },
+    ]
+}
+
+params_occipital_triple_view = {
+    'figsize': [16, 9],
+    'panels': [{
+        'extent': [0.260, 0.000, 0.480, 1.000],
+        'view': {
+            'angle': 'flatmap',
+            'surface': 'flatmap',
+            'zoom': [0.250, 0.000, 0.500, 1.000]
+        }
+    }, {
+        'extent': [0.000, 0.000, 0.250, 0.333],
+        'view': {
+            'hemisphere': 'left',
+            'angle': 'bottom_pivot',
+            'surface': 'inflated'
+        }
+    }, {
+        'extent': [0.000, 0.333, 0.250, 0.333],
+        'view': {
+            'hemisphere': 'left',
+            'angle': 'medial_pivot',
+            'surface': 'inflated'
+        }
+    }, {
+        'extent': [0.000, 0.666, 0.250, 0.333],
+        'view': {
+            'hemisphere': 'left',
+            'angle': 'lateral_pivot',
+            'surface': 'inflated'
+        }
+    }, {
+        'extent': [0.750, 0.000, 0.250, 0.333],
+        'view': {
+            'hemisphere': 'right',
+            'angle': 'bottom_pivot',
+            'surface': 'inflated'
+        }
+    }, {
+        'extent': [0.750, 0.333, 0.250, 0.333],
+        'view': {
+            'hemisphere': 'right',
+            'angle': 'medial_pivot',
+            'surface': 'inflated'
+        }
+    }, {
+        'extent': [0.750, 0.666, 0.250, 0.333],
+        'view': {
+            'hemisphere': 'right',
+            'angle': 'lateral_pivot',
+            'surface': 'inflated'
+        }
+    }]
+}

--- a/cortex/export/panels.py
+++ b/cortex/export/panels.py
@@ -6,7 +6,7 @@ import tempfile
 import numpy as np
 import matplotlib.pyplot as plt
 
-from .export import save_3d_views
+from .save_views import save_3d_views
 
 
 def plot_panels(volume, panels, figsize=(16, 9), save_name=None):

--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -25,14 +25,14 @@ def save_3d_views(volume, base_name='fig', list_angles=['lateral_pivot'],
     base_name: str
         Base name for images.
 
-    list_angles: list of str
+    list_angles: list of (str or dict)
         Views to be used. Should be of length one, or of the same length as
         `list_surfaces`. Choices are:
             'left', 'right', 'front', 'back', 'top', 'bottom', 'flatmap',
             'medial_pivot', 'lateral_pivot', 'bottom_pivot',
             or a custom dictionary of parameters.
 
-    list_surfaces: list of str
+    list_surfaces: list of (str or dict)
         Surfaces to be used. Should be of length one, or of the same length as
         `list_angles`. Choices are:
             'inflated', 'flatmap', 'fiducial', 'inflated_cut',
@@ -69,14 +69,18 @@ def save_3d_views(volume, base_name='fig', list_angles=['lateral_pivot'],
             if view == 'flatmap' or surface == 'flatmap':
                 # force flatmap correspondence
                 view = surface = 'flatmap'
-            view = angle_view_params[view]
+            view_params = angle_view_params[view]
+        else:
+            view_params = view
         if isinstance(surface, str):
-            surface = unfold_view_params[surface]
+            surface_params = unfold_view_params[surface]
+        else:
+            surface_params = surface
 
         # Combine view parameters
         this_view_params = default_view_params.copy()
-        this_view_params.update(view)
-        this_view_params.update(surface)
+        this_view_params.update(view_params)
+        this_view_params.update(surface_params)
         print(this_view_params)
 
         # apply params

--- a/examples/utils/plot_multi_panels.py
+++ b/examples/utils/plot_multi_panels.py
@@ -50,7 +50,7 @@ plt.show()
 # List all predefined angles
 
 base_name = os.path.join(tempfile.mkdtemp(), 'fig')
-list_angles = list(cortex.export.export.angle_view_params.keys())
+list_angles = list(cortex.export.save_views.angle_view_params.keys())
 
 filenames = cortex.export.save_3d_views(
     volume, base_name=base_name, list_angles=list_angles,
@@ -66,7 +66,7 @@ for filename, angle in zip(filenames, list_angles):
 # List all predefined surfaces
 
 base_name = os.path.join(tempfile.mkdtemp(), 'fig')
-list_surfaces = list(cortex.export.export.unfold_view_params.keys())
+list_surfaces = list(cortex.export.save_views.unfold_view_params.keys())
 
 filenames = cortex.export.save_3d_views(
     volume, base_name=base_name,

--- a/examples/utils/plot_multi_panels.py
+++ b/examples/utils/plot_multi_panels.py
@@ -1,0 +1,80 @@
+"""
+====================
+Multi-panels figures
+====================
+
+The function `cortex.export.plot_panels` plots a number of 3d views of a given
+volume, in the same matplotlib figure. It does that by saving a temporary image
+for each view, and then aggregating them in the same figure.
+
+The function needs to be run on a system with a display, since it will launch
+a webgl viewer. The best way to get the expected results is to keep the webgl
+viewer visible during the process.
+
+The selection of views and the aggregation is controled by a list of "panels".
+Examples of panels can be imported with:
+
+    from cortex.export import params_flatmap_lateral_medial
+    from cortex.export import params_occipital_triple_view
+
+"""
+import os
+import tempfile
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import cortex
+
+subject = 'S1'
+
+###############################################################################
+# create some artificial data
+
+shape = cortex.db.get_xfm(subject, 'identity').shape
+data = np.arange(np.product(shape)).reshape(shape)
+volume = cortex.Volume(data, subject=subject, xfmname='identity')
+
+###############################################################################
+# Show examples of multi-panels figures
+
+params = cortex.export.params_flatmap_lateral_medial
+cortex.export.plot_panels(volume, **params)
+plt.show()
+
+params = cortex.export.params_occipital_triple_view
+cortex.export.plot_panels(volume, **params)
+plt.show()
+
+###############################################################################
+# List all predefined angles
+
+base_name = os.path.join(tempfile.mkdtemp(), 'fig')
+list_angles = list(cortex.export.export.angle_view_params.keys())
+
+filenames = cortex.export.save_3d_views(
+    volume, base_name=base_name, list_angles=list_angles,
+    list_surfaces=['inflated'] * len(list_angles))
+
+for filename, angle in zip(filenames, list_angles):
+    plt.imshow(plt.imread(filename))
+    plt.axis('off')
+    plt.title(angle)
+    plt.show()
+
+###############################################################################
+# List all predefined surfaces
+
+base_name = os.path.join(tempfile.mkdtemp(), 'fig')
+list_surfaces = list(cortex.export.export.unfold_view_params.keys())
+
+filenames = cortex.export.save_3d_views(
+    volume, base_name=base_name,
+    list_angles=['lateral_pivot'] * len(list_surfaces),
+    list_surfaces=list_surfaces)
+
+for filename, surface in zip(filenames, list_surfaces):
+    plt.imshow(plt.imread(filename))
+    plt.axis('off')
+    plt.title(surface)
+    plt.show()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import sys
 from numpy.distutils.misc_util import get_numpy_include_dirs
 
 try:
@@ -67,7 +66,8 @@ setup(name='pycortex',
       author='James Gao',
       author_email='james@jamesgao.com',
       packages=['cortex', 'cortex.webgl', 'cortex.mapper', 'cortex.dataset',
-                'cortex.blender', 'cortex.tests', 'cortex.quickflat', 'cortex.polyutils'],
+                'cortex.blender', 'cortex.tests', 'cortex.quickflat', 'cortex.polyutils',
+                'cortex.export'],
       ext_modules=cythonize([ctm, formats]),
       package_data={
             'cortex': [


### PR DESCRIPTION
This PR adds two functions, `save_3d_views` and `plot_panels`, to create programmatically figures with multiple views of the same volume. It proposes two layouts as examples.

I added this in a new module, poorly named `export`. Feel free to suggest a better name.

### Layout 1
![Figure_1](https://user-images.githubusercontent.com/11065596/62981213-89de9a80-bddd-11e9-81e6-941247346739.png)
### Layout 2
![Figure_2](https://user-images.githubusercontent.com/11065596/62981224-9105a880-bddd-11e9-9380-1ded0cdfc44a.png)