### PR TITLE
ENH add blend_curvature method to Vertex, Vertex2D, and VertexRGB

### DIFF
--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -1,4 +1,5 @@
 import hashlib
+from copy import deepcopy
 import numpy as np
 import h5py
 
@@ -579,7 +580,7 @@ class VertexData(BrainData):
         alpha = np.clip(alpha.astype("float"), 0, 1)
 
         # blend original map with curvature map
-        blended = self.raw
+        blended = deepcopy(self.raw)  # copy because VertexRGB.raw returns self
         blended.red.data = blended.red.data * alpha + (1 - alpha) * curvature_raw.red.data
         blended.green.data = blended.green.data * alpha + (1 - alpha) * curvature_raw.green.data
         blended.blue.data = blended.blue.data * alpha + (1 - alpha) * curvature_raw.blue.data
@@ -588,7 +589,7 @@ class VertexData(BrainData):
         blended.blue.data = blended.blue.data.astype("uint8")
 
         return blended
-        
+
 
 def _find_mask(nvox, subject, xfmname):
     import os

--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -539,6 +539,57 @@ class VertexData(BrainData):
         else:
             return self.data[self.llen:]
 
+    def blend_curvature(self, alpha, threshold=0, brightness=0.5,
+                        contrast=0.25, smooth=20):
+        """Blend the data with a curvature map depending on a transparency map.
+        
+        Vertex objects cannot use transparency as Volume objects. This method
+        is a hack to mimic the transparency of Volume objects, blending the
+        Vertex data with a curvature map. This method returns a VertexRGB
+        object, and the colormap parameters (vmin, vmax, cmap, ...) of the
+        original Vertex object cannot be changed later on.
+
+        Parameters
+        ----------
+        alpha : array of shape (n_vertices, )
+            Transparency map.
+        threshold : float
+            Threshold for the curvature map.
+        brightness : float
+            Brightness of the curvature map.
+        contrast : float
+            Contrast of the curvature map.
+        smooth : float
+            Smoothness of the curvature map.
+        
+        Returns
+        -------
+        blended : VertexRGB object
+            The original map blended with a curvature map.
+        """
+        from .views import Vertex
+        # prepare curvature map
+        curvature = db.get_surfinfo(self.subject, smooth=smooth).data
+        curvature = (curvature > threshold).astype("float")
+        curvature = curvature * contrast + brightness
+        curvature_raw = Vertex(curvature, self.subject, vmin=0, vmax=1,
+                               cmap="gray").raw
+
+        # prepare alpha map
+        alpha = np.clip(alpha.astype("float"), 0, 1)
+
+        # blend original map with curvature map
+        blended = self.raw
+        blended.red.data = blended.red.data * alpha + (1 - alpha) * curvature_raw.red.data
+        blended.green.data = blended.green.data * alpha + (1 - alpha) * curvature_raw.green.data
+        blended.blue.data = blended.blue.data * alpha + (1 - alpha) * curvature_raw.blue.data
+        blended.red.data = blended.red.data.astype("uint8")
+        blended.green.data = blended.green.data.astype("uint8")
+        blended.blue.data = blended.blue.data.astype("uint8")
+
+        return blended
+        
+
 def _find_mask(nvox, subject, xfmname):
     import os
     import re

--- a/cortex/dataset/view2D.py
+++ b/cortex/dataset/view2D.py
@@ -225,6 +225,7 @@ class Vertex2D(Dataview2D):
 
     """
     _cls = VertexData
+    blend_curvature = _cls.blend_curvature  # hacky inheritance
 
     def __init__(self, dim1, dim2, subject=None, description="", cmap=None,
                  vmin=None, vmax=None, vmin2=None, vmax2=None, **kwargs):

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -456,6 +456,8 @@ class VertexRGB(DataviewRGB):
 
     """
     _cls = VertexData
+    blend_curvature = _cls.blend_curvature  # hacky inheritance
+
     def __init__(self, red, green, blue, subject=None, alpha=None, description="",
                  state=None, **kwargs):
 

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -224,3 +224,26 @@ def test_dataset_operators():
     assert np.allclose(vol.data ** array, (vol ** array).data, equal_nan=True)
     assert np.allclose(-vol.data, (-vol).data)
     assert np.allclose(abs(vol.data), abs(vol).data)
+
+def test_blend_curvature():
+    view = cortex.Vertex.empty(subj)
+    alpha = np.linspace(0, 1, view.data.size).reshape(view.data.shape)
+
+    # test alpha with float
+    view_rgb = view.blend_curvature(alpha)
+    # test alpha with bool
+    view_rgb = view.blend_curvature(alpha > 0.3)
+    # test that it returns a VertexRGB
+    assert isinstance(view_rgb, cortex.VertexRGB)
+
+    # test on Vertex2D
+    view_2d = cortex.Vertex2D(view_rgb.red.data, view_rgb.green.data, subj)
+    view_rgb = view_2d.blend_curvature(alpha)
+
+    # test on VertexRGB
+    view_rgb_new = view_rgb.blend_curvature(alpha)
+    # test that it returns a different VertexRGB
+    assert not np.allclose(view_rgb.red.data, view_rgb_new.red.data)
+    # test that it returns a VertexRGB with same values when alpha is ones
+    view_rgb_new = view_rgb.blend_curvature(np.ones_like(alpha))
+    assert np.allclose(view_rgb.red.data, view_rgb_new.red.data)


### PR DESCRIPTION
Vertex objects cannot use transparency as Volume objects because they are implemented differently in the viewer.
This PR adds a method to Vertex, Vertex2D, and VertexRGB, to mimic the transparency of Volume objects. The method blends the Vertex data with a curvature map, depending on a transparency (alpha) map, and returns a VertexRGB object.

It is a workaround for #323 and #387, using the method described in https://github.com/gallantlab/pycortex/issues/323#issuecomment-477463304.