### PR TITLE
FIX update nibabel deprecated methods

### DIFF
--- a/cortex/anat.py
+++ b/cortex/anat.py
@@ -76,10 +76,10 @@ def voxelize(outfile, subject, surf='wm', mp=True):
     shape = nib.get_shape()
     vox = np.zeros(shape, dtype=bool)
     for pts, polys in db.get_surf(subject, surf, nudge=False):
-        xfm = Transform(np.linalg.inv(nib.get_affine()), nib)
+        xfm = Transform(np.linalg.inv(nib.affine), nib)
         vox += polyutils.voxelize(xfm(pts), polys, shape=shape, center=(0,0,0), mp=mp).astype('bool')
         
-    nib = nibabel.Nifti1Image(vox, nib.get_affine(), header=nib.get_header())
+    nib = nibabel.Nifti1Image(vox, nib.affine, header=nib.header)
     nib.to_filename(outfile)
 
     return vox.T

--- a/cortex/database.py
+++ b/cortex/database.py
@@ -408,7 +408,7 @@ class Database(object):
                 import warnings
                 warnings.warn('You are importing a 4D dataset, automatically selecting the first volume as reference')
                 data = data[...,0]
-            out = nibabel.Nifti1Image(data, nib.get_affine(), header=nib.get_header())
+            out = nibabel.Nifti1Image(data, nib.affine, header=nib.header)
             nibabel.save(out, fpath)
 
             jsdict = dict()
@@ -416,10 +416,10 @@ class Database(object):
         nib = nibabel.load(os.path.join(path, "reference.nii.gz"))
         if xfmtype == "magnet":
             jsdict['magnet'] = np.array(xfm).tolist()
-            jsdict['coord'] = np.dot(np.linalg.inv(nib.get_affine()), xfm).tolist()
+            jsdict['coord'] = np.dot(np.linalg.inv(nib.affine), xfm).tolist()
         elif xfmtype == "coord":
             jsdict['coord'] = np.array(xfm).tolist()
-            jsdict['magnet'] = np.dot(nib.get_affine(), xfm).tolist()
+            jsdict['magnet'] = np.dot(nib.affine, xfm).tolist()
         
         files = self.get_paths(subject)
         if len(glob.glob(files['masks'].format(xfmname=name, type="*"))) > 0:
@@ -449,7 +449,7 @@ class Database(object):
 
         if name == "identity":
             nib = self.get_anat(subject, 'raw')
-            return Transform(np.linalg.inv(nib.get_affine()), nib)
+            return Transform(np.linalg.inv(nib.affine), nib)
 
         fname = os.path.join(self.filestore, subject, "transforms", name, "matrices.xfm")
         reference = os.path.join(self.filestore, subject, "transforms", name, "reference.nii.gz")
@@ -530,7 +530,7 @@ class Database(object):
         xfm = self.get_xfm(subject, xfmname)
         if xfm.shape != mask.shape:
             raise ValueError("Invalid mask shape: must match shape of reference image")
-        affine = xfm.reference.get_affine()
+        affine = xfm.reference.affine
         nib = nibabel.Nifti1Image(mask.astype(np.uint8).T, affine)
         nib.to_filename(fname)
 

--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -333,7 +333,7 @@ class VolumeData(BrainData):
         copied from the reference image for this VolumeData's transform.
         """
         xfm = db.get_xfm(self.subject, self.xfmname)
-        affine = xfm.reference.get_affine()
+        affine = xfm.reference.affine
         import nibabel
         new_nii = nibabel.Nifti1Image(self.volume.T, affine)
         nibabel.save(new_nii, filename)

--- a/cortex/freesurfer.py
+++ b/cortex/freesurfer.py
@@ -194,7 +194,7 @@ def import_subj(fs_subject, cx_subject=None, freesurfer_subject_dir=None, whitem
 
     # Freesurfer uses FOV/2 for center, let's set the surfaces to use the
     # magnet isocenter
-    trans = nibabel.load(out).get_affine()[:3, -1]
+    trans = nibabel.load(out).affine[:3, -1]
     surfmove = trans - np.sign(trans) * [128, 128, 128]
 
     from . import formats

--- a/cortex/mayavi_aligner.py
+++ b/cortex/mayavi_aligner.py
@@ -711,8 +711,8 @@ class Align(HasTraits):
         epi = nii.get_data().astype(float).squeeze()
         if epi.ndim>3:
             epi = epi[:,:,:,0]
-        self.affine = nii.get_affine()
-        base = nii.get_header().get_base_affine()
+        self.affine = nii.affine
+        base = nii.header.get_base_affine()
         self.base = base
         self.origin = base[:3, -1]
         self.spacing = np.diag(base)[:3]

--- a/cortex/mni.py
+++ b/cortex/mni.py
@@ -131,7 +131,7 @@ def transform_surface_to_mni(subject, surfname):
         MNI-transformed surface in same format returned by db.get_surf.
     """
     # Get MNI affine transform
