### PR TITLE
FIX force vmin/vmax to 0/1 whenever an array is passed as alpha

### DIFF
--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -1,5 +1,6 @@
 import numpy as np
 import colorsys
+import warnings
 
 from .views import Dataview, Volume, Vertex
 from .braindata import VolumeData, VertexData, _hash
@@ -256,6 +257,13 @@ class VolumeRGB(DataviewRGB):
             alpha = np.ones(self.red.volume.shape)
             alpha = Volume(alpha, self.red.subject, self.red.xfmname, vmin=0, vmax=1)
         if not isinstance(alpha, Volume):
+            if alpha.min() < 0 or alpha.max() > 1:
+                warnings.warn(
+                    "Some alpha values are outside the range of [0, 1]. "
+                    "Consider passing a Volume object as alpha with explicit vmin, vmax "
+                    "keyword arguments.",
+                    Warning
+                )
             alpha = Volume(alpha, self.red.subject, self.red.xfmname, vmin=0, vmax=1)
 
         rgb = np.array([self.red.volume, self.green.volume, self.blue.volume])
@@ -523,6 +531,13 @@ class VertexRGB(DataviewRGB):
             alpha = np.ones(self.red.vertices.shape[1])
             alpha = Vertex(alpha, self.red.subject, vmin=0, vmax=1)
         if not isinstance(alpha, Vertex):
+            if alpha.min() < 0 or alpha.max() > 1:
+                warnings.warn(
+                    "Some alpha values are outside the range of [0, 1]. "
+                    "Consider passing a Vertex object as alpha with explicit vmin, vmax "
+                    "keyword arguments.",
+                    Warning
+                )
             alpha = Vertex(alpha, self.red.subject, vmin=0, vmax=1)
 
         rgb = np.array([self.red.data, self.green.data, self.blue.data])

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -256,7 +256,7 @@ class VolumeRGB(DataviewRGB):
             alpha = np.ones(self.red.volume.shape)
             alpha = Volume(alpha, self.red.subject, self.red.xfmname, vmin=0, vmax=1)
         if not isinstance(alpha, Volume):
-            alpha = Volume(alpha, self.red.subject, self.red.xfmname)
+            alpha = Volume(alpha, self.red.subject, self.red.xfmname, vmin=0, vmax=1)
 
         rgb = np.array([self.red.volume, self.green.volume, self.blue.volume])
         mask = np.isnan(rgb).any(axis=0)
@@ -523,7 +523,7 @@ class VertexRGB(DataviewRGB):
             alpha = np.ones(self.red.vertices.shape[1])
             alpha = Vertex(alpha, self.red.subject, vmin=0, vmax=1)
         if not isinstance(alpha, Vertex):
-            alpha = Vertex(alpha, self.red.subject)
+            alpha = Vertex(alpha, self.red.subject, vmin=0, vmax=1)
 
         rgb = np.array([self.red.data, self.green.data, self.blue.data])
         mask = np.isnan(rgb).any(axis=0)


### PR DESCRIPTION
This should lead to a more intuitive behavior when passing an array as alpha to both `VolumeRGB` and `VertexRGB` objects.