### PR TITLE
FIX,MNT import surfaces generated from volumes with any voxel size

### DIFF
--- a/cortex/freesurfer.py
+++ b/cortex/freesurfer.py
@@ -235,6 +235,11 @@ def import_subj(
             # Use the --to-scanner flag to store the surfaces with the same coordinate
             # system as the volume data, rather than the TKR coordinate system, which
             # has the center set to FOV/2.
+            # NOTE: the resulting gifti surfaces will look misaligned with respect to
+            # the anatomical volumes when visualized in freeview, because freeview 
+            # expects the surfaces to be in TKR coordinates (with center set to FOV/2).
+            # But the surfaces stored in the pycortex database are only to be used by
+            # pycortex, so that's fine.
             cmd = f"mris_convert --to-scanner {in_surface} {out_surface}"
             sp.check_output(shlex.split(cmd))
 


### PR DESCRIPTION
This PR fixes the bug first described in #300. Pycortex always assumed that the surfaces were generated out of T1s with 1mm3 isotropic voxel size. If one imported surfaces generated from other volumes (e.g., sub-mm), then the surfaces would be misaligned (see example in #300). To fix this issue, here I'm simply importing and converting the surfaces to gifti with Freesurfer's `mris_convert --to-scanner`, which uses the same coordinate system as the T1 rather than the TKR system used for surfaces. 

This change produces the same surfaces as the old code for 1mm3 volumes. I'm waiting for freesurfer to finish on a sub-mm volume to test it there too.

(This PR also cleans up the code in that function a bit to make it easier to maintain...)