### PR TITLE
FIX keep current sampler when dataview changes - v2

### DIFF
--- a/cortex/webgl/resources/js/dataset.js
+++ b/cortex/webgl/resources/js/dataset.js
@@ -428,6 +428,9 @@ var dataset = (function(module) {
     module.VertexData.prototype.init = function(uniforms, dim) {
         //nothing to set...
     }
+    module.VertexData.prototype.setFilter = function(interp) {
+        //nothing to do...
+    }
     module.VertexData.prototype.set = function(uniforms, dim, fframe, dispatch) {
         var name = dim == 0 ? "data0":"data2";
         dispatch({type:"attribute", name:"data"+(2*dim), value:this.verts[fframe]});

--- a/cortex/webgl/resources/js/dataset.js
+++ b/cortex/webgl/resources/js/dataset.js
@@ -207,6 +207,10 @@ var dataset = (function(module) {
         if (this.loaded.state() == "pending")
             $("#dataload").show();
 
+        if ('sampler' in opts){
+            this.setFilter(opts.sampler);
+        }
+
         //This only kind of supports multiviews
         //TODO: hash the multiview as a separate object
         var shaders = [];

--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -372,7 +372,7 @@ var mriview = (function(module) {
                 halo: false,
                 dither: this._dither,
                 equivolume: this._equivolume,
-                // sampler: this._sampler,
+                sampler: this._sampler,
             });
             this.shaders[dataview.uuid] = shaders[0];
         }.bind(this));


### PR DESCRIPTION
This is a second attempt to fix the issue described in #420 (which was reverted in #421).