### PR TITLE
TST clean up and fix `test_dataset.py::test_pack`

### DIFF
--- a/cortex/dataset/dataset.py
+++ b/cortex/dataset/dataset.py
@@ -208,7 +208,7 @@ def normalize(data):
 
 def _pack_subjs(h5, subjects):
     for subject in subjects:
-        rois = db.get_overlay(subject, allow_change=False)
+        rois = db.get_overlay(subject, modify_svg_file=False)
         rnode = h5.require_dataset("/subjects/%s/rois"%subject, (1,),
                                    dtype=h5py.special_dtype(vlen=str))
         rnode[0] = rois.toxml(pretty=False)

--- a/cortex/dataset/dataset.py
+++ b/cortex/dataset/dataset.py
@@ -208,7 +208,7 @@ def normalize(data):
 
 def _pack_subjs(h5, subjects):
     for subject in subjects:
-        rois = db.get_overlay(subject)
+        rois = db.get_overlay(subject, allow_change=False)
         rnode = h5.require_dataset("/subjects/%s/rois"%subject, (1,),
                                    dtype=h5py.special_dtype(vlen=str))
         rnode[0] = rois.toxml(pretty=False)

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -645,9 +645,43 @@ def make_svg(pts, polys):
     return svg
 
 def get_overlay(subject, svgfile, pts, polys, remove_medial=False, 
-                overlays_available=None, allow_change=True, **kwargs):
-    """Return a python represent of the overlays present in `svgfile`
+                overlays_available=None, modify_svg_file=True, **kwargs):
+    """Return a python represent of the overlays present in `svgfile`.
 
