### PR TITLE
NF Add functions to project volume data to surface while dealing with NaNs.

### DIFF
--- a/cortex/mapper/__init__.py
+++ b/cortex/mapper/__init__.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from .. import dataset
 from .mapper import Mapper, _savecache
+from .utils import nanproject, vol2surf
 
 
 def get_mapper(subject, xfmname, type='nearest', recache=False, **kwargs):

--- a/cortex/mapper/utils.py
+++ b/cortex/mapper/utils.py
@@ -116,7 +116,7 @@ def vol2surf(
     # Select only voxels in the thick mask
     voxel2fsnative = [vfs[:, mask] for vfs in voxel2fsnative]
     if target_surface == "native":
-        data_projected = nanproject(data, voxel2fsnative)
+        data_projected = nanproject(data, scipy.sparse.vstack(voxel2fsnative))
     else:
         fsnative2fsaverage = cortex.db.get_mri_surf2surf_matrix(
             subject, "fiducial", fs_subj=subject_freesurfer, target_subj=target_surface

--- a/cortex/mapper/utils.py
+++ b/cortex/mapper/utils.py
@@ -1,0 +1,131 @@
+import cortex
+import numpy as np
+import scipy
+
+
+def nanproject(data, mapper, reweigh=True):
+    """Project data using the passed mapper while dealing with NaNs.
+
+    Parameters
+    ----------
+    data : array-like (n_voxels,) or (n_samples, n_voxels)
+        The data to be projected.
+    mapper : sparse matrix (n_vertices, n_voxels)
+    reweigh : bool
+        Whether to reweigh the mapper after dealing with NaNs. (Mostly for debugging,
+        this should be left to True).
+
+    Returns
+    -------
+    data_projected : array-like (n_vertices, ) or (n_samples, n_vertices)
+        The projected data.
+    """
+    is_1d = False
+    if data.ndim == 1:
+        data = np.atleast_2d(data)
+        is_1d = True
+    if data.ndim > 2:
+        raise ValueError("Only one-dimensional or two-dimensional data are allowed")
+    # First zero-out nans
+    good = ~(np.any(np.isnan(data), axis=0))
+    n_voxels = data.shape[1]
+    # make diagonal sparse matrix with mask
+    good_sparse = scipy.sparse.csr_matrix(
+        (good.astype(float), (np.arange(n_voxels), np.arange(n_voxels)))
+    )
+    # zero-out voxels with nans
+    good_mapper = mapper.dot(good_sparse)
+    # change data in rows
+    if reweigh:
+        # now convert to lil to reweigh everything
+        good_mapper = good_mapper.tolil()
+        # take only rows with data to be used
+        rows_to_change = np.where(good_mapper.sum(1) > 0.0)[0]
+        for row in rows_to_change:
+            sum_row = sum(good_mapper.data[row])
+            good_mapper.data[row] = [dt / sum_row for dt in good_mapper.data[row]]
+        # convert back to csr
+        good_mapper = good_mapper.tocsr()
+    # project -- mapper is (n_vertices, n_voxels), data is (n_samples, n_voxels)
+    data_projected = good_mapper.dot(data.T).T
+    # set vertices receiving only nans to nan
+    bad = (~good).astype(float)
+    bad_vertex = np.abs(mapper.dot(bad) - 1.0) < 1e-09
+    data_projected[:, bad_vertex] = np.nan
+    if is_1d:
+        data_projected = data_projected[0]
+    return data_projected
+
+
+def vol2surf(
+    data,
+    subject,
+    xfm_name,
+    target_surface="native",
+    mask_name="thick",
+    mapper="line_nearest",
+    subject_freesurfer=None,
+):
+    """Project a subject's volumetric data to a target surface.
+
+    Parameters
+    ----------
+    data : array (n_voxels,) or (n_samples, n_voxels)
+        The flattened volumetric data.
+    subject : str
+        Subject name.
+    xfm_name : str
+        Transform name.
+    mask_name : str
+        Mask to use for the projection. Default is "thick". It should match the
+        `n_voxels`.
+    target_surface : str
+        Surface to project the data to. Default is "native", corresponding to the 
+        participant's surface. Alternatives are "fsaverage", "fsaverage6", "fsaverage5",
+        or other freesurfer participant codes.
+    mapper : str
+        Type of mapper to go from volume to the native surface of the subject.
+        Just use `line_nearest` if in doubt.
+    subject_freesurfer : str or None
+        Freesurfer's subject name. If None, it will be the same as `subject`.
+
+    Returns
+    -------
+    data_projected : array (n_vertices,) or (n_samples, n_vertices)
+        The projected data.
+
+    Notes
+    -----
+    This function averages only non-NaN values. It should be equivalent to nanmean=True
+    in pycortex's quickflat.
+    """
+    if data.ndim == 1:
+        axis = 0
+    elif data.ndim == 2:
+        axis = 1
+    else:
+        raise ValueError(
+            "This function works only with 1-dimensional or 2-dimensional arrays."
+        )
+    if subject_freesurfer is None:
+        subject_freesurfer = subject
+    # Get pycortex's mapper to go from volume to fsnative
+    voxel2fsnative = cortex.get_mapper(subject, xfm_name, mapper).masks
+    mask = cortex.db.get_mask(subject, xfm_name, type=mask_name).ravel()
+    assert mask.sum() == data.shape[axis]
+    # Select only voxels in the thick mask
+    voxel2fsnative = [vfs[:, mask] for vfs in voxel2fsnative]
+    if target_surface == "native":
+        data_projected = nanproject(data, voxel2fsnative)
+    else:
+        fsnative2fsaverage = cortex.db.get_mri_surf2surf_matrix(
+            subject, "fiducial", fs_subj=subject_freesurfer, target_subj=target_surface
+        )
+        # Compute projection from volume to fsaverage by combining
+        # voxel2fsnative -> fsnative2fsaverage
+        voxel2fsaverage = scipy.sparse.vstack(
+            [m1.dot(m2) for m1, m2 in zip(fsnative2fsaverage, voxel2fsnative)]
+        )
+        # Project data
+        data_projected = nanproject(data, voxel2fsaverage)
+    return data_projected


### PR DESCRIPTION
These new functions can be used to project data from the volume to any arbitrary surface via a combination of pycortex mappers and `mri_surf2surf`. The projection deals with nans similar to quickshow and `nanproject=True`.

Example code:
```python
import cortex
from cortex.mapper import vol2surf
import numpy as np

subject = ...  # anonymized
xfm = ...  # anonymized

vol = cortex.Volume.random(subject, xfm, mask="thick")
mask = cortex.db.get_mask(subject, xfm)
data = vol.data[mask]
data[np.random.randn(*data.shape) > 0] = np.nan

new_volume = cortex.Volume(data, subject, xfm, mask="thick")
surface = cortex.Vertex(vol2surf(data, subject, xfm), subject)
fsaverage = cortex.Vertex(vol2surf(data, subject, xfm, target_surface="fsaverage"), "fsaverage")

fig = cortex.quickshow(new_volume, with_colorbar=False, with_curvature=True, with_rois=False, with_labels=False, nanmean=False,)
fig.suptitle("volume, nanmean=False", fontsize=24)
fig = cortex.quickshow(new_volume, with_colorbar=False, with_curvature=True, with_rois=False, with_labels=False, nanmean=True,)
fig.suptitle("volume, nanmean=True", fontsize=24)
fig = cortex.quickshow(surface, with_colorbar=False, with_curvature=True, with_rois=False, with_labels=False,)
fig.suptitle("vol2surf", fontsize=24)
fig = cortex.quickshow(fsaverage, with_colorbar=False, with_curvature=True, with_rois=False, with_labels=False,)
fig.suptitle("fsaverage", fontsize=24)
```

Outputs:
<img width="600" alt="image" src="https://github.com/gallantlab/pycortex/assets/6150554/0724b55e-06bd-490d-b5ab-f322c6945ab5">
<img width="600" alt="image" src="https://github.com/gallantlab/pycortex/assets/6150554/4673a736-6b5b-4245-b1c1-0655e56e2910">
<img width="600" alt="image" src="https://github.com/gallantlab/pycortex/assets/6150554/5613a367-b860-43f3-ae72-5646cd878249">
<img width="600" alt="image" src="https://github.com/gallantlab/pycortex/assets/6150554/c47ad559-6c0c-4fb3-9ad5-af2f1607c642">

