### PR TITLE
make Inkscape command line option explicit

### DIFF
--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -265,7 +265,7 @@ class SVGOverlay(object):
             pngfile = png.name
 
         inkscape_cmd = config.get('dependency_paths', 'inkscape')
-        cmd = "{inkscape_cmd} -z -h {height} -e {outfile} /dev/stdin"
+        cmd = "{inkscape_cmd} -z -h {height} --export-file {outfile} /dev/stdin"
         cmd = cmd.format(inkscape_cmd=inkscape_cmd, height=height, outfile=pngfile)
         proc = sp.Popen(shlex.split(cmd), stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
         stdout, stderr = proc.communicate(etree.tostring(self.svg))


### PR DESCRIPTION
When Inkscape is instructed to create a png based on an svg layer, Mac OS Inkscape doesn't accept the ` -e ` argument. This results in an empty png file, and a subsequent "read past end of file" when the empty file is read. Changing ` -e `  to ` --export-file ` resolves this issue.