### PR TITLE
FIX check if shapes exist before setting the labels in the WebGL viewer

### DIFF
--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -894,7 +894,7 @@ def gen_path(path):
     verts, codes = [], []
     mode, pen = None, np.array([0.,0.])
 
-    it = iter(path.get('d').split(' '))
+    it = iter(path.get('d').strip().split(' '))
     run = True
     while run:
         try:

--- a/cortex/webgl/resources/js/svgoverlay.js
+++ b/cortex/webgl/resources/js/svgoverlay.js
@@ -242,9 +242,12 @@ var svgoverlay = (function(module) {
 	}
 
         var shapes = layer.parentNode.getElementById(this.name+"_shapes");
-        for (var i = 0 ; i < shapes.children.length; i++) {
-            var name = shapes.children[i].getAttribute("inkscape:label");
-            this.shapes[name] = shapes.children[i];
+        // check if shapes is not null
+        if (shapes != null) {
+            for (var i = 0 ; i < shapes.children.length; i++) {
+                var name = shapes.children[i].getAttribute("inkscape:label");
+                this.shapes[name] = shapes.children[i];
+            }
         }
 
         var labels = layer.parentNode.getElementById(this.name+"_labels");


### PR DESCRIPTION
I'm having some issues with loading some very old overlay files. Without the fix in the javascript part, the viewer does not even load. The fix in `svgoverlay.py` is still a work in progress. It fails creating splines for paths such as the following

```
M 612.125 549.625 C 606.51441 549.71551 601.02784 550.65202 596.09375 553 C 589.17538 556.29224 581.97592 562.54109 580.6875 570.09375 C 579.79889 575.30273 580.38513 580.34214 581.84375 585.28125 C 595.21597 595.86604 617.82389 619.97107 616.0625 634.59375 C 615.59786 638.45112 613.76677 641.15406 611.125 643.1875 C 611.24105 643.44807 611.35059 643.70914 611.46875 643.96875 C 614.40667 650.42362 617.18423 652.68087 618.625 659.625 C 619.66885 664.65608 614.83353 672.68837 618.625 676.15625 C 624.39758 681.43616 633.04748 677.01176 638.75 671.65625 C 645.59411 665.22862 647.98061 657.99084 648.8125 649.90625 C 645.7223 646.27481 642.78306 642.19423 639.96875 637.53125 C 637.01433 632.63612 641.5484 627.65256 647.0625 623.15625 C 644.96214 618.76146 642.40742 614.35976 644.625 610.9375 C 647.11354 607.09708 653.35619 607.32934 657.84375 605.53125 C 658.27778 602.14541 659.22061 598.88351 660.71875 596.09375 C 662.40156 592.9601 665.39419 591.22625 668.8125 589.90625 C 670.38848 584.22044 670.27093 578.19798 667.71875 573.03125 C 660.39833 558.21155 645.04481 554.46213 628.8125 551.34375 C 623.44636 550.31286 617.73559 549.53449 612.125 549.625 z
```

I think `gen_path` in https://github.com/gallantlab/pycortex/blob/2a9a5bc05ca5062ff02c42a8cc50ea14779bafc8/cortex/svgoverlay.py#L907-L916 is expecting commas after the `C` mode.