### PR TITLE
FIX avoid using jQuery for getting numpy arrays

### DIFF
--- a/cortex/webgl/data.py
+++ b/cortex/webgl/data.py
@@ -21,12 +21,14 @@ class Package(object):
     """Package the data into a form usable by javascript"""
     def __init__(self, data):
         self.dataset = dataset.normalize(data)
-        self.uniques = data.uniques(collapse=True)
+        self.uniques = list(data.uniques(collapse=True))
+        self.subjects = set()
         
         self.brains = dict()
         self.images = dict()
         for brain in self.uniques:
             name = brain.name
+            self.subjects.add(brain.subject)
             self.brains[name] = brain.to_json(simple=True)
             if isinstance(brain, (dataset.Vertex, dataset.VertexRGB)):
                 encdata = brain.vertices
@@ -59,10 +61,6 @@ class Package(object):
                 meta['attrs']['stim'] = os.path.split(meta['attrs']['stim'])[1] 
             metadata.append(meta)
         return metadata
-
-    @property
-    def subjects(self):
-        return set(braindata.subject for braindata in self.uniques)
 
     def reorder(self, subjects):
         indices = dict((k, np.load(os.path.splitext(v)[0]+".npz")) for k, v in subjects.items())

--- a/cortex/webgl/resources/js/datamodel.js
+++ b/cortex/webgl/resources/js/datamodel.js
@@ -152,7 +152,6 @@ NParray.fromURL = function(url, callback) {
             var length = array.dtype.BYTES_PER_ELEMENT * array.size;
             var increment = array._slice * array.dtype.BYTES_PER_ELEMENT || length;
             var offset = 10 + headerLength;
-            var offset = nbytes + 10;
             Stream(url, length, increment, offset).progress(array.update.bind(array)).done(hideload);
         } else if (xhr.status == 200) { 
             // Server doesn't support partial data, returned the whole thing


### PR DESCRIPTION
This was a nasty 🪲. To visualize a Vertex/VertexRGB object in a static viewer, the `NParray.fromURL` method in `datamodel.js` was using jQuery to fetch the numpy array with the data. However, jQuery by default serializes any type of data and so the binary buffer was automatically encoded as a string. This automatic serialization caused issues when a float32 array was saved (see below for an example.)

This PR completely rewrites the `NParray.fromURL` method to use an `XMLHttpRequest` instead of jQuery. In this way the buffer can be fetched as an arraybuffer, and all the portions of the buffer (header/data) can be decoded appropriately.

## Example code

```python
import cortex

vtx = cortex.Vertex.random("fsaverage")
cortex.webgl.make_static(
    outpath="test-viewer",
    data=vtx,
    recache=True,
)
```

```bash
python minimal-example-error.py && cd test-viewer && python -m http.server 23423
```

### Before
![image](https://github.com/gallantlab/pycortex/assets/6150554/68c38980-0bc8-47fa-990d-43a953155a57)


### After
![image](https://github.com/gallantlab/pycortex/assets/6150554/18837f96-49cc-47b6-8a5c-680d0e735bf4)
