### PR TITLE
Custom colors in VolumeRGB

### DIFF
--- a/cortex/__init__.py
+++ b/cortex/__init__.py
@@ -1,6 +1,6 @@
 # emacs: -*- coding: utf-8; mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set fileencoding=utf-8 ft=python sts=4 ts=4 sw=4 et:
-from cortex.dataset import Dataset, Volume, Vertex, VolumeRGB, VertexRGB, Volume2D, Vertex2D
+from cortex.dataset import Dataset, Volume, Vertex, VolumeRGB, VertexRGB, Volume2D, Vertex2D, Colors
 from cortex import align, volume, quickflat, webgl, segment, options
 from cortex.database import db
 from cortex.utils import *

--- a/cortex/dataset/__init__.py
+++ b/cortex/dataset/__init__.py
@@ -1,5 +1,5 @@
 """Contains classes for representing brain data in either volumetric or vertex (surface-based) formats for visualization.
 """
 
-from .views import Volume, Vertex, VolumeRGB, VertexRGB, Volume2D, Vertex2D, Dataview, _from_hdf_data
+from .views import Volume, Vertex, VolumeRGB, VertexRGB, Volume2D, Vertex2D, Dataview, _from_hdf_data, Colors
 from .dataset import Dataset, normalize

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -359,10 +359,6 @@ class VolumeRGB(DataviewRGB):
             channel1 /= (common_max - common_min)
             channel2 /= (common_max - common_min)
             channel3 /= (common_max - common_min)
-            # needed for if desired max/min is above/below the data's range
-            channel1 = np.clip(channel1, 0, 1)
-            channel2 = np.clip(channel2, 0, 1)
-            channel3 = np.clip(channel3, 0, 1)
         else:
             channelMin = np.percentile(channel1, 1)
             channelMax = np.percentile(channel1, 99)
@@ -376,6 +372,9 @@ class VolumeRGB(DataviewRGB):
             channelMax = np.percentile(channel3, 99)
             channel3 -= channelMin
             channel3 /= (channelMax - channelMin)
+        channel1 = np.clip(channel1, 0, 1)
+        channel2 = np.clip(channel2, 0, 1)
+        channel3 = np.clip(channel3, 0, 1)
 
         channel1color = np.array(channel1color)
         channel2color = np.array(channel2color)

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -278,9 +278,9 @@ class VolumeRGB(DataviewRGB):
         return self
 
     @staticmethod
-    def color_voxels(channel1, channel2, channel3, channel1color = Colors.RoseRed, channel2color = Colors.LimeGreen,
-                     channel3Color = Colors.DodgerBlue, value_max = None, saturation_max = 1.0, common_range = False,
-                     common_min = None, common_max = None):
+    def color_voxels(channel1, channel2, channel3, channel1color, channel2color,
+                     channel3Color, value_max, saturation_max, common_range,
+                     common_min, common_max):
         """
         Colors voxels in 3 color dimensions but not necessarily canonical red, green, and blue
         Parameters

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -156,7 +156,7 @@ class VolumeRGB(DataviewRGB):
         RGB color to use for the first data channel
     channel2color : tuple<uint8, uint8, uint8>
         RGB color to use for the second data channel
-    channel3vcolor : tuple<uint8, uint8, uint8>
+    channel3color : tuple<uint8, uint8, uint8>
         RGB color to use for the third data channel
     max_color_value : float [0, 1], optional
         Maximum HSV value for voxel colors. If not given, will be the value of

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -15,7 +15,8 @@ class Colors(object):
     """
     RoseRed = (237, 35, 96)
     LimeGreen = (141, 198, 63)
-    DodgerBlue = (0, 176, 218)
+    SkyBlue = (0, 176, 218)
+    DodgerBlue = (30, 144, 255)
     Red = (255, 000, 000)
     Green = (000, 255, 000)
     Blue = (000, 000, 255)

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -1,4 +1,5 @@
 import numpy as np
+import colorsys
 
 from .views import Dataview, Volume, Vertex
 from .braindata import VolumeData, VertexData, _hash
@@ -6,6 +7,56 @@ from ..database import db
 
 from .. import options
 default_cmap = options.config.get("basic", "default_cmap")
