### PR TITLE
FIX keep current sampler when dataview changes

### DIFF
--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -324,6 +324,8 @@ var mriview = (function(module) {
     module.Surface.prototype.init = function(dataview) {
 
         this._active = dataview;
+        // Keep current sampler (nearest/trilinear) when the dataview changes.
+        this._active.setFilter(this._sampler);
 
         this.loaded.done(function() {
             var shaders = [];


### PR DESCRIPTION
When the sampler is changed (nearest or trilinear) in the viewer, it only affects the current dataview. After changing the dataview, the menu still displays the new value, but the sampler actually uses the old value.

Example:
- view A, the menu displays "nearest", the view uses "nearest"
- (click on "trilinear" in the menu)
- view A, the menu displays "trilinear", the view uses "trilinear"
- (click on view B)
- view B, the menu displays "trilinear", the view uses "nearest"

This PR fixes this bug. The behavior is now consistent with the other sampling options, that persist when changing the dataview.