### PR TITLE
FIX add missing params to cortex.export.__init__

### DIFF
--- a/cortex/export/__init__.py
+++ b/cortex/export/__init__.py
@@ -5,6 +5,7 @@ from ._default_params import (
     params_flatmap_lateral_medial,
     params_occipital_triple_view,
     params_inflated_dorsal_lateral_medial_ventral,
+    params_flatmap_inflated_lateral_medial_ventral,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "params_occipital_triple_view",
     "params_inflatedless_lateral_medial_ventral",
     "params_inflated_dorsal_lateral_medial_ventral",
+    "params_flatmap_inflated_lateral_medial_ventral",
 ]


### PR DESCRIPTION
Missing from #446 