### PR TITLE
FIX ignore masked voxels when averaging with nanmean=True

### DIFF
--- a/cortex/quickflat/utils.py
+++ b/cortex/quickflat/utils.py
@@ -94,7 +94,8 @@ def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **k
             # to ignore nans in the weighted mean, nanmean =
             # sum(weights * non-nan values) / sum(weights on non-nan values)
             nonnan_sum = pixmap.dot(np.nan_to_num(data.ravel()))
-            weights_on_nonnan = pixmap.dot((~np.isnan(data.ravel())).astype(data.dtype))
+            isnan = np.isnan(data.ravel()).filled()
+            weights_on_nonnan = pixmap.dot((~isnan).astype(data.dtype))
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
                 nanmean_data = nonnan_sum / weights_on_nonnan

--- a/cortex/tests/test_quickflat.py
+++ b/cortex/tests/test_quickflat.py
@@ -10,18 +10,31 @@ no_inkscape = not has_installed('inkscape')
 
 @pytest.mark.skipif(no_inkscape, reason='Inkscape required')
 def test_quickflat():
-	tf = tempfile.NamedTemporaryFile(suffix=".png")
-	view = cortex.Volume.random("S1", "fullhead", cmap="hot")
-	cortex.quickflat.make_png(tf.name, view)
+    tf = tempfile.NamedTemporaryFile(suffix=".png")
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    cortex.quickflat.make_png(tf.name, view)
 
 
 @pytest.mark.skipif(no_inkscape, reason='Inkscape required')
 def test_colorbar_location():
-	view = cortex.Volume.random("S1", "fullhead", cmap="hot")
-	for colorbar_location in ['left', 'center', 'right', (0, 0.2, 0.4, 0.3)]:
-		cortex.quickflat.make_figure(
-			view, with_colorbar=True, colorbar_location=colorbar_location)
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    for colorbar_location in ['left', 'center', 'right', (0, 0.2, 0.4, 0.3)]:
+        cortex.quickflat.make_figure(
+            view, with_colorbar=True, colorbar_location=colorbar_location)
 
-	with pytest.raises(ValueError):
-		cortex.quickflat.make_figure(
-			view, with_colorbar=True, colorbar_location='unknown_location')
+    with pytest.raises(ValueError):
+        cortex.quickflat.make_figure(
+            view, with_colorbar=True, colorbar_location='unknown_location')
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+@pytest.mark.parametrize("type_", ["thick", "thin"])
+def test_make_flatmap_image_nanmean(type_):
+    mask = cortex.db.get_mask("S1", "fullhead", type=type_)
+    data = np.ones(mask.sum())
+    # set 50% of the values in the dataset to NaN
+    data[np.random.rand(*data.shape) > 0.5] = np.nan
+    vol = cortex.Volume(data, "S1", "fullhead", vmin=0, vmax=1)
+    img, extents = cortex.quickflat.utils.make_flatmap_image(vol, nanmean=True)
+    # assert that the nanmean only returns NaNs and 1s
+    assert np.nanmin(img) == 1

--- a/cortex/tests/test_quickflat.py
+++ b/cortex/tests/test_quickflat.py
@@ -19,22 +19,24 @@ def test_quickflat():
 def test_colorbar_location():
     view = cortex.Volume.random("S1", "fullhead", cmap="hot")
     for colorbar_location in ['left', 'center', 'right', (0, 0.2, 0.4, 0.3)]:
-        cortex.quickflat.make_figure(
-            view, with_colorbar=True, colorbar_location=colorbar_location)
+        cortex.quickflat.make_figure(view, with_colorbar=True,
+                                     colorbar_location=colorbar_location)
 
     with pytest.raises(ValueError):
-        cortex.quickflat.make_figure(
-            view, with_colorbar=True, colorbar_location='unknown_location')
+        cortex.quickflat.make_figure(view, with_colorbar=True,
+                                     colorbar_location='unknown_location')
 
 
 @pytest.mark.skipif(no_inkscape, reason='Inkscape required')
 @pytest.mark.parametrize("type_", ["thick", "thin"])
-def test_make_flatmap_image_nanmean(type_):
+@pytest.mark.parametrize("nanmean", [True, False])
+def test_make_flatmap_image_nanmean(type_, nanmean):
     mask = cortex.db.get_mask("S1", "fullhead", type=type_)
     data = np.ones(mask.sum())
     # set 50% of the values in the dataset to NaN
     data[np.random.rand(*data.shape) > 0.5] = np.nan
     vol = cortex.Volume(data, "S1", "fullhead", vmin=0, vmax=1)
-    img, extents = cortex.quickflat.utils.make_flatmap_image(vol, nanmean=True)
+    img, extents = cortex.quickflat.utils.make_flatmap_image(
+        vol, nanmean=nanmean)
     # assert that the nanmean only returns NaNs and 1s
     assert np.nanmin(img) == 1


### PR DESCRIPTION
When averaging over voxels to produce a flatmap, NaNs can be ignored using `nanmean=True`.
However, if the data is masked (e.g. with a "thin" mask), masked voxels are not ignored like NaNs.

Example with data filled with 1s and NaNs:
"thick" mask: correct behavior, averaging 1s into 1s, and NaNs into NaNs.
![thick](https://user-images.githubusercontent.com/11065596/162104394-0397365d-fa2b-47b7-8c9b-505d44815ce6.png)

"thin" mask: incorrect behavior, averaging 1s into value in [0, 1].
![thin](https://user-images.githubusercontent.com/11065596/162104103-8e96a635-24d8-4745-adba-d2f69aca5234.png)

The fix is to use `masked_data.filled()`, which fills masked numpy arrays with the value in `fill_vallue`.

<details>

```python
import cortex
import numpy as np
from matplotlib import pyplot as plt

subject = 'S1'
transform = 'fullhead'

for type_ in ["thin", "thick"]:
    # create dataset with volume from 0 to n_voxels
    mask = cortex.db.get_mask(subject, transform, type=type_)
    vol = cortex.Volume(np.ones(mask.sum()), subject, transform, cmap="viridis", vmin=0, vmax=1)

    # set 50% of the values in the dataset to NaN
    vol.data[np.random.rand(*vol.data.shape) > 0.5] = np.nan

    _ = cortex.quickshow(vol, nanmean=True, with_curvature=False)
    plt.show()
```