+    Parameters
+    ----------
+    subject: str
+        Name of the subject.
+    svgfile: str
+        File name with the overlays (.svg).
+    pts: array of shape (n_vertices, 3)
+        Coordinates of all vertices, as returned by for example by
+        cortex.db.get_surf.
+    polys: arrays of shape (n_polys, 3)
+        Indices of the vertices of all polygons, as returned for example by
+        cortex.db.get_surf.
+    remove_medial: bool
+        Whether to remove duplicate vertices. If True, the function also
+        returns an array with the unique vertices.
+    overlays_available: tuple or None
+        Overlays to keep in the result. If None, then all overlay layers of
+        the SVG file will be available in the result. If None, also add 3 empty
+        layers named 'sulci', 'cutouts', and 'display' (if not already
+        present).
+    modify_svg_file: bool
+        Whether to modify the SVG file when overlays_available=None, which can
+        add layers 'sulci', 'cutouts', and 'display' (if not already present).
+        If False, the SVG file will not be modified.
+    **kwargs
+        Other keyword parameters are given to the SVGOverlay constructor.
+    
+    Returns
+    -------
+    svg : SVGOverlay instance.
+        Object with the overlays.
+    valid : array of shape (n_vertices, )
+        Indices of all vertices (without duplicates).
+        Only returned if remove_medial is True.
     """
     cullpts = pts[:,:2]
     if remove_medial:
@@ -688,7 +722,7 @@ def get_overlay(subject, svgfile, pts, polys, remove_medial=False,
             svg.rois.add_shape(layer_name, binascii.b2a_base64(fp.read()).decode('utf-8'), False)
 
     else:
-        if not allow_change:
+        if not modify_svg_file:
             # To avoid modifying the svg file, we copy it in a temporary file
             import shutil
             svg_tmp = tempfile.NamedTemporaryFile(suffix=".svg")

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -380,7 +380,11 @@ class Labels(object):
 
         # match up existing labels with their respective paths
         def close(pt, x, y):
-            return np.sqrt((pt[0] - x)**2 + (pt[1]-y)**2) < 250
+            try:
+                xx, yy = pt[0], pt[1]
+            except IndexError:  # when loading overlay from a dataset pack
+                xx, yy = float(pt.get('x')), float(pt.get('y'))
+            return np.sqrt((xx - x)**2 + (yy-y)**2) < 250
         for text in self.layer.findall(".//{%s}text"%svgns):
             x = float(text.get('x'))
             y = float(text.get('y'))
@@ -655,6 +659,7 @@ def get_overlay(subject, svgfile, pts, polys, remove_medial=False,
         # I think this should be an entirely separate function, and it should
         # be made clear when this file is created - opening a git issue on 
         # this soon...ML
+        print("Create new file: %s" % (svgfile, ))
         with open(svgfile, "wb") as fp:
             fp.write(make_svg(pts.copy(), polys).encode())
 

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -645,7 +645,7 @@ def make_svg(pts, polys):
     return svg
 
 def get_overlay(subject, svgfile, pts, polys, remove_medial=False, 
-                overlays_available=None, **kwargs):
+                overlays_available=None, allow_change=True, **kwargs):
     """Return a python represent of the overlays present in `svgfile`
 
     """
@@ -688,17 +688,24 @@ def get_overlay(subject, svgfile, pts, polys, remove_medial=False,
             svg.rois.add_shape(layer_name, binascii.b2a_base64(fp.read()).decode('utf-8'), False)
 
     else:
+        if not allow_change:
+            # To avoid modifying the svg file, we copy it in a temporary file
+            import shutil
+            svg_tmp = tempfile.NamedTemporaryFile(suffix=".svg")
+            svgfile_tmp = svg_tmp.name
+            shutil.copy2(svgfile, svgfile_tmp)
+            svgfile = svgfile_tmp
+
         svg = SVGOverlay(svgfile, 
                          coords=cullpts, 
                          overlays_available=overlays_available,
                          **kwargs)
     
-    
     if overlays_available is None:
         # Assure all layers are present
         # (only if some set of overlays is not specified)
-        # NOTE: this actually modifies the svg file. Do we
-        # want this in all cases? (e.g. w/ external svgs?)
+        # NOTE: this actually modifies the svg file.
+        # Use allow_change=False to avoid modifying the svg file.
         for layer in ['sulci', 'cutouts', 'display']:
             if layer not in svg.layers:
                 svg.add_layer(layer)

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -128,11 +128,12 @@ def test_pack():
     dpts, dpolys = ds.get_surf(subj, "fiducial", "lh")
     assert np.allclose(pts, dpts)
 
-    overlay_db = cortex.db.get_overlay(subj, None)
+    overlay_db = cortex.db.get_overlay(subj, None, allow_change=False)
     rois_db = overlay_db.rois.labels.elements.keys()
     # keep the temporary file object in memory to avoid the file being deleted
     temp_file = ds.get_overlay(subj, "rois")
-    overlay_ds = cortex.db.get_overlay(subj, temp_file.name)
+    overlay_ds = cortex.db.get_overlay(subj, temp_file.name,
+                                       allow_change=False)
     rois_ds = overlay_ds.rois.labels.elements.keys()
     assert rois_db == rois_ds
 

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -128,12 +128,12 @@ def test_pack():
     dpts, dpolys = ds.get_surf(subj, "fiducial", "lh")
     assert np.allclose(pts, dpts)
 
-    overlay_db = cortex.db.get_overlay(subj, None, allow_change=False)
+    overlay_db = cortex.db.get_overlay(subj, None, modify_svg_file=False)
     rois_db = overlay_db.rois.labels.elements.keys()
     # keep the temporary file object in memory to avoid the file being deleted
     temp_file = ds.get_overlay(subj, "rois")
     overlay_ds = cortex.db.get_overlay(subj, temp_file.name,
-                                       allow_change=False)
+                                       modify_svg_file=False)
     rois_ds = overlay_ds.rois.labels.elements.keys()
     assert rois_db == rois_ds
 

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -128,9 +128,13 @@ def test_pack():
     dpts, dpolys = ds.get_surf(subj, "fiducial", "lh")
     assert np.allclose(pts, dpts)
 
-    rois = cortex.db.get_overlay(subj, "rois")
-    # Dataset.get_overlay returns a file handle, not an ROIpack ?
-    #assert rois.rois.keys() == ds.get_overlay(subj, "rois").rois.keys()
+    overlay_db = cortex.db.get_overlay(subj, None)
+    rois_db = overlay_db.rois.labels.elements.keys()
+    # keep the temporary file object in memory to avoid the file being deleted
+    temp_file = ds.get_overlay(subj, "rois")
+    overlay_ds = cortex.db.get_overlay(subj, temp_file.name)
+    rois_ds = overlay_ds.rois.labels.elements.keys()
+    assert rois_db == rois_ds
 
     xfm = cortex.db.get_xfm(subj, xfmname)
     assert np.allclose(xfm.xfm, ds.get_xfm(subj, xfmname).xfm)


### PR DESCRIPTION
Running the tests always creates/modifies some files, that one has to delete/revert before doing a git commit. This is a bit annoying. This PR avoid creating a useless `rois` file, and avoid modifying `filestore/db/S1/overlays.svg`.

On the way, this PR also:
- fixes `test_pack` which was partly commented out because it was broken.
- add an option to preserve svg files when loading them with `cortex.db.get_overlay`