### PR TITLE
Thickness nanmean

### DIFF
--- a/cortex/quickflat/composite.py
+++ b/cortex/quickflat/composite.py
@@ -121,7 +121,7 @@ def add_curvature(fig, dataview, extents=None, height=None, threshold=True, cont
     return cvimg
 
 def add_data(fig, braindata, height=1024, thick=32, depth=0.5, pixelwise=True,
-             sampler='nearest', recache=False):
+             sampler='nearest', recache=False, nanmean=False):
     """Add data to quickflat plot
 
     Parameters
@@ -158,7 +158,7 @@ def add_data(fig, braindata, height=1024, thick=32, depth=0.5, pixelwise=True,
         raise TypeError('Please provide a Dataview, not a Dataset')
     # Generate image (2D array, maybe 3D array)
     im, extents = make_flatmap_image(dataview, recache=recache, pixelwise=pixelwise, sampler=sampler,
-                                     height=height, thick=thick, depth=depth)
+                                     height=height, thick=thick, depth=depth, nanmean=nanmean)
     # Check whether dataview has a cmap instance
     cmapdict = _has_cmap(dataview)
     # Plot

--- a/cortex/quickflat/composite.py
+++ b/cortex/quickflat/composite.py
@@ -143,6 +143,8 @@ def add_data(fig, braindata, height=1024, thick=32, depth=0.5, pixelwise=True,
     sampler : str
         Name of sampling function used to sample underlying volume data. Options include
         'trilinear','nearest','lanczos'; see functions in cortex.mapper.samplers.py for all options
+    nanmean : bool, optional (default = False)
+        If True, NaNs in the data will be ignored when averaging across layers.
 
     Returns
     -------

--- a/cortex/quickflat/utils.py
+++ b/cortex/quickflat/utils.py
@@ -79,14 +79,19 @@ def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **k
         img = (np.nan*np.ones(mask.shape)).astype(data.dtype)
         mimg = (np.nan*np.ones(badmask.shape)).astype(data.dtype)
 
-        if nanmean:
-            # create nanmean of pixmap*data
-            nan_to_num_mean = pixmap * np.nan_to_num(data.ravel())
-            non_nan_mean = pixmap * (~np.isnan(data.ravel())).astype(data.dtype)
-            nanmean_data = nan_to_num_mean / non_nan_mean
-            mimg[badmask] = nanmean_data[badmask].astype(mimg.dtype)
+        # pixmap is a (pixels x voxels) sparse non-negative weight matrix
+        # where each row sums to 1
+
+        if not nanmean:
+            # pixmap.dot(vec) gives mean of vec across cortical thickness
+            mimg[badmask] = pixmap.dot(data.ravel())[badmask].astype(mimg.dtype)
         else:
-            mimg[badmask] = (pixmap*data.ravel())[badmask].astype(mimg.dtype)
+            # to ignore nans in the weighted mean, nanmean =
+            # sum(weights * non-nan values) / sum(weights on non-nan values)
+            nonnan_sum = pixmap.dot(np.nan_to_num(data.ravel()))
+            weights_on_nonnan = pixmap.dot((~np.isnan(data.ravel())).astype(data.dtype))
+            nanmean_data = nonnan_sum / weights_on_nonnan
+            mimg[badmask] = nanmean_data[badmask].astype(mimg.dtype)
 
         img[mask] = mimg
 

--- a/cortex/quickflat/utils.py
+++ b/cortex/quickflat/utils.py
@@ -28,6 +28,8 @@ def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **k
     recache : boolean
         Whether or not to recache intermediate files. Takes longer to plot this way, potentially
         resolves some errors. Useful if you've made changes to the alignment.
+    nanmean : bool, optional (default = False)
+        If True, NaNs in the data will be ignored when averaging across layers.
     kwargs : idk
         idk
 
@@ -85,7 +87,7 @@ def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **k
             mimg[badmask] = nanmean_data[badmask].astype(mimg.dtype)
         else:
             mimg[badmask] = (pixmap*data.ravel())[badmask].astype(mimg.dtype)
-        
+
         img[mask] = mimg
 
         return img.T[::-1], extents

--- a/cortex/quickflat/view.py
+++ b/cortex/quickflat/view.py
@@ -19,7 +19,7 @@ def make_figure(braindata, recache=False, pixelwise=True, thick=32, sampler='nea
                 labelsize=None, labelcolor=None, cutout=None, curvature_brightness=None,
                 curvature_contrast=None, curvature_threshold=None, fig=None, extra_hatch=None,
                 colorbar_ticks=None, colorbar_location=(.4, .07, .2, .04), roi_list=None,
-                **kwargs):
+                nanmean=False, **kwargs):
     """Show a Volume or Vertex on a flatmap with matplotlib.
 
     Note that **kwargs are ONLY present now for backward compatibility / warnings. No kwargs
