### PR TITLE
Add pyproject.toml for modern pip installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# Minimum requirements for the build system to execute, according to PEP518
+# specification.
+requires = ["numpy", "cython", "setuptools"]


### PR DESCRIPTION
This additionl made it possible to install the software with pip. It's a change that is compliant with https://www.python.org/dev/peps/pep-0518/ as I understand it. This PR is created thanks to the experience of @arokem that demonstrated this to resolve issues for other packages with similar build dependencies.

Previously, users of the software might have encountered situations like that described here: pypa/pip#5761. This fix should resolve that with modern versions of pip.