### PR TITLE
FIX update sources before apt-get installing

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
         pip install wheel numpy cython pillow

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,6 +26,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
         pip install wheel numpy cython


### PR DESCRIPTION
Sometimes sources might be unavailable and cause the actions to fail (see #417)