### PR TITLE
FIX do not show labels for invisible shapes

### DIFF
--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -249,23 +249,23 @@ class SVGOverlay(object):
         # separate kwargs starting with "label-"
         label_kwargs = {k[6:]:v for k, v in kwargs.items() if k[:6] == "label-"}
         kwargs = {k:v for k, v in kwargs.items() if k[:6] != "label-"}
-
         for layer in self:
-            if layer.name==layer_name:
+            if layer.name == layer_name:
                 layer.visible = True
                 layer.labels.visible = labels
-                if shape_list is not None:
-                    for name_, shape_ in layer.shapes.items():
+                for name_, shape_ in layer.shapes.items():
+                    # honor visibility set in the svg
+                    if shape_list is not None:
                         shape_.visible = name_ in shape_list
-                        # Set visibility of labels (by setting text alpha to 0)
-                        # This could be less baroque, but text elements currently
-                        # do not have individually settable visibility / style params
-                        tmp_style = copy.deepcopy(layer.labels.text_style)
-                        tmp_style['fill-opacity'] = '1' if shape_.visible else '0'
-                        tmp_style.update(label_kwargs)
-                        tmp_style_str = ';'.join(['%s:%s'%(k,v) for k, v in tmp_style.items() if v != 'None'])
-                        for i in range(len(layer.labels.elements[name_])):
-                            layer.labels.elements[name_][i].set('style', tmp_style_str)
+                    # Set visibility of labels (by setting text alpha to 0)
+                    # This could be less baroque, but text elements currently
+                    # do not have individually settable visibility / style params
+                    tmp_style = copy.deepcopy(layer.labels.text_style)
+                    tmp_style['fill-opacity'] = '1' if shape_.visible else '0'
+                    tmp_style.update(label_kwargs)
+                    tmp_style_str = ';'.join(['%s:%s'%(k,v) for k, v in tmp_style.items() if v != 'None'])
+                    for i in range(len(layer.labels.elements[name_])):
+                        layer.labels.elements[name_][i].set('style', tmp_style_str)
                 layer.set(**kwargs)
             else:
                 layer.visible = False

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -329,7 +329,11 @@ class Overlay(object):
 
     @property
     def visible(self):
-        return 'none' not in self.layer.attrib['style']
+        # assume visible if "style" property is not set
+        if 'style' not in self.layer.attrib:
+            return True
+        else:
+            return 'none' not in self.layer.attrib['style']
 
     @visible.setter
     def visible(self, value):
@@ -499,7 +503,11 @@ class Shape(object):
 
     @property
     def visible(self):
-        return 'none' not in self.layer.attrib['style']
+        # assume visible if "style" property is not set
+        if "style" not in self.layer.attrib:
+            return True
+        else:
+            return 'none' not in self.layer.attrib['style']
 
     @visible.setter
     def visible(self, value):


### PR DESCRIPTION
The visibility setting of individual shapes in the `overlays.svg` file is currently not checked in `cortex.svgoverlay.get_texture`. This causes labels for invisible ROIs to show up in the quickflat. This PR fixes the logic by honoring the visibility of the SVG shapes in `overlays.svg`.

Previous version (note labels like FC, VTC, STG showing up):
![image](https://user-images.githubusercontent.com/6150554/154754884-960c6e56-9e39-4bd2-9d9b-c92a27f4d9b2.png)


This PR:
![image](https://user-images.githubusercontent.com/6150554/154754805-0dde007d-acc7-433c-92b8-219fbdfa76c4.png)
