### PR TITLE
FIX Check if overlays file exists before unlinking.

### DIFF
--- a/cortex/freesurfer.py
+++ b/cortex/freesurfer.py
@@ -279,7 +279,8 @@ def import_flat(fs_subject, patch, hemis=['lh', 'rh'], cx_subject=None,
     database.db.clear_cache(cx_subject)
     # Remove overlays.svg file (FLATMAPS HAVE CHANGED)
     overlays_file = database.db.get_paths(cx_subject)['overlays']
-    os.unlink(overlays_file)
+    if os.path.exists(overlays_file):
+        os.unlink(overlays_file)
     # Regenerate it? 
 
 


### PR DESCRIPTION
When a new flattened surface is imported into pycortex, the `overlays.svg` of the subject is removed from pycortex store. However, this produces an error if the subject does not yet have an `overlays.svg` file. This PR checks if the `overlays.svg` file exits, and only attempts to delete the file if it already exists. 