### PR TITLE
FIX pycortex install with numpy < 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,12 @@ before_install:
   - travis_retry sudo apt-get install -y inkscape
 
 install:
+  - pip install numpy cython
   - pip install -e . --no-build-isolation
   - python -c 'import cortex; print(cortex.__full_version__)'
 
 script:
-  # install necessary packages to run tests and run tests
+  # install necessary packages to run tests and get coverage
   - travis_retry pip install -q -U pytest pytest-cov codecov
   - pytest --cov=./
   # test installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - travis_retry sudo apt-get install -y inkscape
 
 install:
-  - pip install -e .
+  - pip install -e . --no-build-isolation
   - python -c 'import cortex; print(cortex.__full_version__)'
 
 script:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To do so, replace the second install line above with the following:
 
 ```bash
 # Install development version of pycortex from github
-pip install -U git+git://github.com/gallantlab/pycortex.git
+pip install -U git+git://github.com/gallantlab/pycortex.git  --no-build-isolation
 ```
 
 Documentation

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(name=DISTNAME,
                 'resources/images/*'
             ]
             },
+      setup_requires=['Cython', 'numpy'],
       install_requires=INSTALL_REQUIRES,
       cmdclass=dict(install=my_install),
       include_package_data=True,


### PR DESCRIPTION
Travis is failing (e.g. in #384) on python 3.7+ due to a backward incompatibility in numpy ABI in version 1.20 ([see explaination](https://github.com/scikit-learn-contrib/hdbscan/issues/457)), and because pip is mixing the versions during the install.
This should fix the failure.
