### PR TITLE
ENH: Long-overdue update to Blender 2.8+

### DIFF
--- a/cortex/blender/__init__.py
+++ b/cortex/blender/__init__.py
@@ -1,6 +1,8 @@
 import os
+import re
 import six
 import shlex
+import shutil
 import xdrlib
 import tempfile
 import subprocess as sp
@@ -35,12 +37,53 @@ def _call_blender(filename, code, blender_path=default_blender):
         if not os.path.exists(filename):
             startcode += "blendlib.clear_all()\n"
             cmd = "{blender_path} -b -P {tfname}".format(blender_path=blender_path, tfname=tf.name)
-
+        else:
+            _legacy_blender_backup(filename, blender_path=blender_path)
         tf.write((startcode+code+endcode).encode())
         tf.flush()
         sp.check_call([w.encode() for w in shlex.split(cmd)],)
 
-def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh="hemi"):
+
+def _get_blender_version(blender_path=default_blender):
+    """Get blender version number"""
+    blender_version = sp.check_output([blender_path, '--version']).decode()
+    blender_version = blender_version.split('\n')[0]
+    print("Detected %s"%blender_version)
+    blender_version_number = re.findall('(?<=Blender\s)[0-9]*[,.][0-9]*', blender_version)[0]
+    blender_version_number = tuple([int(x) for x in blender_version_number.split('.')])
+    # For ver 2.79.x, minor version is not always returned, so standardize:
+    blender_major_version_number = blender_version_number[:2]
+    return blender_major_version_number
+
+
+def _legacy_blender_backup(fname, blender_path=default_blender):
+    """Create a copy of a .blend file, because if a blender 2.7x file is 
+    opened with blender 2.8+, it usually can't be opened with 2.7x again.
+    
+    Yes this seems quite bad."""
+    if _get_blender_version(blender_path=blender_path) >= (2, 80):
+        fname_bkup, _ = os.path.splitext(fname)
+        fname_bkup += '_b2.7bkup.blend'
+        if os.path.exists(fname_bkup):
+            # backup already created
+            print("Found extant blender 2.7x backup file, leaving it alone...")
+        else:
+            msg = ["==============================================",
+                   "",
+                   "NOTE! If a file is saved with blender 2.8+,",
+                   "it cannot be opened with blender 2.7. Thus, we",
+                   "are saving a backup file for you just in case:",
+                   f"{fname_bkup}",
+                   "If you plan to keep using blender 2.8+, you can",
+                   "ignore this message (and the backup file), and",
+                   "sorry for cluttering up your file system.",
+                   "==============================================",
+                   ]
+            print('\n'.join(msg))
+            shutil.copy(fname, fname_bkup)
+
+
+def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh="hemi", blender_path=default_blender):
     """Add data as vertex colors to blender mesh
     
     Useful to add localizer data for help in placing flatmap cuts
@@ -64,7 +107,6 @@ def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh=
         for view_name, data in braindata.views.items():
             add_cutdata(fname, data, name=view_name, projection=projection, mesh=mesh)
         return
-    from matplotlib import cm
     braindata = dataset.normalize(braindata)
     if not isinstance(braindata, dataset.braindata.VertexData):
         mapped = braindata.map(projection)
@@ -102,12 +144,12 @@ def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh=
             print(len(lcolor), len(rcolor))
             blendlib.add_vcolor((lcolor, rcolor), mesh, name)
         """.format(tfname=tf.name)
-        _call_blender(fname, code)
+        _call_blender(fname, code, blender_path=blender_path)
 
     return 
 
 
-def gii_cut(fname, subject, hemi):
+def gii_cut(fname, subject, hemi, blender_path=default_blender):
     '''
     Add gifti surface to blender
     '''
@@ -136,10 +178,10 @@ def gii_cut(fname, subject, hemi):
             curv = u.unpack_array(u.unpack_double)
             blendlib.init_subject(wpts, ipts, polys, curv)
         """.format(tfname=tf.name)
-        _call_blender(fname, code)
+        _call_blender(fname, code, blender_path=blender_path)
 
 
-def fs_cut(fname, subject, hemi, freesurfer_subject_dir=None):
+def fs_cut(fname, subject, hemi, freesurfer_subject_dir=None, blender_path=default_blender):
     """Cut freesurfer surface using blender interface
 
     Parameters
