### PR TITLE
ENH Use freesurfer BBR by default for automatic alignment with mri_coreg

### DIFF
--- a/cortex/align.py
+++ b/cortex/align.py
@@ -3,6 +3,7 @@
 import os
 import numpy as np
 from builtins import input
+import warnings
 
 def manual(subject, xfmname, reference=None, **kwargs):
     """Open GUI for manually aligning a functional volume to the cortical surface for `subject`. This
@@ -256,6 +257,9 @@ def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed",
     -------
     Nothing unless `noclean` is True.
     """
+    warnings.warn("Defaults changed in pycortex 1.3. Now automatic alignment "
+                  "uses Freesurfer's bbregister and mri_coreg for "
+                  "initialization.")
     import shlex
     import shutil
     import tempfile

--- a/cortex/align.py
+++ b/cortex/align.py
@@ -215,7 +215,8 @@ def fs_manual(subject, xfmname, output_name="register.lta", wm_color="yellow",
     return retval
 
 
-def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed", pre_flirt_args='', use_fs_bbr=False, epi_mask=False):
+def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed",
+              pre_flirt_args='', use_fs_bbr=True, epi_mask=False):
     """Create an automatic alignment using the FLIRT boundary-based alignment (BBR) from FSL.
 
     If `noclean`, intermediate files will not be removed from /tmp. The `reference` image and resulting
@@ -245,7 +246,7 @@ def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed", pre_
     pre_flirt_args : str, optional
         Additional arguments that are passed to the FLIRT pre-alignment step (not BBR).
     use_fs_bbr : bool, optional
-        If True will use freesurfer bbregister instead of FSL BBR.
+        If True will use freesurfer bbregister instead of FSL BBR. (default, True)
     epi_mask : bool, optional
         If True, and use_fs_bbr is True, then the flag --epi-mask is passed to bbregister
         to mask out areas with spatial distortions. This setting is to be used whenever
@@ -274,7 +275,7 @@ def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed", pre_
 
         if use_fs_bbr:
             print('Running freesurfer BBR')
-            cmd = 'bbregister --s {sub} --mov {absref} --init-fsl --reg {cache}/register.dat --t2'
+            cmd = 'bbregister --s {sub} --mov {absref} --init-coreg --reg {cache}/register.dat --t2'
             if epi_mask:
                 cmd += ' --epi-mask'
             cmd = cmd.format(sub=subject, absref=absreference, cache=cache)


### PR DESCRIPTION
Freesurfer's BBR registration works much better, so let's switch to that default. Also, initializing with `mri_coreg` is more robust than using FSL.