### PR TITLE
MNT use latest ubuntu and more recent actions for publishing to pypi

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -3,11 +3,11 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish to PyPI if tagged
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install pypa/build
@@ -23,6 +23,6 @@ jobs:
         --outdir dist/
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR should fix some warnings here: https://github.com/gallantlab/pycortex/actions/runs/4110667503