### PR TITLE
FIX random crashes in `save_3d_views`

### DIFF
--- a/cortex/webgl/resources/js/axes3d.js
+++ b/cortex/webgl/resources/js/axes3d.js
@@ -298,6 +298,8 @@ var jsplot = (function (module) {
         var img = mriview.getTexture(this.renderer.context, renderbuf)
         if (post !== undefined)
             $.post(post, {png:img.toDataURL()});
+        // Draw again -- for some reason the scene disappears after getting the texture
+        this.draw()
         return img;
     };
 


### PR DESCRIPTION
I realized that after calling `getImage`, sometimes the view was not rendered. I believe this is what caused the random crashes with `save_3d_views`. Forcing the view to be drawn again after `getImage` solves the random crashes. (Or at least, I've been running `cortex.export.plot_panels` for ~20 times in a loop and it hasn't crashed...