@@ -168,9 +210,9 @@ def fs_cut(fname, subject, hemi, freesurfer_subject_dir=None):
             curv = u.unpack_array(u.unpack_double)
             blendlib.init_subject(wpts, ipts, polys, curv)
         """.format(tfname=tf.name)
-        _call_blender(fname, code)
+        _call_blender(fname, code, blender_path=blender_path)
 
-def write_patch(bname, pname, mesh="hemi"):
+def write_patch(bname, pname, mesh="hemi", blender_path=default_blender):
     """Write out the mesh 'mesh' in the blender file 'bname' into patch file 'pname'
     This is a necessary step for flattening the surface in freesurfer
 
@@ -195,5 +237,5 @@ def write_patch(bname, pname, mesh="hemi"):
             mesh = u.unpack_string().decode('utf-8')
             blendlib.save_patch(pname, mesh)
         """.format(tfname=tf.name)
-        _call_blender(bname, code)
+        _call_blender(bname, code, blender_path=blender_path)
 

--- a/cortex/blender/blendlib.py
+++ b/cortex/blender/blendlib.py
@@ -22,7 +22,7 @@ def clear_all():
     bpy.ops.object.delete()
 
 def init_subject(wpts, ipts, polys, curv):
-    """Initialize a suject """
+    """Initialize a subject """
     print('Started init_subject in blender!')
     obj, mesh = make_object(_repack(wpts), _repack(polys), name='hemi')
     obj.scale = .1, .1, .1

--- a/cortex/segment.py
+++ b/cortex/segment.py
@@ -125,7 +125,7 @@ def edit_segmentation(subject,
 
 def cut_surface(cx_subject, hemi, name='flatten', fs_subject=None, data=None,
                 freesurfer_subject_dir=None, flatten_with='freesurfer', 
-                do_import_subject=True, **kwargs):
+                do_import_subject=True, blender_cmd=None, **kwargs):
     """Initializes an interface to cut the segmented surface for flatmapping.
     This function creates or opens a blend file in your filestore which allows
     surfaces to be cut along hand-defined seams. Blender will automatically
@@ -183,12 +183,15 @@ def cut_surface(cx_subject, hemi, name='flatten', fs_subject=None, data=None,
     # Add localizer data to facilitate cutting
     if data is not None:
         blender.add_cutdata(fname, data, name=data.description)
-    blender_cmd = options.config.get('dependency_paths', 'blender')
+    if blender_cmd is None:
+        blender_cmd = options.config.get('dependency_paths', 'blender')
+    # May be redundant after blender.fs_cut above...
+    blender._legacy_blender_backup(fname, blender_path=blender_cmd)
     sp.call([blender_cmd, fname])
     patchpath = freesurfer.get_paths(fs_subject, hemi,
                                      freesurfer_subject_dir=freesurfer_subject_dir)
     patchpath = patchpath.format(name=name)
-    blender.write_patch(fname, patchpath)
+    blender.write_patch(fname, patchpath, blender_path=blender_cmd)
     if flatten_with == 'freesurfer':
         done = freesurfer.flatten(fs_subject, hemi, patch=name,
                            freesurfer_subject_dir=freesurfer_subject_dir,


### PR DESCRIPTION
approximately working, needs further testing. 

One big annoyance with blender 2.8 is that if you open a .blend file with blender 2.8+, you will no longer be able to open it with blender 2.7. Nuking backward compatibility seems bad, so what I have tried to do here is implement an automatic (and likely annoying) backup:  every time you try to call a command that opens blender on an extant file, it creates a backup (<file>_b2.7bkup.blend). This happens once for the file (presumably, the first time it is called with the updated code if the blender version is >= 2.8). 

Putting a flag around these backups is potentially a good idea - something settable in the config file? e.g. make_legacy_backups=True, then once people decide they don't want a million _b2.7bkup files running around, and that they are committed to more recent blender, they can shut it off and delete those files? 

This element is still a bit kludge-y, but it's aiming to prevent pain and suffering. Happy to take suggestions on how to better handle this. The compatibility with blender 2.8+ wasn't actually bad at all, just a few lines. 