### PR TITLE
FIX stop using expired deprecation for numpy 1.24

### DIFF
--- a/cortex/database.py
+++ b/cortex/database.py
@@ -222,7 +222,7 @@ class Database(object):
             return anatnib
 
         from . import volume
-        return volume.anat2epispace(anatnib.get_data().T.astype(np.float), subject, xfmname, order=order)
+        return volume.anat2epispace(anatnib.get_data().T.astype(float), subject, xfmname, order=order)
 
     def get_surfinfo(self, subject, type="curvature", recache=False, **kwargs):
         """Return auxillary surface information from the filestore. Surface info is defined as 

--- a/cortex/freesurfer.py
+++ b/cortex/freesurfer.py
@@ -555,7 +555,7 @@ def get_label(cx_subject, label, fs_subject=None, fs_dir=None, src_subject='fsav
             print("Transforming label file to subject's freesurfer directory...")
             _move_labels(fs_subject, label, hemisphere=hemisphere, fs_dir=fs_dir, src_subject=src_subject)
     verts, values = _parse_labels(label_files, cx_subject)
-    idx = verts.astype(np.int)
+    idx = verts.astype(int)
     return idx, values
 
 

--- a/cortex/polyutils/subsurface.py
+++ b/cortex/polyutils/subsurface.py
@@ -92,7 +92,7 @@ class SubsurfaceMixin(object):
         - helper method for other methods
 
         Parameters
-        -----------
+        ----------
         - vertex : one of [scalar int index | list of int indices | numpy array of int indices]
             vertex or set of vertices to use as seed
         - mask : boolean array

--- a/cortex/polyutils/subsurface.py
+++ b/cortex/polyutils/subsurface.py
@@ -66,7 +66,7 @@ class SubsurfaceMixin(object):
 
         # build map from old index to new index
         # vertices not in the subsurface are represented with large numbers
-        vertex_map = np.ones(self.pts.shape[0], dtype=np.int) * np.iinfo(np.int32).max
+        vertex_map = np.ones(self.pts.shape[0], dtype=int) * np.iinfo(np.int32).max
         vertex_map[vertex_mask] = range(vertex_mask.sum())
 
         # reindex vertices and polygons

--- a/cortex/quickflat/composite.py
+++ b/cortex/quickflat/composite.py
@@ -66,7 +66,7 @@ def add_curvature(fig, dataview, extents=None, height=None, threshold=True, cont
     if default_smoothing.lower()=='none':
         default_smoothing = None
     else:
-        default_smoothing = np.float(default_smoothing)
+        default_smoothing = np.float_(default_smoothing)
     if smooth is None:
         # (Might still be None!)
         smooth = default_smoothing
@@ -98,7 +98,7 @@ def add_curvature(fig, dataview, extents=None, height=None, threshold=True, cont
     if not legacy_mode:
         if use_threshold_curvature:
             # Assumes symmetrical curvature_lims
-            curv_im = (np.nan_to_num(curv_im) > 0.5).astype(np.float)
+            curv_im = (np.nan_to_num(curv_im) > 0.5).astype(float)
             curv_im[np.isnan(curv)] = np.nan
         # Get defaults for brightness, contrast
         if brightness is None:

--- a/cortex/surfinfo.py
+++ b/cortex/surfinfo.py
@@ -147,7 +147,9 @@ def tissots_indicatrix(outfile, sub, radius=10, spacing=50):
 
         tissots.append(tissot_array)
         allcenters.append(np.array(centers))
-
+    
+    # make an array of objects to allow different lengths for each hemisphere
+    allcenters = np.array(allcenters, dtype="object")
     np.savez(outfile, left=tissots[0], right=tissots[1], centers=allcenters)
 
 def flat_border(outfile, subject):

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -280,7 +280,7 @@ class SVGOverlay(object):
         import warnings
         warnings.warn(inkscape_cmd)
         warnings.warn(INKSCAPE_VERSION)
-        warnings.warn(height)
+        warnings.warn(str(height))
         if LooseVersion(INKSCAPE_VERSION) < LooseVersion('1.0'):
             cmd = "{inkscape_cmd} -z -h {height} -e {outfile} /dev/stdin"
         else:

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -277,6 +277,7 @@ class SVGOverlay(object):
             pngfile = png.name
 
         inkscape_cmd = config.get('dependency_paths', 'inkscape')
+        import warnings
         warnings.warn(inkscape_cmd)
         warnings.warn(INKSCAPE_VERSION)
         warnings.warn(height)

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -244,6 +244,7 @@ class SVGOverlay(object):
             self.svg.getroot().insert(0, img)
         if height is None:
             height = self.svgshape[1]
+        height = int(height)
         #label_defaults = _parse_defaults(layer+'_labels')
         
         # separate kwargs starting with "label-"
@@ -300,14 +301,13 @@ class SVGOverlay(object):
             png.seek(0)
             try:
                 im = plt.imread(png)
-                return im
             except SyntaxError as e:
                 raise RuntimeError(f"Error reading image from {pngfile}: {e}"
                                    f" (inkscape version: {INKSCAPE_VERSION})"
                                    f" (inkscape command: {inkscape_cmd})"
                                    f" (stdout: {stdout})"
                                    f" (stderr: {stderr})")
-                                        
+            return im
 
 class Overlay(object):
     """Class to represent a single layer of an SVG file

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -277,6 +277,9 @@ class SVGOverlay(object):
             pngfile = png.name
 
         inkscape_cmd = config.get('dependency_paths', 'inkscape')
