### PR TITLE
MNT require cython<3.0 to avoid breaking install

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
-        pip install wheel numpy cython pillow
+        pip install wheel numpy "cython<3.0" pillow
         pip install -q ipython Sphinx sphinx-gallery numpydoc
         pip install -e . --no-build-isolation
         python -c 'import cortex; print(cortex.__full_version__)'

--- a/.github/workflows/install_from_wheel.yml
+++ b/.github/workflows/install_from_wheel.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
-        pip install wheel numpy cython
+        pip install wheel numpy "cython<3.0"
 
     - name: Create the wheel
       run: python setup.py bdist_wheel

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
-        pip install wheel numpy cython
+        pip install wheel numpy "cython<3.0"
         # force using latest nibabel
         pip install -U nibabel
         pip install -e . --no-build-isolation

--- a/cortex/quickflat/utils.py
+++ b/cortex/quickflat/utils.py
@@ -1,13 +1,13 @@
 """Makes flattened views of volumetric data on the cortical surface.
 """
-from functools import reduce
 import os
-import numpy as np
 import string
 import warnings
+from functools import reduce
 
-from .. import utils
-from .. import dataset
+import numpy as np
+
+from .. import dataset, utils
 from ..database import db
 from ..options import config
 
@@ -354,8 +354,9 @@ def _make_hatch_image(hatch_data, height, sampler='nearest', hatch_space=4, reca
     return hatchim
 
 def _make_flatmask(subject, height=1024):
-    from .. import polyutils
     from PIL import Image, ImageDraw
+
+    from .. import polyutils
     pts, polys = db.get_surf(subject, "flat", merge=True, nudge=True)
     left, right = polyutils.trace_poly(polyutils.boundary_edges(polys))
 
@@ -423,8 +424,8 @@ def _make_pixel_cache(subject, xfmname, height=1024, thick=32, depth=0.5, sample
     try:
         pia, polys = db.get_surf(subject, "pia", merge=True, nudge=False)
         wm, polys = db.get_surf(subject, "wm", merge=True, nudge=False)
-        piacoords = xfm((pia[valid][dl.vertices][simps] * ll[np.newaxis].T).sum(1))
-        wmcoords = xfm((wm[valid][dl.vertices][simps] * ll[np.newaxis].T).sum(1))
+        piacoords = xfm((pia[valid][dl.simplices][simps] * ll[np.newaxis].T).sum(1))
+        wmcoords = xfm((wm[valid][dl.simplices][simps] * ll[np.newaxis].T).sum(1))
 
         valid_p = np.array([np.all((0 <= piacoords), axis=1),
                             piacoords[:,0] < xfm.shape[2],
@@ -455,7 +456,7 @@ def _make_pixel_cache(subject, xfmname, height=1024, thick=32, depth=0.5, sample
 
     except IOError:
         fid, polys = db.get_surf(subject, "fiducial", merge=True)
-        fidcoords = xfm((fid[valid][dl.vertices][simps] * ll[np.newaxis].T).sum(1))
+        fidcoords = xfm((fid[valid][dl.simplices][simps] * ll[np.newaxis].T).sum(1))
 
         valid = reduce(np.logical_and,
                        [reduce(np.logical_and, (0 <= fidcoords).T),

--- a/cortex/tests/test_formats.py
+++ b/cortex/tests/test_formats.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+import numpy as np
+
 import cortex
 from cortex.formats import read_gii, write_gii
 
@@ -8,6 +10,9 @@ from numpy.testing import assert_array_equal
 
 def test_write_read_gii():
     wm, polys = cortex.db.get_surf("S1", "wm", "lh")
+    # make sure they are int32 or nibabel will complain
+    wm = wm.astype(np.int32)
+    polys = wm.astype(np.int32)
     with tempfile.TemporaryDirectory() as tmpdir:
         fnout = os.path.join(tmpdir, "out.gii")
         write_gii(fnout, wm, polys)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 # Minimum requirements for the build system to execute, according to PEP518
 # specification.
-requires = ["numpy", "cython", "setuptools", "wheel"]
+requires = ["numpy", "cython<3.0", "setuptools", "wheel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ lxml
 html5lib
 h5py
 numexpr
-cython
+cython<3.0
 matplotlib
 pillow
 nibabel>=2.1


### PR DESCRIPTION
Cython 3.0 was released a couple of days ago, and it introduces changes that break our install process. For now we can just fix the issue by requiring cython < 3.0. In the long run, we may want to adapt our cythonized code.

Closes #490 