### PR TITLE
DEP Use encodebytes instead of encodestring.

### DIFF
--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -32,10 +32,7 @@ hostname = socket.gethostname()
 def make_base64(imgfile):
     with open(imgfile, 'rb') as img:
         mtype = mimetypes.guess_type(imgfile)[0]
-        if sys.version_info[0] < 3:
-            imbytes = base64.encodestring(img.read())
-        else:
-            imbytes = base64.encodebytes(img.read())
+        imbytes = base64.encodebytes(img.read())
         data = imbytes.decode('utf-8').strip()
         return u"data:{mtype};base64,{data}".format(mtype=mtype, data=data)
 

--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -3,7 +3,6 @@ import re
 import time
 import json
 import stat
-import sys
 import email
 try:  # python 2
     from Queue import Queue

--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -3,6 +3,7 @@ import re
 import time
 import json
 import stat
+import sys
 import email
 try:  # python 2
     from Queue import Queue
@@ -31,7 +32,10 @@ hostname = socket.gethostname()
 def make_base64(imgfile):
     with open(imgfile, 'rb') as img:
         mtype = mimetypes.guess_type(imgfile)[0]
-        imbytes = base64.encodestring(img.read())
+        if sys.version_info[0] < 3:
+            imbytes = base64.encodestring(img.read())
+        else:
+            imbytes = base64.encodebytes(img.read())
         data = imbytes.decode('utf-8').strip()
         return u"data:{mtype};base64,{data}".format(mtype=mtype, data=data)
 


### PR DESCRIPTION
Use base64.encodestring if python version < 3.0, otherwise use
base.encodebytes.

base64.encodestring is deprecated (unavailable in python3.9), and
base64.encodebytes is unavailable in python2.
https://docs.python.org/3.1/library/base64.html#base64.encodebytes