+        warnings.warn(inkscape_cmd)
+        warnings.warn(INKSCAPE_VERSION)
+        warnings.warn(height)
         if LooseVersion(INKSCAPE_VERSION) < LooseVersion('1.0'):
             cmd = "{inkscape_cmd} -z -h {height} -e {outfile} /dev/stdin"
         else:
@@ -291,7 +294,7 @@ class SVGOverlay(object):
             stderr = stderr.decode()
         for line in stderr.split('\n'):
             if line != '' and 'Format autodetect failed.' not in line:
-                print(line)
+                warnings.warn(line)
 
         if background is not None:
             self.svg.getroot().remove(img)

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -277,10 +277,6 @@ class SVGOverlay(object):
             pngfile = png.name
 
         inkscape_cmd = config.get('dependency_paths', 'inkscape')
-        import warnings
-        warnings.warn(inkscape_cmd)
-        warnings.warn(INKSCAPE_VERSION)
-        warnings.warn(str(height))
         if LooseVersion(INKSCAPE_VERSION) < LooseVersion('1.0'):
             cmd = "{inkscape_cmd} -z -h {height} -e {outfile} /dev/stdin"
         else:
@@ -295,15 +291,23 @@ class SVGOverlay(object):
             stderr = stderr.decode()
         for line in stderr.split('\n'):
             if line != '' and 'Format autodetect failed.' not in line:
-                warnings.warn(line)
+                print(line)
 
         if background is not None:
             self.svg.getroot().remove(img)
 
         if name is None:
             png.seek(0)
