### PR TITLE
MNT deal with some nibabel deprecation errors

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,6 +34,8 @@ jobs:
         sudo apt-get install -y inkscape
         pip install --upgrade pip
         pip install wheel numpy cython
+        # force using latest nibabel
+        pip install -U nibabel
         pip install -e . --no-build-isolation
         python -c 'import cortex; print(cortex.__full_version__)'
 

--- a/cortex/formats.pyx
+++ b/cortex/formats.pyx
@@ -189,11 +189,12 @@ def write_stl(filename, object pts, object polys):
 
 
 def write_gii(filename, object pts, object polys):
+    import nibabel
     from nibabel import gifti
     pts_darray = gifti.GiftiDataArray(pts.astype(np.float32), "pointset")
     polys_darray = gifti.GiftiDataArray(polys, "triangle")
     gii = gifti.GiftiImage(darrays=[pts_darray, polys_darray])
-    gifti.write(gii, filename)
+    nibabel.save(gii, filename)
 
 
 def write_obj(filename, object pts, object polys, object colors=None):

--- a/cortex/formats.pyx
+++ b/cortex/formats.pyx
@@ -190,8 +190,8 @@ def write_stl(filename, object pts, object polys):
 
 def write_gii(filename, object pts, object polys):
     from nibabel import gifti
-    pts_darray = gifti.GiftiDataArray.from_array(pts.astype(np.float32), "pointset")
-    polys_darray = gifti.GiftiDataArray.from_array(polys, "triangle")
+    pts_darray = gifti.GiftiDataArray(pts.astype(np.float32), "pointset")
+    polys_darray = gifti.GiftiDataArray(polys, "triangle")
     gii = gifti.GiftiImage(darrays=[pts_darray, polys_darray])
     gifti.write(gii, filename)
 

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -34,14 +34,12 @@ def test_dataset():
     ds = dataset.Dataset.from_file(tf.name)
     assert len(ds['thickstack'].data) == mask.sum()
     assert np.allclose(ds['stack'].data[mask], ds['thickstack'].data)
-    return ds
 
 def test_findmask():
     vol = np.random.rand(10, *volshape)
     mask = db.get_mask(subj, xfmname, "thin")
     ds = dataset.Volume(vol[:, mask], subj, xfmname)
     assert np.allclose(ds.volume[:, mask], vol[:, mask])
-    return ds
 
 def test_rgb():
     red, green, blue, alpha = [np.random.randn(*volshape) for _ in range(4)]
@@ -78,7 +76,6 @@ def test_2D():
     twod = cortex.Volume2D(d1, d2)
     cortex.Volume2D(d1.data, d2.data, subject=subj, xfmname=xfmname, vmin=0, vmax=2, vmin2=1)
     twod.to_json()
-    return twod
 
 def test_braindata_hash():
     d = cortex.Volume.random(subj, xfmname)

--- a/cortex/tests/test_formats.py
+++ b/cortex/tests/test_formats.py
@@ -1,0 +1,17 @@
+import os
+import tempfile
+
+import cortex
+from cortex.formats import read_gii, write_gii
+
+from numpy.testing import assert_array_equal
+
+def test_write_read_gii():
+    wm, polys = cortex.db.get_surf("S1", "wm", "lh")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fnout = os.path.join(tmpdir, "out.gii")
+        write_gii(fnout, wm, polys)
+        wm2, polys2 = read_gii(fnout)
+        assert_array_equal(wm, wm2)
+        assert_array_equal(polys, polys2)
+

--- a/cortex/tests/test_polyutils.py
+++ b/cortex/tests/test_polyutils.py
@@ -15,4 +15,4 @@ def test_surfpatch():
     surf = polyutils.Surface(wm, polys)
     subwm, subpia, subpolys = surf.extract_chunk(auxpts=pia)
     subsurf = polyutils.Surface(subwm, subpolys)
-    return [patch for patch in subsurf.patches(n=0.5)]
+    _ = [patch for patch in subsurf.patches(n=0.5)]


### PR DESCRIPTION
Fixes the most urgent issues with deprecation errors in nibabel.

We still need to change the `nibabel.get_data` to `nibabel.get_fdata`. Those will fail in Nibabel 5.0.X