### PR TITLE
MNT change default fsl-prefix and 2D colormap

### DIFF
--- a/cortex/defaults.cfg
+++ b/cortex/defaults.cfg
@@ -1,7 +1,9 @@
 [basic]
 default_cmap = RdBu_r
-default_cmap2D = RdBu_covar
-fsl_prefix = fsl5.0-
+default_cmap2D = PU_BuOr_covar
+# Change fsl_prefix to fsl5.0- only if FSL was installed with 
+# NeuroDebian and you don't want to source /etc/fsl/fsl.sh every time.
+fsl_prefix = 
 
 [dependency_paths]
 # The following specify paths to the binary executable files


### PR DESCRIPTION
`fsl_prefix` is needed to be specified only if FSL is installed with NeuroDebian (and users do not want to source it with `/etc/fsl/fsl.sh` every time). However, FSL is stuck to 5.0 in NeuroDebian, and most people would install FSL with other means (e.g. the python FSL installer). So I think we should set the prefix to blank by default (see #443).

This PR also changes the default 2D colormap from RdBu_covar to PU_BuOr_covar, which I believe is a better default.