### PR TITLE
FIX create intermediate dirs for config file

### DIFF
--- a/cortex/options.py
+++ b/cortex/options.py
@@ -19,7 +19,7 @@ files_successfully_read = config.read(usercfg)
 # If user config doesn't exist, create it
 if len(files_successfully_read) == 0:
     if not os.path.exists(userdir):
-        os.mkdir(userdir)
+        os.makedirs(userdir)
     with open(usercfg, 'w') as fp:
         config.write(fp)
         


### PR DESCRIPTION
Right now the installation step assumes that `~/.config` exists. The installation blows up if the directory doesn't exist (see #414). Creating intermediate dirs should be a simple enough fix for the problem.