### PR TITLE
Update and consolidate install & demo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,49 +6,54 @@ pycortex
 
 Pycortex is a software library that allows you to visualize fMRI or other volumetric neuroimaging data on cortical surfaces.
 
-Quickstart
-----------
+Installation
+------------
+To install the stable release version of pycortex, do the following:
+
 ```bash
-# create a virtual environment called env with Python 3
-python3 -m venv env  
-# activate the virtual environment
-source env/bin/activate
-# install some prerequisite packages
+# First, install some required dependencies (if not already installed)
 pip install -U setuptools wheel numpy cython
-# install the latest release of pycortex from pip
+# Install the latest release of pycortex from pip
 pip install -U pycortex
 ```
 
-This command creates a new [virtualenv](https://docs.python.org/3/library/venv.html) for pycortex to resolve dependencies. Run `source env/bin/activate` whenever you need pycortex.
+If you wish to install the development version of pycortex, you can install it directly from Github.
 
-If you want to install the latest, unreleased version of pycortex from github, instead of the last line you can run
+To do so, replace the second install line above with the following:
 
 ```bash
-# install unreleased version of pycortex from github
+# Install development version of pycortex from github
 pip install -U git+git://github.com/gallantlab/pycortex.git
 ```
 
 Documentation
 -------------
-Pycortex documentation is available at [https://gallantlab.github.io/pycortex](https://gallantlab.github.io/pycortex). You can find many examples of pycortex features in the [pycortex example gallery](https://gallantlab.github.io/pycortex/auto_examples/index.html).
+Pycortex documentation is available at [https://gallantlab.github.io/pycortex](https://gallantlab.github.io/pycortex).
+
+You can find many examples of pycortex features in the [pycortex example gallery](https://gallantlab.github.io/pycortex/auto_examples/index.html).
 
 To build the documentation locally:
 ```bash
-pip install sphinx_gallery
-pip install numpydoc
+# Install required dependencies for the documentation
+pip install sphinx_gallery numpydoc
+# Move into the docs folder (assuming already in pycortex directory)
 cd docs
+# Build a local version of the documentation site
 make html
-# open `docs/_build/html/index.html` in web browser
 ```
+
+After you run the above, you can open `docs/_build/html/index.html` in a web browser to view the locally built documentation.
 
 Demo
 ----
-Pycortex is best used with [IPython](http://www.ipython.org/). Install it in your virtualenv using 
+Pycortex is best used with [IPython]().
+
+If you do not already have IPython, you can install it by running:
 ```bash
-source env/bin/activate
 pip install ipython
 ```
-To run the pycortex demo,
+
+To run the pycortex demo, using IPython, run:
 ```ipython
 $ ipython
 In [1]: import cortex
@@ -62,6 +67,6 @@ If you use pycortex in published work, please cite the [pycortex paper](http://d
 _Gao JS, Huth AG, Lescroart MD and Gallant JL (2015) Pycortex: an interactive surface visualizer for fMRI. Front. Neuroinform. 9:23. doi: 10.3389/fninf.2015.00023_
 
 Getting help
------------
-Please post on [NeuroStars](https://neurostars.org/) with the tag `pycortex` to 
+------------
+Please post on [NeuroStars](https://neurostars.org/) with the tag `pycortex` to
 ask questions about how to use Pycortex.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,39 +1,49 @@
 Installation
 ============
-The best way to install pycortex currently is by getting the latest source code from github::
 
-    git clone https://github.com/gallantlab/pycortex.git
-    cd pycortex
+To install the stable release version of pycortex, do the following::
 
-    python setup.py develop
+    # First, install some required dependencies
+    pip install -U setuptools wheel numpy cython
+    # Install the latest release of pycortex from pip
+    pip install -U pycortex
 
 
-Dependencies
-------------
-The easiest way to get most of the dependencies is using Anaconda_. To use pycortex with Anaconda_, first install anaconda as instructed, then::
+If you wish to install the development version of pycortex, you can install it directly from Github.
 
-    pip install numpy Cython scipy h5py nibabel matplotlib Pillow numexpr tornado lxml networkx
+To do so, replace the second install line above with the following::
 
-You will also need to install Inkscape_ using whatever method is appropriate for your system. On Mac OS X you will also need to enable access to Inkscape on the command line, see these instructions_.
+    # Install development version of pycortex from github
+    pip install -U git+git://github.com/gallantlab/pycortex.git
 
-If you are running Ubuntu without Anaconda, use the following commands::
+Optional Dependencies
+---------------------
+For some functionality, you will also need to install Inkscape_, using whatever method is appropriate for your system.
 
-    sudo apt-get install python-dev python-numpy python-scipy python-matplotlib python-h5py python-nibabel python-lxml python-shapely python-html5lib inkscape
+On Mac OS X you will also need to enable access to Inkscape on the command line, see these instructions_.
 
-.. _Anaconda: https://store.continuum.io/cshop/anaconda/
 .. _Inkscape: https://inkscape.org/en/
 .. _instructions: http://wiki.inkscape.org/wiki/index.php/Mac_OS_X#Inkscape_command_line
 
 Demo
 ----
-To test if your install went well, first download the `example dataset <http://gallantlab.org/pycortex/S1_retinotopy.hdf>`_. Then run the following commands at a terminal::
-    
+To test if your install went well, you can run the pycortex demo.
+
+Pycortex is best used with IPython_
+
+If you do not already have IPython, you can install it by running::
+
+    pip install ipython
+
+To run the pycortex demo, using IPython, run::
+
     $ ipython
     In [1]: import cortex
-    In [2]: ds = cortex.load("S1_retinotopy.hdf")
-    In [3]: cortex.webshow(ds)
+    In [2]: cortex.webshow(cortex.Volume.random("S1", "fullhead"))
 
-If everything went well, this should pop up a web browser window with the same view as http://gallantlab.org/pycortex/retinotopy_demo/.
+If everything went well, this should pop up a web browser window with a demo subject.
+
+.. _IPython: http://www.ipython.org/
 
 Basic Configuration
 -------------------
@@ -53,4 +63,3 @@ If you want to move the filestore, you need to update the config file::
 
    [basic]
    filestore=/abs/path/to/filestore
-


### PR DESCRIPTION
This PR relates to #358 - and acts to standardize the listed instructions to install and run the demo, updating from having two different versions between the README and documentation site.

This basically updates the documentation site to follow what was in the README. Following this approach, I tested I can install and run the demo. It needs checking to make sure this is the right approach to recommend to users, and check I haven't missed anything.  

Notes on the updates:
- I dropped reference to using either anaconda or venv
    - This follows the discussion in #358, and is based on the idea that it can / should be up to the user as to how manage an environment for pycortex
- I consolidated the docsite so the install and demo instructions to follow what was in the README
    - For install, this standardizes instructions to use the stable pip install. 
    - For the demo, this meant removing the instructions on the docsite to download data, and do something different than the README version. I *think* the README version is the current recommended demo version. 

Questions / things to check:
- The documentation site mentions also installing`Inkscape`. I *think* this is an optional dependency, required for some functionality, and so I updated the description to reflect that. This needs checking though, to make sure this is the intended interpretation. Questions:
    - Is this the intended way to think about and document Inkscape?
    - Are there any other optional dependencies / extras that should be mentioned?
    - Inkscape was not and is not currently mentioned in the README. Should it be?