### PR TITLE
FIX change location of filestore during the install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class my_install(install):
     def run(self):
         install.run(self)
         optfile = [f for f in self.get_outputs() if 'defaults.cfg' in f]
-        prefix = os.path.join(self.install_data, "share", "pycortex")
+        prefix = os.path.join(self.install_base, "share", "pycortex")
         set_default_filestore(prefix, optfile[0])
         self.copy_tree('filestore', prefix)
         for root, folders, files in os.walk(prefix):


### PR DESCRIPTION
Fixes #335, #360

In some machines (macos, colab), the install would put the filestore in a location of the form `build/bdist.*/wheel/pycortex-*.data/data/share/pycortex/db`, which seems to be deleted after the install. This PR fixes this issue by changing the default location.
___
Tested on my machine:
- before: `.../tomdlt/miniconda3/envs/py37/share/pycortex/db`
- after: `.../tomdlt/miniconda3/envs/py37/share/pycortex/db`

Tested on my machine, installing with `--user`:
- before: `.../tomdlt/.local/share/pycortex/db`
- after: `.../tomdlt/.local/share/pycortex/db`


Tested on Colab:
- before: `build/bdist.linux-x86_64/wheel/pycortex-1.2.3.data/data/share/pycortex/db`
- after: `/usr/share/pycortex/db`