+
+
+class Colors(object):
+    """
+    Set of known colors
+    """
+    RoseRed =		(237,  35,  96)
+    LimeGreen =		(141, 198,  63)
+    DodgerBlue =	(  0, 176, 218)
+    Red =			(255, 000, 000)
+    Green = 		(000, 255, 000)
+    Blue = 			(000, 000, 255)
+
+
+def RGB2HSV(color):
+    """
+    Converts RGB to HS
+    Parameters
+    ----------
+    color : tuple<uint8, uint8, uint8>
+        RGB color value
+
+    Returns
+    -------
+    tuple<int, float, float>
+        HSV values. Hue in degres, saturation and value on [0, 1]
+
+    """
+    hue, saturation, value = colorsys.rgb_to_hsv(color[0] / 255.0, color[1] / 255.0, color[2] / 255.0)
+    hue *= 360
+    return (int(hue), saturation, value)
+
+
+def HSV2RGB(color):
+    """
+    Converts HSV to RGB
+
+    Parameters
+    ----------
+    color : tuple<int, float, float>
+        HSV values. Hue in degres, saturation and value on [0, 1]
+
+    Returns
+    -------
+    tuple<uint8, uint8, uint8>
+        RGB color value
+    """
+    r, g, b = colorsys.hsv_to_rgb(color[0] / 360.0, color[1], color[2])
+    return (int(r * 255), int(g * 255), int(b * 255))
+
 
 class DataviewRGB(Dataview):
     """Abstract base class for RGB data views.
@@ -46,7 +97,7 @@ class DataviewRGB(Dataview):
             alpha = self.alpha.name
 
         data = [self.red.name, self.green.name, self.blue.name, alpha]
-        viewnode = Dataview._write_hdf(self, h5, name=name, 
+        viewnode = Dataview._write_hdf(self, h5, name=name,
                                        data=[data], xfmname=xfmname)
 
         return viewnode
@@ -68,24 +119,24 @@ class DataviewRGB(Dataview):
 
 class VolumeRGB(DataviewRGB):
     """
-    Contains RGB (or RGBA) colors for each voxel in a volumetric dataset. 
+    Contains RGB (or RGBA) colors for each voxel in a volumetric dataset.
     Includes information about the subject and transform for the data.
 
