### PR TITLE
FIX git URL for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To do so, replace the second install line above with the following:
 
 ```bash
 # Install development version of pycortex from github
-pip install -U git+git://github.com/gallantlab/pycortex.git  --no-build-isolation
+pip install -U git+https://github.com/gallantlab/pycortex.git  --no-build-isolation
 ```
 
 Documentation

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,7 +14,7 @@ If you wish to install the development version of pycortex, you can install it d
 To do so, replace the second install line above with the following::
 
     # Install development version of pycortex from github
-    pip install -U git+git://github.com/gallantlab/pycortex.git
+    pip install -U git+https://github.com/gallantlab/pycortex.git
 
 Optional Dependencies
 ---------------------


### PR DESCRIPTION
It looks like the unencrypted git:// protocol was deprecated: https://github.blog/2021-09-01-improving-git-protocol-security-github/

When trying to install pycortex with `pip install -U git+git://github.com/gallantlab/pycortex.git`, it tries to clone from `git://github.com/gallantlab/pycortex.git`, which hangs. If we do `pip install -U git+https://github.com/gallantlab/pycortex.git`, it is able to successfully clone from `https://github.com/gallantlab/pycortex.git`.