### PR TITLE
FIX add more informative error in get_texture if inkscape is not installed

### DIFF
--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -223,6 +223,15 @@ class SVGOverlay(object):
         missing bits=32 keyword input argument, did not seeme necessary to specify
         png bits.
         """
+        # Give a more informative error in case we don't have inkscape
+        # installed
+        if INKSCAPE_VERSION is None:
+            raise RuntimeError(
+                "Inkscape doesn't seem to be installed on this system."
+                "SVGOverlay.get_texture requires inkscape."
+                "Please make sure that inkscape is installed and that is "
+                "accessible from the terminal.")
+
         import matplotlib.pyplot as plt
         # Set the size of the texture
         if background is not None:


### PR DESCRIPTION
See #390.

There is another place where `INKSCAPE_VERSION` is used (`cortex.utils.add_roi`), but that requires the user to pass an `open_inkscape` kwarg, so I think we can skip the check there.