### PR TITLE
FIX set default imshow interpolation to nearest for `composite.add_data`

### DIFF
--- a/cortex/quickflat/composite.py
+++ b/cortex/quickflat/composite.py
@@ -170,6 +170,7 @@ def add_data(fig, braindata, height=1024, thick=32, depth=0.5, pixelwise=True,
                     extent=extents,
                     label='data',
                     zorder=1,
+                    interpolation="nearest",
                     **cmapdict)
     return img, extents
 


### PR DESCRIPTION
The default image interpolation in matplotlib is now `antialiased`. This can cause issues when plotting data containing NaNs with `cortex.quickflat.make_figure`. For example, when setting different dpi levels, the images can look wildly different. To fix this issue, this PR sets the default interpolation of the `imshow` in `composite.add_data` to `nearest`. (Thanks to @alexhuth for help debugging this issue!)

The following code demonstrates how `antialiased` interpolation can cause issues:

```python
import cortex
import numpy as np
import matplotlib.pyplot as plt

vol = cortex.Volume.empty('S1', 'fullhead', vmin=0, vmax=2) + 1
vol.data[np.random.rand(*vol.data.shape) > 0.6] = np.nan

img = cortex.quickflat.make_flatmap_image(vol, thick=1, nanmean=False, height=800)

fig, ax = plt.subplots(1, 1)
ax.imshow(img[0])
fig.savefig("test-dpi-100-make_flatmap_image.png", dpi=100)
fig.savefig("test-dpi-300-make_flatmap_image.png", dpi=300)
```
![test-dpi-100-make_flatmap_image](https://user-images.githubusercontent.com/6150554/138489529-14467475-6b0a-4b15-ba63-74df5f13679a.png)
![test-dpi-300-make_flatmap_image](https://user-images.githubusercontent.com/6150554/138489539-5b16fe4b-e236-4703-a0e6-c132907520ac.png)

Setting `interpolation='nearest'` fixes the problem:

```python
import cortex
import numpy as np
import matplotlib.pyplot as plt

vol = cortex.Volume.empty('S1', 'fullhead', vmin=0, vmax=2) + 1
vol.data[np.random.rand(*vol.data.shape) > 0.6] = np.nan

img = cortex.quickflat.make_flatmap_image(vol, thick=1, nanmean=False, height=800)

fig, ax = plt.subplots(1, 1)
ax.imshow(img[0], interpolation="nearest")
fig.savefig("test-dpi-100-make_flatmap_image.png", dpi=100)
fig.savefig("test-dpi-300-make_flatmap_image.png", dpi=300)
```

![test-dpi-300-make_flatmap_image-nearest](https://user-images.githubusercontent.com/6150554/138489626-77ae5b39-5cc5-49ef-8e7f-ed3a29770a36.png)
![test-dpi-100-make_flatmap_image-nearest](https://user-images.githubusercontent.com/6150554/138489632-d23f90fc-2d70-400a-9c04-797ad330d138.png)


