### PR TITLE
ENH,FIX add dropout option to make_svg, fix transparency

### DIFF
--- a/cortex/quickflat/utils.py
+++ b/cortex/quickflat/utils.py
@@ -320,9 +320,15 @@ def _make_hatch_image(hatch_data, height, sampler='nearest', hatch_space=4, reca
         space between hatch lines (in pixels)
     recache : boolean
 
-
+    Returns
+    -------
+    hatchim : RGBA array
+        flatmap image with hatches over hatch_data
     """
-    dmap, _ = make_flatmap_image(hatch_data, height=height, sampler=sampler, recache=recache)
+    dmap, _ = make_flatmap_image(
+        hatch_data, height=height, sampler=sampler, recache=recache, nanmean=True
+    )
+    mask_nans = np.isnan(dmap)
     hx, hy = np.meshgrid(range(dmap.shape[1]), range(dmap.shape[0]))
 
     hatchpat = (hx+hy)%(2*hatch_space) < 2
@@ -332,7 +338,9 @@ def _make_hatch_image(hatch_data, height, sampler='nearest', hatch_space=4, reca
 
     hatchpat = np.logical_or(hatchpat, hatchpat[:,::-1]).astype(float)
     hatchim = np.dstack([1-hatchpat]*3 + [hatchpat])
-    hatchim[:, : ,3] *= np.clip(dmap, 0, 1).astype(float)
+    hatchim[:, :, 3] *= np.clip(dmap, 0, 1).astype(float)
+    # Set nans to alpha = 0. for transparency
+    hatchim[mask_nans, 3] = 0.
 
     return hatchim
 

--- a/cortex/quickflat/view.py
+++ b/cortex/quickflat/view.py
@@ -346,7 +346,9 @@ def make_svg(fname, braindata, with_labels=False, with_curvature=True, layers=['
         If True or a cortex.Dataview object, hatches will be overlaid on top of the
         flatmap to indicate areas with dropout. If set to True, the dropout areas will
         be estimated from the intensity of the reference image. If set to a
-        cortex.Dataview object, values equal to 1 will be considered dropout areas.
+        cortex.Dataview object, values in the dataset will be considered dropout areas.
+        The transparency of the hatches is proportional to the intensity of the values
+        in the dropout dataset.
     """
     fp = io.BytesIO()
     from matplotlib.pyplot import imsave


### PR DESCRIPTION
This PR adds the option to visualize areas of dropout also for `make_svg`. In addition, this PR fixes transparency issues with `make_svg`. (While `nan`s pixels are shown as transparent with `imshow`, they are not transparent when saved with `imsave`, so their alpha value needs to be modified accordingly.)

