### PR TITLE
ENH warn non-perceptually-uniform 2D colormap

### DIFF
--- a/cortex/dataset/view2D.py
+++ b/cortex/dataset/view2D.py
@@ -1,5 +1,7 @@
 import os
 import json
+import warnings
+
 import numpy as np
 
 from .. import options
@@ -62,6 +64,7 @@ class Dataview2D(Dataview):
         from matplotlib.colors import Normalize
         cmapdir = options.config.get("webgl", "colormaps")
         cmap = plt.imread(os.path.join(cmapdir, "%s.png"%self.cmap))
+        _warn_non_perceptually_uniform_colormap(self.cmap)
 
         norm1 = Normalize(self.vmin, self.vmax)
         norm2 = Normalize(self.vmin2, self.vmax2)
@@ -266,3 +269,18 @@ class Vertex2D(Dataview2D):
     @property
     def vertices(self):
         return self.raw.vertices
+
+
+def _warn_non_perceptually_uniform_colormap(cmap):
+    mapping = {
+        "BuOr_2D": "PU_BuOr_covar",
+        "BuWtRd_alpha": "RdBu_r_alpha",
+        "RdBu_covar": "PU_RdBu_covar",
+        "RdBu_covar2": "PU_BuOr_covar",
+        "RdBu_covar_alpha": "PU_RdBu_covar_alpha",
+        "RdGn_covar": "PU_RdGn_covar",
+        "hot_alpha": "fire_alpha",
+    }
+    if cmap in mapping:
+        warnings.warn("Colormap %r is not perceptually uniform. Consider using"
+                      " %r instead." % (cmap, mapping[cmap]), UserWarning)

--- a/cortex/dataset/view2D.py
+++ b/cortex/dataset/view2D.py
@@ -274,7 +274,6 @@ class Vertex2D(Dataview2D):
 def _warn_non_perceptually_uniform_colormap(cmap):
     mapping = {
         "BuOr_2D": "PU_BuOr_covar",
-        "BuWtRd_alpha": "RdBu_r_alpha",
         "RdBu_covar": "PU_RdBu_covar",
         "RdBu_covar2": "PU_BuOr_covar",
         "RdBu_covar_alpha": "PU_RdBu_covar_alpha",

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -263,3 +263,10 @@ def test_get_cmapdict():
     view = cortex.VolumeRGB(red, green, blue, subject=subj, xfmname=xfmname)
     cmapdict = view.get_cmapdict()
     assert "cmap" not in cmapdict
+
+def test_warn_non_perceptually_uniform_2D_cmap():
+    data0, data1 = [np.random.randn(*volshape) for _ in range(2)]
+    view = cortex.Volume2D(data0, data1, subject=subj, xfmname=xfmname,
+                           cmap="RdBu_covar")
+    with pytest.warns(UserWarning):
+        cortex.quickshow(view)


### PR DESCRIPTION
Add a warning for non-perceptually uniform 2D colormaps (first row in the plot) that have a clear perceptually uniform equivalent (second row in the plot). 
![image](https://user-images.githubusercontent.com/11065596/192605445-93a193c7-2201-45d7-b7a9-ed0a132df629.png)



<details>

```py
import os
import cortex
cmapdir = cortex.options.config.get("webgl", "colormaps")

#######################
# plot all 2D colormaps
cmap_list = sorted(os.listdir(cmapdir))
fig, axes = plt.subplots(4, 8, figsize=(18, 10))
axes = axes.ravel()
for ax in axes:
    ax.set_axis_off()
ii = 0
for cmap_file in cmap_list:
    cmap_img = plt.imread(os.path.join(cmapdir, cmap_file))
    if 1 not in cmap_img.shape:
        axes[ii].imshow(cmap_img)
        axes[ii].set_title(cmap_file)
        ii += 1

fig.tight_layout()
plt.show()

######################################################################
# plot 2D colormaps with a corresponding perceptually uniform colormap
mapping = {
    "BuOr_2D":"PU_BuOr_covar",
    "BuWtRd_alpha":"RdBu_r_alpha",
    "RdBu_covar": "PU_RdBu_covar",
    "RdBu_covar2":"PU_BuOr_covar",
    "RdBu_covar_alpha":"PU_RdBu_covar_alpha",
    "RdGn_covar":"PU_RdGn_covar",
    "hot_alpha":"fire_alpha",
}
fig, axes = plt.subplots(2, 8, figsize=(18, 5))
for ax in axes.ravel():
    ax.set_axis_off()
for ii, (key, val) in enumerate(mapping.items()):
    cmap_img = plt.imread(os.path.join(cmapdir, key + ".png"))
    axes[0, ii].imshow(cmap_img)
    axes[0, ii].set_title(key)
    cmap_img = plt.imread(os.path.join(cmapdir, val + ".png"))
    axes[1, ii].imshow(cmap_img)
    axes[1, ii].set_title(val)
plt.show()

```