### PR TITLE
FIX `cortex.export.plot_panels` correctly shows inflated surfaces for subjects without a flatmap 

### DIFF
--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -106,7 +106,7 @@ def save_3d_views(
             # With a flatmap, the inflated surf corresponds to an unfold value of 0.5
             if not has_flatmap:
                 surface_params["surface.{subject}.unfold"] = min(
-                    surface_params["surface.{subject}.unfold"] + 0.5, 1
+                    surface_params["surface.{subject}.unfold"] * 2, 1
                 )
         else:
             surface_params = surface

--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -102,8 +102,8 @@ def save_3d_views(
         if isinstance(surface, str):
             surface_params = unfold_view_params[surface].copy()
             # Fix unfold parameters if this subject doesn't have a flatmap
-            # Without a flatmap, the inflated view corresponds to an unfold value of 1
-            # With a flatmap, the inflated view corresponds to an unfold value of 0.5
+            # Without a flatmap, the inflated surf corresponds to an unfold value of 1
+            # With a flatmap, the inflated surf corresponds to an unfold value of 0.5
             if not has_flatmap:
                 surface_params["surface.{subject}.unfold"] = min(
                     surface_params["surface.{subject}.unfold"] + 0.5, 1

--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -100,7 +100,7 @@ def save_3d_views(
         else:
             view_name, view_params = view
         if isinstance(surface, str):
-            surface_params = unfold_view_params[surface]
+            surface_params = unfold_view_params[surface].copy()
             # Fix unfold parameters if this subject doesn't have a flatmap
             # Without a flatmap, the inflated view corresponds to an unfold value of 1
             # With a flatmap, the inflated view corresponds to an unfold value of 0.5

--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -212,6 +212,8 @@ unfold_view_params = {
     "fiducial": {"surface.{subject}.unfold": 0,},
     "inflated_less": {"surface.{subject}.unfold": 0.25,},
     "inflated": {"surface.{subject}.unfold": 0.5,},
+    # to have an inflated view when a flatmap is not available
+    "inflated_no_flatmap": {"surface.{subject}.unfold": 1,},
     "inflated_cut": {"surface.{subject}.unfold": 0.501,},
     "flatmap": {"surface.{subject}.unfold": 1,},
 }


### PR DESCRIPTION
If a subject doesn't have a flatmap, then the unfold parameter needs to be 1 in order to get a fully inflated surface. 