-    mni_affine = nibabel.load(default_template).get_affine()
+    mni_affine = nibabel.load(default_template).affine
 
     # Get subject anatomical-to-MNI transform
     mni_xfm = np.dot(mni_affine, db.get_mnixfm(subject, "identity"))
@@ -183,7 +183,7 @@ def transform_mni_to_subject(subject, xfm, volarray, func_to_mni,
     funcspace_nii = tempfile.mktemp(".nii.gz")
 
     # Save out relevant things
-    affine = nibabel.load(template).get_affine()
+    affine = nibabel.load(template).affine
     nibabel.save(nibabel.Nifti1Image(volarray, affine), mnispace_func_nii)
     _save_fsl_xfm(mni_to_func_xfm, np.linalg.inv(func_to_mni))
 

--- a/cortex/volume.py
+++ b/cortex/volume.py
@@ -230,8 +230,8 @@ def epi2anatspace(volumedata, order=1):
     anat = db.get_anat(volumedata.subject, "raw")
     xfm = db.get_xfm(volumedata.subject, volumedata.xfmname, "coord")
 
-    #allxfm =  Transform(anat.get_affine(), anat.shape).inv * xfm.inv
-    allxfm = xfm * Transform(anat.get_affine(), anat.shape)
+    #allxfm =  Transform(anat.affine, anat.shape).inv * xfm.inv
+    allxfm = xfm * Transform(anat.affine, anat.shape)
 
     rotpart = allxfm.xfm[:3, :3]
     transpart = allxfm.xfm[:3,-1]
@@ -262,8 +262,8 @@ def anat2epispace(anatdata, subject, xfmname, order=1):
     anatref = db.get_anat(subject)
     target = db.get_xfm(subject, xfmname, "coord")
 
-    allxfm =  Transform(anatref.get_affine(), anatref.shape).inv * target.inv
-    #allxfm = xfm * Transform(anat.get_affine(), anat.shape)
+    allxfm =  Transform(anatref.affine, anatref.shape).inv * target.inv
+    #allxfm = xfm * Transform(anat.affine, anat.shape)
 
     rotpart = allxfm.xfm[:3, :3]
     transpart = allxfm.xfm[:3,-1]
@@ -299,7 +299,7 @@ def epi2anatspace_fsl(volumedata):
             xfmh.write(" ".join(["%0.5f"%f for f in ll])+"\n")
 
     ## Save out data into nifti file
-    datafile = nibabel.Nifti1Image(data.T, xfm.reference.get_affine(), xfm.reference.get_header())
+    datafile = nibabel.Nifti1Image(data.T, xfm.reference.affine, xfm.reference.header)
     datafilename = tempfile.mktemp(".nii")
     nibabel.save(datafile, datafilename)
 
@@ -342,7 +342,7 @@ def anat2epispace_fsl(data,subject,xfmname):
             xfmh.write(" ".join(["%0.5f"%f for f in ll])+"\n")
 
     ## Save out data into nifti file
-    datafile = nibabel.Nifti1Image(data.T, anatNII.get_affine(), anatNII.get_header())
+    datafile = nibabel.Nifti1Image(data.T, anatNII.affine, anatNII.header)
     datafilename = tempfile.mktemp(".nii")
     nibabel.save(datafile, datafilename)
 

--- a/cortex/xfm.py
+++ b/cortex/xfm.py
@@ -125,8 +125,8 @@ class Transform(object):
             inIm = infile
 
         refIm = nibabel.load(reffile)
-        in_hdr = inIm.get_header()
-        ref_hdr = refIm.get_header()
+        in_hdr = inIm.header
+        ref_hdr = refIm.header
         # get_zooms gets the positive voxel sizes as returned in the header
         inspace = np.diag(in_hdr.get_zooms()[:3] + (1,))
         refspace = np.diag(ref_hdr.get_zooms()[:3] + (1,))
@@ -138,7 +138,7 @@ class Transform(object):
         if npl.det(ref_hdr.get_best_affine())>=0:
             refspace = np.dot(refspace, _x_flipper(ref_hdr.get_data_shape()[0]))
 
-        inAffine = inIm.get_affine()
+        inAffine = inIm.affine
 
         coord = np.dot(inv(refspace),np.dot(xfm,np.dot(inspace,inv(inAffine))))
         return cls(coord, refIm)
@@ -178,8 +178,8 @@ class Transform(object):
             inIm = nibabel.load(infile)
         except AttributeError:
             inIm = infile
-        in_hdr = inIm.get_header()
-        ref_hdr = self.reference.get_header()
+        in_hdr = inIm.header
+        ref_hdr = self.reference.header
         # get_zooms gets the positive voxel sizes as returned in the header
         inspace = np.diag(in_hdr.get_zooms()[:3] + (1,))
         refspace = np.diag(ref_hdr.get_zooms()[:3] + (1,))
@@ -193,7 +193,7 @@ class Transform(object):
             print("Determinant is > 0: FLIPPING!")
             refspace = np.dot(refspace, _x_flipper(ref_hdr.get_data_shape()[0]))
 
-        inAffine = inIm.get_affine()
+        inAffine = inIm.affine
 
         fslx = np.dot(refspace,np.dot(self.xfm,np.dot(inAffine,inv(inspace))))
         if direction=='func>anat':

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -109,7 +109,7 @@ Transformations in pycortex are stored as **affine** matrices encoded in magnet 
 
 Each transform is stored in its own subdirectory containing two files: ``matrices.xfm``, and ``reference.nii.gz``. Masks are also stored in the transforms directory.
 
-Transforms are saved as JSON-encoded text files. They have the format ``{subject}_{transform}.xfm``. There are four fields in this JSON structure: ``subject``, ``epifile``, ``coord``, ``magnet``. ``epifile`` gives the filename of the functional volume (EPI) that served as the reference for this transform. ``coord`` stores the transform from fiducial to coordinate space (for fast index lookups). ``magnet`` stores the transform from the fiducial to the magnet space, as defined in the return of ``nibabel.get_affine()``.
+Transforms are saved as JSON-encoded text files. They have the format ``{subject}_{transform}.xfm``. There are four fields in this JSON structure: ``subject``, ``epifile``, ``coord``, ``magnet``. ``epifile`` gives the filename of the functional volume (EPI) that served as the reference for this transform. ``coord`` stores the transform from fiducial to coordinate space (for fast index lookups). ``magnet`` stores the transform from the fiducial to the magnet space, as defined in the return of ``nibabel.affine``.
 
 Reference volumes are typically in Nifti_ format (*.nii), but can be any format that nibabel_ understands. These are stored to ensure that we know what the reference for any transform was. This makes it possible to visually verify and tweak alignments as well as keep a static store of images for future coregistrations.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ numexpr
 cython
 matplotlib
 pillow
-nibabel
+nibabel>=2.1
 networkx>=2.1
 imageio
 wget


### PR DESCRIPTION
Fix failing test with recent nibabel (as in #456 for example).

See [nibabel 2.1 changelog](https://github.com/nipy/nibabel/blob/225892af18d82b9a91ab63a9d072b894588b670e/Changelog#api-changes-and-deprecations-10=):
> Deprecation of `get_header`, `get_affine` method of image objects for removal in version 4.0;