### PR TITLE
NF new params for a multipanel figure with all views

### DIFF
--- a/cortex/export/_default_params.py
+++ b/cortex/export/_default_params.py
@@ -226,3 +226,61 @@ params_inflated_dorsal_lateral_medial_ventral = {
         },
     ],
 }
+
+params_flatmap_inflated_lateral_medial_ventral = {
+    "figsize": [16, 9],
+    "panels": [
+        {
+            "extent": [0.0, 0.2, 1.0, 0.8],
+            "view": {"angle": "flatmap", "surface": "flatmap"},
+        },
+        {
+            "extent": [0.1, 0.05, 0.2, 0.2],
+            "view": {
+                "hemisphere": "left",
+                "angle": "medial_pivot",
+                "surface": "inflated",
+            },
+        },
+        {
+            "extent": [0.7, 0.05, 0.2, 0.2],
+            "view": {
+                "hemisphere": "right",
+                "angle": "medial_pivot",
+                "surface": "inflated",
+            },
+        },
+        {
+            "extent": [0.0, 0.25, 0.2, 0.2],
+            "view": {
+                "hemisphere": "left",
+                "angle": "lateral_pivot",
+                "surface": "inflated",
+            },
+        },
+        {
+            "extent": [0.8, 0.25, 0.2, 0.2],
+            "view": {
+                "hemisphere": "right",
+                "angle": "lateral_pivot",
+                "surface": "inflated",
+            },
+        },
+        {
+            "extent": [0.3, 0.05, 0.15, 0.15],
+            "view": {
+                "hemisphere": "left",
+                "angle": "bottom_pivot",
+                "surface": "inflated",
+            },
+        },
+        {
+            "extent": [0.55, 0.05, 0.15, 0.15],
+            "view": {
+                "hemisphere": "right",
+                "angle": "bottom_pivot",
+                "surface": "inflated",
+            },
+        },
+    ],
+}

--- a/cortex/export/panels.py
+++ b/cortex/export/panels.py
@@ -12,6 +12,7 @@ from ._default_params import (
     params_occipital_triple_view,
     params_flatmap_lateral_medial,
     params_inflated_dorsal_lateral_medial_ventral,
+    params_flatmap_inflated_lateral_medial_ventral
 )
 
 


### PR DESCRIPTION
Example output:
![example-new-view](https://user-images.githubusercontent.com/6150554/169116958-ea8a9e11-5309-485c-8119-550e5218a073.png)

Code to generate example:

```python
import cortex
import numpy as np
from cortex.export.panels import params_flatmap_inflated_lateral_medial_ventral as params

subject = 'S1'
shape = cortex.db.get_xfm(subject, 'identity').shape
data = np.arange(np.product(shape)).reshape(shape)
volume = cortex.Volume(data, subject=subject, xfmname='identity')

cortex.export.plot_panels(volume, **params, save_name="example-new-view.png")
```