### PR TITLE
ENH: added config file specfication of domain name; blank by default

### DIFF
--- a/cortex/defaults.cfg
+++ b/cortex/defaults.cfg
@@ -139,6 +139,7 @@ webgl_smooth = 0.0
 
 [webgl]
 layers = rois,
+# When creating webgl viewers, this domain name will be appended to your computer name. Default is blank (no extra domain name)
 domain_name = 
 [webshow]
 autoclose = true

--- a/cortex/defaults.cfg
+++ b/cortex/defaults.cfg
@@ -139,7 +139,7 @@ webgl_smooth = 0.0
 
 [webgl]
 layers = rois,
-
+domain_name = 
 [webshow]
 autoclose = true
 open_browser = true

--- a/cortex/webgl/view.py
+++ b/cortex/webgl/view.py
@@ -36,6 +36,7 @@ except NoOptionError:
     if not os.path.exists(cmapdir):
         raise Exception("Colormap directory was not defined in the config file and the default (%s) does not exits"%cmapdir)
 
+domain_name = options.config.get("webgl", "domain_name")
 
 colormaps = glob.glob(os.path.join(cmapdir, "*.png"))
 colormaps = [(os.path.splitext(os.path.split(cm)[1])[0], serve.make_base64(cm))
@@ -817,7 +818,7 @@ def show(data, types=("inflated", ), recache=False, cmap='RdBu_r', layout=None,
 
     server.start()
     print("Started server on port %d"%server.port)
-    url = "http://%s:%d/mixer.html"%(serve.hostname, server.port)
+    url = "http://%s%s:%d/mixer.html"%(serve.hostname, domain_name, server.port)
     if open_browser:
         webbrowser.open(url)
         client = server.get_client()


### PR DESCRIPTION
This PR makes it easier for me to view webgl viewers on my lab machines, which have extra domain info (blah.unr.edu) which isn't present by default in the webgl server address that pops up in pycortex. The upshot of this is that without this PR I need to change the address that pops up in order to see the webgl viewer, every time. This is annoying. Should be no change for anyone else, fully backward compatible. There may be a way to do this with `socket` or some other means, but `socket.getfqdn()` did not work for me, and my googling wasn't able to turn up anything else. 