### PR TITLE
Revert "FIX keep current sampler when dataview changes (#420)"

### DIFF
--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -324,8 +324,6 @@ var mriview = (function(module) {
     module.Surface.prototype.init = function(dataview) {
 
         this._active = dataview;
-        // Keep current sampler (nearest/trilinear) when the dataview changes.
-        this._active.setFilter(this._sampler);
 
         this.loaded.done(function() {
             var shaders = [];


### PR DESCRIPTION
With the change in #420, the viewers hang with "loading brain". I tested this on two different machines and two different operating systems (but with the same browser: firefox). Removing that line fixes the problem. I don't know enough javascript to figure out if there's a better fix...

This reverts commit d388b2b2cf47a2e3acc38a2567a85495d262e443.