### PR TITLE
FIX Correctly handle NaNs in `VertexRGB` and `VolumeRGB`

### DIFF
--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -477,7 +477,9 @@ class VertexRGB(DataviewRGB):
             self.blue = Vertex(blue, subject)
 
         if alpha is None:
-            alpha = np.ones(self.red.vertices.shape)
+            # If we have a NaN in one of the channels, set the alpha to 0
+            rgb = np.array([red, green, blue])
+            alpha = 1. - (~np.isnan(rgb).any(axis=0)).astype(float)
             alpha = Vertex(alpha, self.red.subject, vmin=0, vmax=1)
         if not isinstance(alpha, Vertex):
             alpha = Vertex(alpha, self.red.subject)

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -479,7 +479,7 @@ class VertexRGB(DataviewRGB):
         if alpha is None:
             # If we have a NaN in one of the channels, set the alpha to 0
             rgb = np.array([red, green, blue])
-            alpha = 1. - (~np.isnan(rgb).any(axis=0)).astype(float)
+            alpha = 1. - np.isnan(rgb).any(axis=0).astype(float)
             alpha = Vertex(alpha, self.red.subject, vmin=0, vmax=1)
         if not isinstance(alpha, Vertex):
             alpha = Vertex(alpha, self.red.subject)

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -493,7 +493,7 @@ class VertexRGB(DataviewRGB):
 
         rgb = np.array([self.red.data, self.green.data, self.blue.data])
         mask = np.isnan(rgb).any(axis=0)
-        alpha._data[..., mask] = alpha.vmin
+        alpha.data[..., mask] = alpha.vmin
         return alpha
 
     @alpha.setter

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -486,14 +486,14 @@ class VertexRGB(DataviewRGB):
         """Compute alpha transparency"""
         alpha = self._alpha
         if alpha is None:
-            alpha = np.ones(self.red.vertices.shape)
+            alpha = np.ones(self.red.vertices.shape[1])
             alpha = Vertex(alpha, self.red.subject, vmin=0, vmax=1)
         if not isinstance(alpha, Vertex):
             alpha = Vertex(alpha, self.red.subject)
 
         rgb = np.array([self.red.data, self.green.data, self.blue.data])
         mask = np.isnan(rgb).any(axis=0)
-        alpha.data[..., mask] = alpha.vmin
+        alpha.data[mask] = alpha.vmin
         return alpha
 
     @alpha.setter


### PR DESCRIPTION
When creating a new `VertexRGB` object with vertices containing NaNs, the values of those vertices would be cast to uint8 and transformed to 0. However, the alpha value would be set to 1, causing the Nan vertices to appear black. This PR fixes this issue by automatically setting a correct alpha of 0 for NaN values. It partially addresses #455.

Minimal example:
```python
import cortex
import numpy as np
import matplotlib.pyplot as plt

# get an roi to mask out
roi = cortex.get_roi_verts("fsaverage", roi="IPS0")["IPS0"]

# Make a VertexRGB object
c = np.linspace(0, 1, 327684)
rgb = np.array([c, np.zeros_like(c), np.zeros_like(c)])
rgb[:, roi] = np.nan
vtx = cortex.VertexRGB(*rgb, "fsaverage")

cortex.webgl.show(vtx)
cortex.quickshow(vtx, with_colorbar=False, with_curvature=True);plt.show()
```

Before:
![image](https://user-images.githubusercontent.com/6150554/178616975-171a6903-3c23-4a55-a02f-5602e94d9e79.png)
![image](https://user-images.githubusercontent.com/6150554/178616990-004c096d-09a9-4f56-abc7-d6c7357ff8e5.png)


After:
![image](https://user-images.githubusercontent.com/6150554/178616768-f30da715-225a-45fb-b44f-f3b5a87c0641.png)
![image](https://user-images.githubusercontent.com/6150554/178616724-c98d0610-f185-4163-971e-5c12664e2684.png)