@@ -119,7 +119,7 @@ def make_figure(braindata, recache=False, pixelwise=True, thick=32, sampler='nea
 
     # Add data
     data_im, extents = composite.add_data(ax, dataview, pixelwise=pixelwise, thick=thick, sampler=sampler,
-                                          height=height, depth=depth, recache=recache)
+                                          height=height, depth=depth, recache=recache, nanmean=nanmean)
 
     layers = dict(data=data_im)
     # Add curvature

--- a/cortex/quickflat/view.py
+++ b/cortex/quickflat/view.py
@@ -98,6 +98,8 @@ def make_figure(braindata, recache=False, pixelwise=True, thick=32, sampler='nea
         vmin, vmax specified in the Volume2D object.
     fig : figure or ax
         figure into which to plot flatmap
+    nanmean : bool, optional (default = False)
+        If True, NaNs in the data will be ignored when averaging across layers.
     """
     from matplotlib import pyplot as plt
 

--- a/examples/quickflat/plot_thickness_nanmean.py
+++ b/examples/quickflat/plot_thickness_nanmean.py
@@ -39,3 +39,4 @@ _ = cortex.quickshow(vol, nanmean=False, vmin=0, vmax=2, with_curvature=True)
 # and, again, all the non-hole points should have value of 1
 _ = cortex.quickshow(vol, nanmean=True, vmin=0, vmax=2, with_curvature=True)
 
+plt.show()

--- a/examples/quickflat/plot_thickness_nanmean.py
+++ b/examples/quickflat/plot_thickness_nanmean.py
@@ -18,7 +18,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 # create dataset with volume of all 1's
-vol = cortex.Volume.empty('S1', 'fullhead') + 1
+vol = cortex.Volume.empty('S1', 'fullhead', vmin=0, vmax=2) + 1
 
 # set 20% of the values in the dataset to NaN
 vol.data[np.random.rand(*vol.data.shape) > 0.8] = np.nan
@@ -29,14 +29,15 @@ vol.data[np.random.rand(*vol.data.shape) > 0.8] = np.nan
 # in the final image
 # so this image should have many, many holes that show curvature
 # and all the non-hole points should have value of 1
-_ = cortex.quickshow(vol, nanmean=False, vmin=0, vmax=2, with_curvature=True)
+_ = cortex.quickshow(vol, nanmean=False, with_curvature=True)
 
+plt.show()
 
 # plot the volume with nanmean=True
 # here there should only be a nan in the final image if EVERY layer of the
 # thickness mapping has a nan for the given pixel
 # so this image should have many fewer holes that show curvature
 # and, again, all the non-hole points should have value of 1
-_ = cortex.quickshow(vol, nanmean=True, vmin=0, vmax=2, with_curvature=True)
+_ = cortex.quickshow(vol, nanmean=True, with_curvature=True)
 
 plt.show()

--- a/examples/quickflat/plot_thickness_nanmean.py
+++ b/examples/quickflat/plot_thickness_nanmean.py
@@ -1,0 +1,41 @@
+"""
+===================================
+Ignore NaN (not-a-number) values in thickness mapping
+===================================
+
+By default, pycortex quickshow averages across the thickness of the cortex
+for each pixel in the resulting flatmap. If any of these layers contain a value
+of NaN (not-a-number), then the result of the average will also be Nan. This
+behavior might be undesirable. To avoid it, pass the argument `nanmean=True` to
+`cortex.quickshow` (or `cortex.quickflat.make_figure`). This will only take the
+mean of the non-NaN values when averaging across the thickness of cortex. A
+pixel will only have the value NaN if every voxel between pia and white matter 
+has the value NaN.
+"""
+
+import cortex
+import numpy as np
+from matplotlib import pyplot as plt
+
+# create dataset with volume of all 1's
+vol = cortex.Volume.empty('S1', 'fullhead') + 1
+
+# set 20% of the values in the dataset to NaN
+vol.data[np.random.rand(*vol.data.shape) > 0.8] = np.nan
+
+
+# plot the volume with nanmean=False
+# here a nan in ANY layer of the thickness mapping will result in a nan
+# in the final image
+# so this image should have many, many holes that show curvature
+# and all the non-hole points should have value of 1
+_ = cortex.quickshow(vol, nanmean=False, vmin=0, vmax=2, with_curvature=True)
+
+
+# plot the volume with nanmean=True
+# here there should only be a nan in the final image if EVERY layer of the
+# thickness mapping has a nan for the given pixel
+# so this image should have many fewer holes that show curvature
+# and, again, all the non-hole points should have value of 1
+_ = cortex.quickshow(vol, nanmean=True, vmin=0, vmax=2, with_curvature=True)
+


### PR DESCRIPTION
This adds the kwarg `nanmean` to `cortex.quickshow`. Setting `nanmean` to True makes quickflat only take the mean over non-nan values when averaging across the thickness of cortex. Pixels will still be set to nan if every voxel across the thickness is nan.

By default `nanmean` is set to False, giving the current behavior (i.e. no existing plots should change after this merge).

I also created an example that shows how it works.

This might solve issues #323 and #280. 