### PR TITLE
ENH sort subject list and improve repr of transforms

### DIFF
--- a/cortex/database.py
+++ b/cortex/database.py
@@ -105,7 +105,8 @@ class XfmDB(object):
         raise AttributeError
     
     def __repr__(self):
-        return "Transforms: [{xfms}]".format(xfms=",".join(self.xfms))
+        xfms = "\n".join(sorted(self.xfms))
+        return f"Available transforms for {self.subject}:\n{xfms}"
 
 class XfmSet(object):
     def __init__(self, subj, name, filestore=default_filestore):
@@ -178,6 +179,7 @@ class Database(object):
             return self._subjects
         subjs = os.listdir(os.path.join(self.filestore))
         subjs = [s for s in subjs if os.path.isdir(os.path.join(self.filestore, s))]
+        subjs = sorted(subjs)
         self._subjects = dict([(sname, SubjectDB(sname, filestore=self.filestore)) for sname in subjs])
         return self._subjects
 


### PR DESCRIPTION
Maybe this problem was a problem only for me. But I always hated how the transforms were listed in the `__repr__`, as it wasn't really easy to understand what transforms were available for a subject.

Before the PR they would be listed as

```
>>> cortex.db.subjects["fsaverage"].transforms
Transforms: [atlas,atlas336,atlas_2mm,atlas_3mm]
```
which is fine for a few transforms, but it becomes quickly unreadable if one has many transforms.

After this PR they are listed as
```
>>> cortex.db.subjects["fsaverage"].transforms
Available transforms for fsaverage:
atlas
atlas336
atlas_2mm
atlas_3mm
```

This PR also sorts the subjects when running `cortex.db` and `cortex.db.subjects`. The unsorted subjects also bugged me in the past.