### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ ctm = Extension('cortex.openctm', [
             'OpenCTM-1.0.3/lib/liblzma/LzmaDec.c',
             'OpenCTM-1.0.3/lib/liblzma/LzmaEnc.c',
             'OpenCTM-1.0.3/lib/liblzma/LzmaLib.c',], 
-            libraries=['m'], include_dirs=[
+            libraries=[], include_dirs=[
             'OpenCTM-1.0.3/lib/', 
             'OpenCTM-1.0.3/lib/liblzma/'] + get_numpy_include_dirs(),
             define_macros=[


### PR DESCRIPTION
Removing 'm' from libraries = ['m'] to deal with error ->error LINK1181: cannot open file 'm.lib'.

Sources:
https://github.com/coreylynch/pyFM/issues/18
https://stackoverflow.com/questions/19333898/lnk1181-cannot-open-input-file-m-lib

This error prevents users from building wheel for pycortex. pip install works after change.