### PR TITLE
FIX add downloaded subjects to the cortex database

### DIFF
--- a/cortex/database.py
+++ b/cortex/database.py
@@ -180,6 +180,11 @@ class Database(object):
         self._subjects = dict([(sname, SubjectDB(sname, filestore=self.filestore)) for sname in subjs])
         return self._subjects
 
+    def reload_subjects(self):
+        """Force the reload of the subject dictionary."""
+        self._subjects = None
+        self.subjects
+
     def get_anat(self, subject, type='raw', xfmname=None, recache=False, order=1, **kwargs):
         """Return anatomical information from the filestore. Anatomical information is defined as
         any volume-space anatomical information pertaining to the subject, such as T1 image,

--- a/cortex/tests/test_utils.py
+++ b/cortex/tests/test_utils.py
@@ -1,0 +1,12 @@
+import cortex
+
+def test_download_subject():
+    # Test that newly downloaded subjects are added to the current database.
+
+    # remove fsaverage from the list of available subjects if present.
+    if "fsaverage" in cortex.db.subjects:
+        cortex.db._subjects.pop("fsaverage")
+
+    assert "fsaverage" not in cortex.db.subjects
+    cortex.utils.download_subject(subject_id='fsaverage')
+    assert "fsaverage" in cortex.db.subjects

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -1005,7 +1005,7 @@ def download_subject(subject_id='fsaverage', url=None, pycortex_store=None,
         to add more in the future. If provided, URL overrides `subject_id`
     pycortex_store : string or None
         Directory to which to put the new subject folder. If None, defaults to
-        the `filestore` variable specified in the pycortex config file.
+        current filestore in use (`cortex.db.filestore`).
     download_again : bool
         Download the data again even if the subject id is already present in
         the pycortex's database.
@@ -1030,12 +1030,15 @@ def download_subject(subject_id='fsaverage', url=None, pycortex_store=None,
     print('Downloaded subject {} to {}'.format(subject_id, tmp_dir))
     # Un-tar to pycortex store
     if pycortex_store is None:
-        # Default location is config file pycortex store.
-        pycortex_store = config.get('basic', 'filestore')
+        # Default location is current filestore in cortex.db
+        pycortex_store = db.filestore
     pycortex_store = os.path.expanduser(pycortex_store)
     with tarfile.open(os.path.join(tmp_dir, subject_id + '.tar.gz'), "r:gz") as tar:
         print("Extracting subject {} to {}".format(subject_id, pycortex_store))
         tar.extractall(path=pycortex_store)
+
+    # force filestore reload
+    db._subjects = None  
 
 
 def rotate_flatmap(surf_id, theta, plot=False):

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -1037,8 +1037,8 @@ def download_subject(subject_id='fsaverage', url=None, pycortex_store=None,
         print("Extracting subject {} to {}".format(subject_id, pycortex_store))
         tar.extractall(path=pycortex_store)
 
-    # force filestore reload
-    db._subjects = None  
+    # reload all subjects from the filestore
+    db.reload_subjects()
 
 
 def rotate_flatmap(surf_id, theta, plot=False):


### PR DESCRIPTION
The function `cortex.utils.download_subject` does not update the database (`cortex.db`) with the newly added subject, because the cached dictionary is not updated `cortex.db._subjects`. This PR reset the cached dictionary to update the list of available subject after the download.

This PR also changes the default filestore to the current filestore in use (`cortex.db.filstore`) instead of the one listed in the config file.