-    Each color channel is represented as a separate Volume object (these can 
-    either be supplied explicitly as Volume objects or implicitly as numpy 
+    Each color channel is represented as a separate Volume object (these can
+    either be supplied explicitly as Volume objects or implicitly as numpy
     arrays). The vmin for each Volume will be mapped to the minimum value for
     that color channel, and the vmax will be mapped to the maximum value.
 
     Parameters
     ----------
-    red : ndarray or Volume
-        Array or Volume that represents the red component of the color for each 
+    channel1 : ndarray or Volume
+        Array or Volume that represents the red component of the color for each
         voxel. Can be a 1D or 3D array (see Volume for details), or a Volume.
-    green : ndarray or Volume
-        Array or Volume that represents the green component of the color for each 
+    channel2 : ndarray or Volume
+        Array or Volume that represents the green component of the color for each
         voxel. Can be a 1D or 3D array (see Volume for details), or a Volume.
-    blue : ndarray or Volume
-        Array or Volume that represents the blue component of the color for each 
+    channel3 : ndarray or Volume
+        Array or Volume that represents the blue component of the color for each
         voxel. Can be a 1D or 3D array (see Volume for details), or a Volume.
     subject : str, optional
         Subject identifier. Must exist in the pycortex database. If not given,
@@ -94,36 +145,68 @@ class VolumeRGB(DataviewRGB):
         Transform name. Must exist in the pycortex database. If not given,
         red must be a Volume from which the subject can be extracted.
     alpha : ndarray or Volume, optional
-        Array or Volume that represents the alpha component of the color for each 
+        Array or Volume that represents the alpha component of the color for each
         voxel. Can be a 1D or 3D array (see Volume for details), or a Volume. If
         None, all voxels will be assumed to have alpha=1.0.
     description : str, optional
         String describing this dataset. Displayed in webgl viewer.
     state : optional
         TODO: describe what this is
+    channel1color : tuple<uint8, uint8, uint8>
+        RGB color to use for the first data channel
+    channel2color : tuple<uint8, uint8, uint8>
+        RGB color to use for the second data channel
+    channel3vcolor : tuple<uint8, uint8, uint8>
+        RGB color to use for the third data channel
+    max_color_value : float [0, 1], optional
+        Maximum HSV value for voxel colors. If not given, will be the value of
+        the average of the three channel colors.
+    max_color_saturation: float [0, 1]
+        Maximum HSV saturation for voxel colors.
+    shared_range : bool
+        Use the same vmin and vmax for all three color channels?
+    shared_vmin : float, optional
+        Predetermined shared vmin. Does nothing if shared_range == False. If not given,
+        will be the 1st percentil of all values across all three channels.
+    shared_vmax : float, optional
+        Predetermined shared vmax. Does nothing if shared_range == False. If not given,
+        will be the 99th percentile of all values across all three channels
     **kwargs
-        All additional arguments in kwargs are passed to the VolumeData and 
+        All additional arguments in kwargs are passed to the VolumeData and
         Dataview.
 
     """
     _cls = VolumeData
 
-    def __init__(self, red, green, blue, subject=None, xfmname=None, alpha=None, description="", 
-                 state=None, **kwargs):
-        if isinstance(red, VolumeData):
-            if not isinstance(green, VolumeData) or red.subject != green.subject:
-                raise TypeError("Invalid data for green channel")
-            if not isinstance(blue, VolumeData) or red.subject != blue.subject:
-                raise TypeError("Invalid data for blue channel")
-            self.red = red
-            self.green = green
-            self.blue = blue
+    def __init__(self, channel1, channel2, channel3, subject=None, xfmname=None, alpha=None, description="",
+                 state=None, channel1color = Colors.Red, channel2color = Colors.Green, channel3color = Colors.Blue,
+                 max_color_value = None, max_color_saturation = 1.0, shared_range = False, shared_vmin = None,
+                 shared_vmax = None, **kwargs):
+        if isinstance(channel1, VolumeData):
+            if not isinstance(channel2, VolumeData) or channel1.subject != channel2.subject:
+                raise TypeError("Invalid data for channel2 channel")
+            if not isinstance(channel3, VolumeData) or channel1.subject != channel3.subject:
+                raise TypeError("Invalid data for channel3 channel")
+            self.red = channel1
+            self.green = channel2
+            self.blue = channel3
         else:
             if subject is None or xfmname is None:
                 raise TypeError("Subject and xfmname are required")
-            self.red = Volume(red, subject, xfmname)
-            self.green = Volume(green, subject, xfmname)
-            self.blue = Volume(blue, subject, xfmname)
+            if (channel1color == Colors.Red) and (channel2color == Colors.Green) and (channel3color == Colors.Blue)\
+                    and shared_range is False:
+                # R/G/B basis can be directly passed through
+                self.red = Volume(channel1, subject, xfmname)
+                self.green = Volume(channel2, subject, xfmname)
+                self.blue = Volume(channel3, subject, xfmname)
+            else:	# need to remap colors
+                remapped_colors = VolumeRGB.color_voxels(channel1, channel2, channel3, channel1color, channel2color,
+                                                         channel3color, max_color_value, max_color_saturation,
+                                                         shared_range, shared_vmin, shared_vmax)
+                self.red = Volume(remapped_colors[:, 0], subject, xfmname)
+                self.green = Volume(remapped_colors[:, 1], subject, xfmname)
+                self.blue = Volume(remapped_colors[:, 2], subject, xfmname)
+
 
         if alpha is None:
             alpha = np.ones(self.red.volume.shape)
@@ -194,33 +277,138 @@ class VolumeRGB(DataviewRGB):
     def raw(self):
         return self
 
+    @staticmethod
+    def color_voxels(channel1, channel2, channel3, channel1color = Colors.RoseRed, channel2color = Colors.LimeGreen,
+                     channel3Color = Colors.DodgerBlue, value_max = None, saturation_max = 1.0, common_range = False,
+                     common_min = None, common_max = None):
+        """
+        Colors voxels in 3 color dimensions but not necessarily canonical red, green, and blue
+        Parameters
+        ----------
+        channel1 : 1d array or Volume
+            voxel values for first channel
+        channel2 : 1d array or Volume
+            voxel values for second channel
+        channel3 : 1d array or Volume
+            voxel values for third channel
+        channel1color : tuple<uint8, uint8, uint8>
+            color in RGB for first channel
+        channel2color : tuple<uint8, uint8, uint8>
+            color in RGB for second channel
+        channel3Color : tuple<uint8, uint8, uint8>
+            color in RGB for third channel
+        value_max : float, optional
+            Maximum HSV value for voxel colors. If not given, will be the value of
+            the average of the three channel colors.
+        saturation_max : float [0, 1]
+            Maximum HSV saturation for voxel colors.
+        common_range : bool
+            Use the same vmin and vmax for all three color channels?
+        common_min : float, optional
+            Predetermined shared vmin. Does nothing if shared_range == False. If not given,
+            will be the 1st percentil of all values across all three channels.
+        common_max : float, optional
+            Predetermined shared vmax. Does nothing if shared_range == False. If not given,
+            will be the 99th percentile of all values across all three channels
+
+        Returns
+        -------
+        [voxels x 3] uint8 array of RGB colors for each voxel
+
+        """
+        # normalize each channel to [0, 1]
+        channel1 = np.nan_to_num(channel1.data if isinstance(channel1, VolumeData) else channel1)
+        channel2 = np.nan_to_num(channel2.data if isinstance(channel2, VolumeData) else channel2)
+        channel3 = np.nan_to_num(channel3.data if isinstance(channel3, VolumeData) else channel3)
+
+        if common_range:
+            if common_min is None:
+                if common_max is None:
+                    common_min = np.percentile(np.hstack((channel1, channel2, channel3)), 1)
+                else:
+                    common_min = 0
+            if common_max is None:
+                common_max = np.percentile(np.hstack((channel1, channel2, channel3)), 99)
+            channel1 -= common_min
+            channel2 -= common_min
+            channel3 -= common_min
+            channel1 /= (common_max - common_min)
+            channel2 /= (common_max - common_min)
+            channel3 /= (common_max - common_min)
+            # needed for if desired max/min is above/below the data's range
+            channel1 = np.clip(channel1, 0, 1)
+            channel2 = np.clip(channel2, 0, 1)
+            channel3 = np.clip(channel3, 0, 1)
+        else:
+            channelMin = np.percentile(channel1, 1)
+            channelMax = np.percentile(channel1, 99)
+            channel1 -= channelMin
+            channel1 /= (channelMax - channelMin)
+            channelMin = np.percentile(channel2, 1)
+            channelMax = np.percentile(channel2, 99)
+            channel2 -= channelMin
+            channel2 /= (channelMax - channelMin)
+            channelMin = np.percentile(channel3, 1)
+            channelMax = np.percentile(channel3, 99)
+            channel3 -= channelMin
+            channel3 /= (channelMax - channelMin)
+
+        channel1color = np.array(channel1color)
+        channel2color = np.array(channel2color)
+        channel3Color = np.array(channel3Color)
+
+        averageColor = (channel1color + channel2color + channel3Color) / 3
+
+        if value_max is None:
+            _, _, value = RGB2HSV(averageColor)
+            value_max = value
+
+        colors = np.zeros([channel1.shape[0], 3])
+        for i in range(channel1.shape[0]):
+            colors[i, :] += channel1[i] * channel1color
+            colors[i, :] += channel2[i] * channel2color
+            colors[i, :] += channel3[i] * channel3Color
+            colors[i, :] /= 3.0
+            if (value_max != 1.0) or (saturation_max != 1.0):
+                hue, saturation, value = RGB2HSV(colors[i, :])
+                saturation /= saturation_max
+                value /= value_max
+                if saturation > 1:
+                    saturation = 1.0
+                if value > 1:
+                    value = 1.0
+                colors[i, :] = HSV2RGB([hue, saturation, value])
+
+        return colors.astype(np.uint8)
+
+
 
 class VertexRGB(DataviewRGB):
     """
-    Contains RGB (or RGBA) colors for each vertex in a surface dataset. 
+    Contains RGB (or RGBA) colors for each vertex in a surface dataset.
     Includes information about the subject.
 
-    Each color channel is represented as a separate Vertex object (these can 
-    either be supplied explicitly as Vertex objects or implicitly as numpy 
+    Each color channel is represented as a separate Vertex object (these can
+    either be supplied explicitly as Vertex objects or implicitly as np
     arrays). The vmin for each Vertex will be mapped to the minimum value for
     that color channel, and the vmax will be mapped to the maximum value.
 
     Parameters
     ----------
     red : ndarray or Vertex
-        Array or Vertex that represents the red component of the color for each 
+        Array or Vertex that represents the red component of the color for each
         voxel. Can be a 1D or 3D array (see Vertex for details), or a Vertex.
     green : ndarray or Vertex
-        Array or Vertex that represents the green component of the color for each 
+        Array or Vertex that represents the green component of the color for each
         voxel. Can be a 1D or 3D array (see Vertex for details), or a Vertex.
     blue : ndarray or Vertex
-        Array or Vertex that represents the blue component of the color for each 
+        Array or Vertex that represents the blue component of the color for each
         voxel. Can be a 1D or 3D array (see Vertex for details), or a Vertex.
     subject : str, optional
         Subject identifier. Must exist in the pycortex database. If not given,
         red must be a Vertex from which the subject can be extracted.
     alpha : ndarray or Vertex, optional
-        Array or Vertex that represents the alpha component of the color for each 
+        Array or Vertex that represents the alpha component of the color for each
         voxel. Can be a 1D or 3D array (see Vertex for details), or a Vertex. If
         None, all vertices will be assumed to have alpha=1.0.
     description : str, optional
@@ -228,12 +416,12 @@ class VertexRGB(DataviewRGB):
     state : optional
         TODO: describe what this is
     **kwargs
-        All additional arguments in kwargs are passed to the VertexData and 
+        All additional arguments in kwargs are passed to the VertexData and
         Dataview.
 
     """
     _cls = VertexData
-    def __init__(self, red, green, blue, subject=None, alpha=None, description="", 
+    def __init__(self, red, green, blue, subject=None, alpha=None, description="",
                  state=None, **kwargs):
 
         if isinstance(red, VertexData):
@@ -251,7 +439,7 @@ class VertexRGB(DataviewRGB):
             self.green = Vertex(green, subject)
             self.blue = Vertex(blue, subject)
 
-        super(VertexRGB, self).__init__(subject, alpha, description=description, 
+        super(VertexRGB, self).__init__(subject, alpha, description=description,
                                         state=state, **kwargs)
 
     @property
@@ -290,7 +478,7 @@ class VertexRGB(DataviewRGB):
 
     def to_json(self, simple=False):
         sdict = super(VertexRGB, self).to_json(simple=simple)
-        
+
         if simple:
             sdict.update(dict(split=self.red.llen, frames=self.vertices.shape[0]))
 

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -13,12 +13,12 @@ class Colors(object):
     """
     Set of known colors
     """
-	RoseRed = (237, 35, 96)
-	LimeGreen = (141, 198, 63)
-	DodgerBlue = (0, 176, 218)
-	Red = (255, 000, 000)
-	Green = (000, 255, 000)
-	Blue = (000, 000, 255)
+    RoseRed = (237, 35, 96)
+    LimeGreen = (141, 198, 63)
+    DodgerBlue = (0, 176, 218)
+    Red = (255, 000, 000)
+    Green = (000, 255, 000)
+    Blue = (000, 000, 255)
 
 
 def RGB2HSV(color):
@@ -183,9 +183,9 @@ class VolumeRGB(DataviewRGB):
                  max_color_value=None, max_color_saturation=1.0, shared_range=False, shared_vmin=None,
                  shared_vmax=None, **kwargs):
 
-		channel1color = tuple(channel1color)
-		channel2color = tuple(channel2color)
-		channel3color = tuple(channel3color)
+        channel1color = tuple(channel1color)
+        channel2color = tuple(channel2color)
+        channel3color = tuple(channel3color)
 
         if isinstance(channel1, VolumeData):
             if not isinstance(channel2, VolumeData) or channel1.subject != channel2.subject:

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -346,9 +346,9 @@ class VolumeRGB(DataviewRGB):
 
         """
         # normalize each channel to [0, 1]
-        data1 = np.nan_to_num(channel1.data if isinstance(channel1, VolumeData) else channel1)
-        data2 = np.nan_to_num(channel2.data if isinstance(channel2, VolumeData) else channel2)
-        data3 = np.nan_to_num(channel3.data if isinstance(channel3, VolumeData) else channel3)
+        data1 = np.nan_to_num(channel1.data if isinstance(channel1, VolumeData) else channel1).astype(np.float)
+        data2 = np.nan_to_num(channel2.data if isinstance(channel2, VolumeData) else channel2).astype(np.float)
+        data3 = np.nan_to_num(channel3.data if isinstance(channel3, VolumeData) else channel3).astype(np.float)
 
         if (data1.shape != data2.shape) or (data2.shape != data3.shape):
             raise ValueError('Volumes are of different shapes')

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -13,12 +13,12 @@ class Colors(object):
     """
     Set of known colors
     """
-    RoseRed =		(237,  35,  96)
-    LimeGreen =		(141, 198,  63)
-    DodgerBlue =	(  0, 176, 218)
-    Red =			(255, 000, 000)
-    Green = 		(000, 255, 000)
-    Blue = 			(000, 000, 255)
+	RoseRed = (237, 35, 96)
+	LimeGreen = (141, 198, 63)
+	DodgerBlue = (0, 176, 218)
+	Red = (255, 000, 000)
+	Green = (000, 255, 000)
+	Blue = (000, 000, 255)
 
 
 def RGB2HSV(color):
@@ -182,11 +182,16 @@ class VolumeRGB(DataviewRGB):
                  state=None, channel1color=Colors.Red, channel2color=Colors.Green, channel3color=Colors.Blue,
                  max_color_value=None, max_color_saturation=1.0, shared_range=False, shared_vmin=None,
                  shared_vmax=None, **kwargs):
+
+		channel1color = tuple(channel1color)
+		channel2color = tuple(channel2color)
+		channel3color = tuple(channel3color)
+
         if isinstance(channel1, VolumeData):
             if not isinstance(channel2, VolumeData) or channel1.subject != channel2.subject:
-                raise TypeError("Invalid data for channel2 channel")
+                raise TypeError("Invalid data for data channel 2")
             if not isinstance(channel3, VolumeData) or channel1.subject != channel3.subject:
-                raise TypeError("Invalid data for channel3 channel")
+                raise TypeError("Invalid data for data channel 3")
             self.red = channel1
             self.green = channel2
             self.blue = channel3

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -306,7 +306,7 @@ class VolumeRGB(DataviewRGB):
             Use the same vmin and vmax for all three color channels?
         common_min : float, optional
             Predetermined shared vmin. Does nothing if shared_range == False. If not given,
-            will be the 1st percentil of all values across all three channels.
+            will be the 1st percentile of all values across all three channels.
         common_max : float, optional
             Predetermined shared vmax. Does nothing if shared_range == False. If not given,
             will be the 99th percentile of all values across all three channels

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -130,7 +130,9 @@ class VolumeRGB(DataviewRGB):
     Each data channel is represented as a separate Volume object (these can
     either be supplied explicitly as Volume objects or implicitly as numpy
     arrays). The vmin for each Volume will be mapped to the minimum value for
-    that color channel, and the vmax will be mapped to the maximum value.
+    that data channel, and the vmax will be mapped to the maximum value.
+    If `shared_range` is True, the vim and vmax will instead computed by
+    combining all three data channels.
 
     Parameters
     ----------

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -32,7 +32,7 @@ def RGB2HSV(color):
     Returns
     -------
     tuple<int, float, float>
-        HSV values. Hue in degres, saturation and value on [0, 1]
+        HSV values. Hue in degrees, saturation and value on [0, 1]
 
     """
     hue, saturation, value = colorsys.rgb_to_hsv(color[0] / 255.0, color[1] / 255.0, color[2] / 255.0)
@@ -47,7 +47,7 @@ def HSV2RGB(color):
     Parameters
     ----------
     color : tuple<int, float, float>
-        HSV values. Hue in degres, saturation and value on [0, 1]
+        HSV values. Hue in degrees, saturation and value on [0, 1]
 
     Returns
     -------
@@ -179,9 +179,9 @@ class VolumeRGB(DataviewRGB):
     _cls = VolumeData
 
     def __init__(self, channel1, channel2, channel3, subject=None, xfmname=None, alpha=None, description="",
-                 state=None, channel1color = Colors.Red, channel2color = Colors.Green, channel3color = Colors.Blue,
-                 max_color_value = None, max_color_saturation = 1.0, shared_range = False, shared_vmin = None,
-                 shared_vmax = None, **kwargs):
+                 state=None, channel1color=Colors.Red, channel2color=Colors.Green, channel3color=Colors.Blue,
+                 max_color_value=None, max_color_saturation=1.0, shared_range=False, shared_vmin=None,
+                 shared_vmax=None, **kwargs):
         if isinstance(channel1, VolumeData):
             if not isinstance(channel2, VolumeData) or channel1.subject != channel2.subject:
                 raise TypeError("Invalid data for channel2 channel")

--- a/cortex/dataset/views.py
+++ b/cortex/dataset/views.py
@@ -379,5 +379,5 @@ def u(s, encoding='utf8'):
         return s
 
 
-from .viewRGB import VolumeRGB, VertexRGB
+from .viewRGB import VolumeRGB, VertexRGB, Colors
 from .view2D import Volume2D, Vertex2D

--- a/cortex/quickflat/view.py
+++ b/cortex/quickflat/view.py
@@ -319,7 +319,7 @@ def make_png(fname, braindata, recache=False, pixelwise=True, sampler='nearest',
     plt.close(fig)
 
 def make_svg(fname, braindata, with_labels=False, with_curvature=True, layers=['rois'],
-             height=1024, overlay_file = None, **kwargs):
+             height=1024, overlay_file=None, **kwargs):
     """Save an svg file of the desired flatmap.
 
     This function creates an SVG file with vector graphic ROIs overlaid on a single png image.

--- a/cortex/quickflat/view.py
+++ b/cortex/quickflat/view.py
@@ -319,7 +319,7 @@ def make_png(fname, braindata, recache=False, pixelwise=True, sampler='nearest',
     plt.close(fig)
 
 def make_svg(fname, braindata, with_labels=False, with_curvature=True, layers=['rois'],
-             height=1024, **kwargs):
+             height=1024, overlay_file = None, **kwargs):
     """Save an svg file of the desired flatmap.
 
     This function creates an SVG file with vector graphic ROIs overlaid on a single png image.
@@ -340,6 +340,8 @@ def make_svg(fname, braindata, with_labels=False, with_curvature=True, layers=['
         List of layer names to show
     height : int
         Height of PNG in pixels
+    overlay_file : str
+    	Custom ROI overlays file to use
 
     """
     fp = io.BytesIO()
@@ -371,7 +373,7 @@ def make_svg(fname, braindata, with_labels=False, with_curvature=True, layers=['
         image_data = [binascii.b2a_base64(fpc.read()), pngdata]
 
     ## Create and save SVG file
-    roipack = utils.get_roipack(braindata.subject)
+    roipack = utils.db.get_overlay(braindata.subject, overlay_file)
     roipack.get_svg(fname, layers=layers, labels=with_labels, with_ims=image_data)
 
 

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -1069,9 +1069,9 @@ def rotate_flatmap(surf_id, theta, plot=False):
         formats.write_gii(this_file, pts_new, polys)
         print('Overwriting %s...' % this_file)
         if plot:
-            axs[0,j].plot(*pts[::100, :2].T, marker='.', color='r')
+            axs[0,j].plot(*pts[::100, :2].T, marker = 'r.')
             axs[0,j].axis('equal')
-            axs[1,j].plot(*pts_new[::100, :2].T, marker='.', color='b')
+            axs[1,j].plot(*pts_new[::100, :2].T, marker =  'b.')
             axs[1,j].axis('equal')
     # Remove and back up overlays file
     overlay_file = db.get_paths(surf_id)['overlays']

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -1069,9 +1069,9 @@ def rotate_flatmap(surf_id, theta, plot=False):
         formats.write_gii(this_file, pts_new, polys)
         print('Overwriting %s...' % this_file)
         if plot:
-            axs[0,j].plot(*pts[::100, :2].T, marker = 'r.')
+            axs[0,j].plot(*pts[::100, :2].T, marker='r.')
             axs[0,j].axis('equal')
-            axs[1,j].plot(*pts_new[::100, :2].T, marker =  'b.')
+            axs[1,j].plot(*pts_new[::100, :2].T, marker='b.')
             axs[1,j].axis('equal')
     # Remove and back up overlays file
     overlay_file = db.get_paths(surf_id)['overlays']

--- a/examples/datasets/plot_volumeRGB.py
+++ b/examples/datasets/plot_volumeRGB.py
@@ -9,10 +9,26 @@ this subject in the pycortex filestore.
 
 The cortex.VolumeRGB object is instantiated with three cortex.Volume objects,
 one for each of the three color channels. Ideally, the data in the Volume
-objects will be scaled to be between 0-255 and be np.uint8 type.
+objects will be scaled to be between 0-255 and be np.uint8 type. The objects
+can also be 1D numpy arrays of equal sizes, in which case the subject and
+transform will need to be given as arguments.
 
 Here, two datasets are generated to look like gradients across the brain and
 a third dataset makes a series of stripes across the brain.
+
+By default, VolumeRGB maps each data channels on to the red, green, and blue
+channels in RGB color space. You can also specify custom colors for each data
+channel, and the colors will be linearly combined. Custom colors can be specified
+by the `channel1color`, `channel2color`, and `channel2color` arguments, using
+3-ples of uint8 to specify RGB colors for each data channel. `cortex.Colors` provides
+a set of named colors that can be used.
+
+Also by default, each data channel is normalized separately on to its respective
+color. Doing so is not necessarily good for quantitative comparisons in cases in
+which the range of values in each data channel differs. The argument `shared_range`,
+if set to `True`, will force all three data channels to be on the same scale for
+equitable comparisons. When `shared_range` is true, the arguments `shared_vmin` and
+shared_vmax` will allow you to specify minimum and maximum values manually.
 """
 
 import cortex
@@ -42,9 +58,32 @@ green = cortex.Volume(test2_scaled.astype(np.uint8), 'S1', 'fullhead')
 blue = cortex.Volume(test3_scaled.astype(np.uint8), 'S1', 'fullhead')
 
 # This creates an RGB Volume from the three different color channels for
-# this subject
+# this subject using the default RGB mappings
 # Note that you do not need to specify the transform when creating this as it
 # is already specified in the red, green, and blue channels
 vol_data = cortex.VolumeRGB(red, green, blue, subject)
+cortex.quickshow(vol_data, with_colorbar=False)
+plt.show()
+
+# This creates an RGB Volume from the three different color channels for
+# this subject using custom colors.
+# Note that you do not need to specify the transform when creating this as it
+# is already specified in the red, green, and blue channels
+vol_data = cortex.VolumeRGB(red, green, blue, subject,
+							channel1color=cortex.Colors.RoseRed,
+							channel2color=cortex.Colors.LimeGreen,
+							channel3color=cortex.Colors.DodgerBlue)
+cortex.quickshow(vol_data, with_colorbar=False)
+plt.show()
+
+# This creates an RGB Volume from the three different color channels for
+# this subject using custom colors, and shared value ranges.
+# Note that you do not need to specify the transform when creating this as it
+# is already specified in the red, green, and blue channels
+vol_data = cortex.VolumeRGB(red, green, blue, subject,
+							channel1color=cortex.Colors.RoseRed,
+							channel2color=cortex.Colors.LimeGreen,
+							channel3color=cortex.Colors.DodgerBlue,
+							shared_range=True, shared_vmin=10, shared_vmax=100)
 cortex.quickshow(vol_data, with_colorbar=False)
 plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ nibabel
 networkx==2.1
 imageio
 wget
-colorsys

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ nibabel
 networkx==2.1
 imageio
 wget
+colorsys


### PR DESCRIPTION
Added things to `VolumeRGB` to allow data channels to be mapped to custom base colors instead of just red, green, and blue. Also added an option to have all three data channels to use the same `vmin` and `vmax`. Backwards compatible as the default behavior is to bypass all the new features and map data channels directly to RGB.

Also added a `Colors` class to keep track of colors to use.

Specify custom colors:
`volume = cortex.VolumeRGB(visual, progression, integration, subject, transform, channel1color = cortex.Colors.RoseRed, channel2color = cortex.Colors.LimeGreen, channel3color = 
 cortex.Colors.DodgerBlue)`

Force shared ranges:
`volume = cortex.VolumeRGB(visual, progression, integration, subject, transform, shared_range = True)`

Also have a minor thing to specify an overlays file in `quickflat.make_svg`