### PR TITLE
ENH add option for intermediate image in bbregister

### DIFF
--- a/cortex/align.py
+++ b/cortex/align.py
@@ -205,7 +205,7 @@ def fs_manual(subject, xfmname, output_name="register.lta", wm_color="yellow",
                 # Save transform to pycortex
                 xfm = Transform.from_freesurfer(reg_dat, reference, subject)
                 db.save_xfm(subject, xfmname, xfm.xfm, xfmtype='coord', reference=reference)
-                print("saved xfm")
+                print("saved xfm", xfmname)
     except Exception as e:
         raise(e)
     finally:
@@ -217,7 +217,7 @@ def fs_manual(subject, xfmname, output_name="register.lta", wm_color="yellow",
 
 
 def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed",
-              pre_flirt_args='', use_fs_bbr=True, epi_mask=False):
+              pre_flirt_args='', use_fs_bbr=True, epi_mask=False, intermediate=None):
     """Create an automatic alignment using the FLIRT boundary-based alignment (BBR) from FSL.
 
     If `noclean`, intermediate files will not be removed from /tmp. The `reference` image and resulting
@@ -252,6 +252,9 @@ def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed",
         If True, and use_fs_bbr is True, then the flag --epi-mask is passed to bbregister
         to mask out areas with spatial distortions. This setting is to be used whenever
         the reference was not distortion corrected.
+    intermediate : str
+        Path to a nibabel-readable image that will be used as intermediate for the alignment.
+        Usually, this is a single (3D) functional data volume.
 
     Returns
     -------
@@ -282,6 +285,8 @@ def automatic(subject, xfmname, reference, noclean=False, bbrtype="signed",
             cmd = 'bbregister --s {sub} --mov {absref} --init-coreg --reg {cache}/register.dat --t2'
             if epi_mask:
                 cmd += ' --epi-mask'
+            if intermediate is not None:
+                cmd += f' --int {intermediate}'
             cmd = cmd.format(sub=subject, absref=absreference, cache=cache)
 
             if sp.call(cmd, shell=True) != 0:


### PR DESCRIPTION
This option is useful to improve automatic alignment of a partial field of view image using a whole field of view intermediate image.