### PR TITLE
MNT Remove dependency on distutils

### DIFF
--- a/.github/workflows/install_from_wheel.yml
+++ b/.github/workflows/install_from_wheel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
       max-parallel: 5
 
     steps:

--- a/.github/workflows/install_from_wheel.yml
+++ b/.github/workflows/install_from_wheel.yml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
-        pip install build wheel numpy "cython<3.0"
+        pip install setuptools build wheel numpy "cython<3.0"
 
     - name: Create the wheel
       run: python setup.py bdist_wheel

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
       max-parallel: 5
 
     steps:

--- a/cortex/svgoverlay.py
+++ b/cortex/svgoverlay.py
@@ -11,7 +11,7 @@ from matplotlib.path import Path
 from scipy.spatial import cKDTree
 from builtins import zip, str
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 from lxml import etree
 from lxml.builder import E

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -9,7 +9,7 @@ import tarfile
 import tempfile
 import urllib.request
 import warnings
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from importlib import import_module
 
 import h5py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute, according to PEP518
 # specification.
-requires = ["setuptools<60.0", "build", "numpy", "cython<3.0", "wheel"]
+requires = ["setuptools", "build", "numpy", "cython<3.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.codespell]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pillow
 nibabel>=2.1
 networkx>=2.1
 imageio
+looseversion

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import os
 from glob import glob
-from numpy.distutils.misc_util import get_numpy_include_dirs
+import numpy
 
 try:
     import configparser
@@ -78,10 +78,10 @@ ctm = Extension('cortex.openctm', [
             'OpenCTM-1.0.3/lib/liblzma/LzFind.c',
             'OpenCTM-1.0.3/lib/liblzma/LzmaDec.c',
             'OpenCTM-1.0.3/lib/liblzma/LzmaEnc.c',
-            'OpenCTM-1.0.3/lib/liblzma/LzmaLib.c',], 
+            'OpenCTM-1.0.3/lib/liblzma/LzmaLib.c',],
             libraries=['m'], include_dirs=[
-            'OpenCTM-1.0.3/lib/', 
-            'OpenCTM-1.0.3/lib/liblzma/'] + get_numpy_include_dirs(),
+            'OpenCTM-1.0.3/lib/',
+            'OpenCTM-1.0.3/lib/liblzma/', numpy.get_include()],
             define_macros=[
                 ('LZMA_PREFIX_CTM', None),
                 ('OPENCTM_BUILD', None),
@@ -89,7 +89,7 @@ ctm = Extension('cortex.openctm', [
             ]
         )
 formats = Extension('cortex.formats', ['cortex/formats.pyx'],
-                    include_dirs=get_numpy_include_dirs())
+                    include_dirs=[numpy.get_include()])
 
 DISTNAME = 'pycortex'
 # VERSION needs to be modified under cortex/version.py


### PR DESCRIPTION
This should remove any explicit mentions of `distutils` and fix installation in Python 3.12.

I'm not super familiar with the packaging system, so there's 2 things I'm not sure about:
 * Does anything else need to be done to address #538 ?
 * Does setuptools still need to be pinned to `<60.0` ? It looks like this was done to fix #552, but the [NumPy migration docs](https://numpy.org/doc/stable/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools) suggest this is only if you're using `numpy.distutils` (which this PR removes).