### PR TITLE
FIX avoid registering the same colormap twice to matplotlib

### DIFF
--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -119,7 +119,7 @@ class DataviewRGB(Dataview):
             sdict['vmax'] = [255]
         return sdict
 
-    def get_cmap(self):
+    def get_cmapdict(self):
         return dict()
 
 

--- a/cortex/dataset/viewRGB.py
+++ b/cortex/dataset/viewRGB.py
@@ -119,6 +119,10 @@ class DataviewRGB(Dataview):
             sdict['vmax'] = [255]
         return sdict
 
+    def get_cmap(self):
+        return dict()
+
+
 class VolumeRGB(DataviewRGB):
     """
     Contains RGB (or RGBA) colors for each voxel in a volumetric dataset.

--- a/cortex/dataset/views.py
+++ b/cortex/dataset/views.py
@@ -192,14 +192,14 @@ class Dataview(object):
     def get_cmapdict(self):
         """Returns a dictionary with cmap information."""
 
-        from matplotlib import colors, cm, pyplot as plt
+        from matplotlib import colors, pyplot as plt
 
         try:
             # cm.get_cmap accepts:
             # - matplotlib colormap names
             # - pycortex colormap names previously registered in matplotlib
             # - matplotlib.colors.Colormap instances
-            cmap = cm.get_cmap(self.cmap)
+            cmap = plt.get_cmap(self.cmap)
         except ValueError:
             # unknown colormap, test whether it's in pycortex colormaps
             cmapdir = options.config.get('webgl', 'colormaps')
@@ -210,7 +210,7 @@ class Dataview(object):
             I = plt.imread(colormaps[self.cmap])
             cmap = colors.ListedColormap(np.squeeze(I))
             # Register colormap to matplotlib to avoid loading it again
-            cm.register_cmap(self.cmap, cmap)
+            plt.register_cmap(self.cmap, cmap)
 
         return dict(cmap=cmap, vmin=self.vmin, vmax=self.vmax)
 

--- a/cortex/dataset/views.py
+++ b/cortex/dataset/views.py
@@ -195,7 +195,7 @@ class Dataview(object):
         from matplotlib import colors, pyplot as plt
 
         try:
-            # cm.get_cmap accepts:
+            # plt.get_cmap accepts:
             # - matplotlib colormap names
             # - pycortex colormap names previously registered in matplotlib
             # - matplotlib.colors.Colormap instances

--- a/cortex/quickflat/composite.py
+++ b/cortex/quickflat/composite.py
@@ -3,7 +3,7 @@ import numpy as np
 from .. import dataset
 from ..database import db
 from ..options import config
-from .utils import _get_height, _get_extents, _convert_svg_kwargs, _has_cmap, _get_images, _parse_defaults
+from .utils import _get_height, _get_extents, _convert_svg_kwargs, _get_images, _parse_defaults
 from .utils import make_flatmap_image, _make_hatch_image, _get_fig_and_ax, get_flatmask, get_flatcache
 
 
@@ -162,7 +162,7 @@ def add_data(fig, braindata, height=1024, thick=32, depth=0.5, pixelwise=True,
     im, extents = make_flatmap_image(dataview, recache=recache, pixelwise=pixelwise, sampler=sampler,
                                      height=height, thick=thick, depth=depth, nanmean=nanmean)
     # Check whether dataview has a cmap instance
-    cmapdict = _has_cmap(dataview)
+    cmapdict = dataview.get_cmapdict()
     # Plot
     _, ax = _get_fig_and_ax(fig)
     img = ax.imshow(im,

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -247,3 +247,11 @@ def test_blend_curvature():
     # test that it returns a VertexRGB with same values when alpha is ones
     view_rgb_new = view_rgb.blend_curvature(np.ones_like(alpha))
     assert np.allclose(view_rgb.red.data, view_rgb_new.red.data)
+
+def test_get_cmapdict():
+    data0, data1 = [np.random.randn(*volshape) for _ in range(2)]
+    view = cortex.Volume2D(data0, data1, subject=subj, xfmname=xfmname)
+    cmapdict = view.get_cmapdict()
+    assert "cmap" in cmapdict and "vmin" in cmapdict and "vmax" in cmapdict
+    # test that it does not register the cmap twice to matplotlib
+    view.get_cmapdict()

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -249,9 +249,17 @@ def test_blend_curvature():
     assert np.allclose(view_rgb.red.data, view_rgb_new.red.data)
 
 def test_get_cmapdict():
-    data0, data1 = [np.random.randn(*volshape) for _ in range(2)]
-    view = cortex.Volume2D(data0, data1, subject=subj, xfmname=xfmname)
+    red, green, blue = [np.random.randn(*volshape) for _ in range(3)]
+    view = cortex.Volume2D(red, green, subject=subj, xfmname=xfmname)
+
+    # test that it returns a dict with correct keys
     cmapdict = view.get_cmapdict()
     assert "cmap" in cmapdict and "vmin" in cmapdict and "vmax" in cmapdict
-    # test that it does not register the cmap twice to matplotlib
+
+    # Calling it twice should not try to register the cmap twice to matplotlib
     view.get_cmapdict()
+
+    # VolumeRGB should return an empty dict
+    view = cortex.VolumeRGB(red, green, blue, subject=subj, xfmname=xfmname)
+    cmapdict = view.get_cmapdict()
+    assert "cmap" not in cmapdict


### PR DESCRIPTION
Pycortex raises an error with matplotlib 3.6, when it tries to register the same colormap twice. This is because the check `if self.cmap not in cm.__dict__` does not work anymore. (See recent changes to the colormaps API in matplotlib [here](https://matplotlib.org/3.6.0/api/prev_api_changes/api_changes_3.6.0.html#pending-deprecation-top-level-cmap-registration-and-access-functions-in-mpl-cm))

This PR:
- fixes how to check that the colormap is already registered
- refactors duplicated code into a new method `get_cmapdict` in `Dataview` and `DataviewRGB`
- add a test for clarity

I tested the fix with matplotlib 3.3 and 3.6.