-            im = plt.imread(png)
-            return im
+            try:
+                im = plt.imread(png)
+                return im
+            except SyntaxError as e:
+                raise RuntimeError(f"Error reading image from {pngfile}: {e}"
+                                   f" (inkscape version: {INKSCAPE_VERSION})"
+                                   f" (inkscape command: {inkscape_cmd})"
+                                   f" (stdout: {stdout})"
+                                   f" (stderr: {stderr})")
+                                        
 
 class Overlay(object):
     """Class to represent a single layer of an SVG file

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -407,7 +407,7 @@ def get_roi_mask(subject, xfmname, roi=None, projection='nearest'):
         # This is broken; unclear when/if backward mappers ever worked this way.
         #left, right = mapper.backwards(vert_mask)
         #output[name] = left + right
-        output[name] = mapper.backwards(verts.astype(np.float))
+        output[name] = mapper.backwards(verts.astype(float))
         # Threshold?
     return output
 
@@ -613,7 +613,7 @@ def get_roi_masks(subject, xfmname, roi_list=None, gm_sampler='cortical', split_
                 print("ROI {} not found...".format(roi))
             continue
         if use_mapper:
-            roi_voxels[roi] = mapper.backwards(roi_verts[roi].astype(np.float))
+            roi_voxels[roi] = mapper.backwards(roi_verts[roi].astype(float))
             # Optionally threshold probablistic values returned by mapper
             if threshold is not None:
                 roi_voxels[roi] = roi_voxels[roi] > threshold

--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -38,9 +38,9 @@ def make_base64(imgfile):
 class NPEncode(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
-            if obj.dtype == np.float:
+            if obj.dtype == float:
                 obj = obj.astype(np.float32)
-            elif obj.dtype == np.int:
+            elif obj.dtype == int:
                 obj = obj.astype(np.int32)
 
             return dict(

--- a/cortex/webgl/view.py
+++ b/cortex/webgl/view.py
@@ -709,7 +709,7 @@ def show(data, types=("inflated", ), recache=False, cmap='RdBu_r', layout=None,
                 tdif = float(t1-t0)
                 # Check whether to continue frame sequence to endpoint
                 use_endpoint = keyframes[-1]==end
-                nvalues = np.round(tdif/fs).astype(np.int)
+                nvalues = np.round(tdif/fs).astype(int)
                 if use_endpoint:
                     nvalues += 1
                 fr_time = np.linspace(0, 1, nvalues, endpoint=use_endpoint)

--- a/cortex/xfm.py
+++ b/cortex/xfm.py
@@ -109,7 +109,7 @@ class Transform(object):
         if isinstance(xfm, string_types):
             with open(xfm, 'r') as fid:
                 L = fid.readlines()
-            xfm  = np.array([[np.float(s) for s in ll.split() if s] for ll in L])
+            xfm  = np.array([[np.float_(s) for s in ll.split() if s] for ll in L])
 
         # Internally, pycortex computes the OPPOSITE transform: from anatomical volume to functional volume.
         # Thus, assign anat to "infile" (starting point for transform)
@@ -248,7 +248,7 @@ class Transform(object):
         if isinstance(fs_register, string_types):
             with open(fs_register, 'r') as fid:
                 L = fid.readlines()
-            anat2func = np.array([[np.float(s) for s in ll.split() if s] for ll in L[4:8]])
+            anat2func = np.array([[np.float_(s) for s in ll.split() if s] for ll in L[4:8]])
         else:
             anat2func = fs_register
 
@@ -263,7 +263,7 @@ class Transform(object):
         try:
             cmd = ('mri_info', '--vox2ras', anat_mgz)
             L = decode(subprocess.check_output(cmd)).splitlines()
-            anat_vox2ras = np.array([[np.float(s) for s in ll.split() if s] for ll in L])
+            anat_vox2ras = np.array([[np.float_(s) for s in ll.split() if s] for ll in L])
         except OSError:
             print ("Error occured while executing:\n{}".format(' '.join(cmd)))
             raise
@@ -381,7 +381,7 @@ def _vox2ras_tkr(image):
         # unpredictable.
         L = L[-4:]
         tkrvox2ras = np.array(
-            [[np.float(s) for s in ll.split() if s] for ll in L])
+            [[np.float_(s) for s in ll.split() if s] for ll in L])
     except OSError as e:
         print("Error occured while executing:\n{}".format(' '.join(cmd)))
         raise e


### PR DESCRIPTION
Fixes #478

Numpy 1.24 has [expired](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) some deprecation warnings and now raises errors. Here are the fixes for pycortex:

- Changes `np.int` into `int`, and `np.float` into `float` (dtype) or `np.float_` (casting function).
- Use explicitly `np.array(..., dtype="object")` to allow arrays of arrays of different lengths.