### PR TITLE
Clipping sliceplanes

### DIFF
--- a/cortex/webgl/resources/js/dataset.js
+++ b/cortex/webgl/resources/js/dataset.js
@@ -83,6 +83,18 @@ var dataset = (function(module) {
         this.uniforms = {
             framemix:   { type:'f',   value:0},
             dataAlpha:  { type:'f', value:1.0},
+
+            slicexn:     { type:'v3', value:new THREE.Vector3( 0,0,0 )},
+            sliceyn:     { type:'v3', value:new THREE.Vector3( 0,0,0 )},
+            slicezn:     { type:'v3', value:new THREE.Vector3( 0,0,0 )},
+
+            slicexc:     { type:'v3', value:new THREE.Vector3( 0,0,0 )},
+            sliceyc:     { type:'v3', value:new THREE.Vector3( 0,0,0 )},
+            slicezc:     { type:'v3', value:new THREE.Vector3( 0,0,0 )},
+
+            doslicex:   { type:'i', value:false},
+            doslicey:   { type:'i', value:false},
+            doslicez:   { type:'i', value:false},
         }
 
         if (!this.vertex) {

--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -49,6 +49,9 @@ var mriview = (function(module) {
             y: new sliceplane.Plane(this, 1),
             z: new sliceplane.Plane(this, 2),
         };
+        this._clipx = false;
+        this._clipy = false;
+        this._clipz = false;
 
         this.ui = new jsplot.Menu();
         this.ui.addEventListener("update", this.schedule.bind(this));
@@ -1164,6 +1167,18 @@ var mriview = (function(module) {
             rotate_z: {action:[this.sliceplanes.z, 'setAngle', -89, 89]}
         });
 
+        var sliceplane_clip = sliceplane_ui.addFolder("clip", true);
+        sliceplane_clip.add({
+            clip_x: {action:[this, "setClippingX"]},
+            flip_x: {action:[this.sliceplanes.x, "setFlip"]},
+            clip_y: {action:[this, "setClippingY"]},
+            flip_y: {action:[this.sliceplanes.y, "setFlip"]},
+            clip_z: {action:[this, "setClippingZ"]},
+            flip_z: {action:[this.sliceplanes.z, "setFlip"]},
+        })
+
+        //
+
         if ($(this.object).find("#colormap_category").length > 0) {
             $(this.object).find("#colormap").ddslick({ width:296, height:350,
                 onSelected: function() {
@@ -1294,6 +1309,39 @@ var mriview = (function(module) {
         this.sliceplanes.z.setVisible(!this.sliceplanes.z._visible);
         viewer.schedule();
     };
+    module.Viewer.prototype.setClippingX = function(val) {
+        if (val === undefined)
+            return this._clipx;
+
+        this._clipx = val;
+
+        if (this.active !== undefined) {
+            this.active.uniforms.doslicex.value = this._clipx;
+        }
+        this.schedule();
+    }
+    module.Viewer.prototype.setClippingY = function(val) {
+        if (val === undefined)
+            return this._clipy;
+
+        this._clipy = val;
+
+        if (this.active !== undefined) {
+            this.active.uniforms.doslicey.value = this._clipy;
+        }
+        this.schedule();
+    }
+    module.Viewer.prototype.setClippingZ = function(val) {
+        if (val === undefined)
+            return this._clipz;
+
+        this._clipz = val;
+
+        if (this.active !== undefined) {
+            this.active.uniforms.doslicez.value = this._clipz;
+        }
+        this.schedule();
+    }
 
     return module;
 }(mriview || {}));

--- a/cortex/webgl/resources/js/shaderlib.js
+++ b/cortex/webgl/resources/js/shaderlib.js
@@ -363,6 +363,18 @@ var Shaderlib = (function() {
             "uniform int bumpyflat;",
             "float f_bumpyflat = float(bumpyflat);",
 
+            "uniform vec3 slicexn;",
+            "uniform vec3 sliceyn;",
+            "uniform vec3 slicezn;",
+
+            "uniform vec3 slicexc;",
+            "uniform vec3 sliceyc;",
+            "uniform vec3 slicezc;",
+
+            "uniform bool doslicex;",
+            "uniform bool doslicey;",
+            "uniform bool doslicez;",
+
             "attribute vec4 wm;",
             "attribute vec3 wmnorm;",
             "attribute vec4 auxdat;",
@@ -379,6 +391,8 @@ var Shaderlib = (function() {
             "varying float vCurv;",
             "varying float vMedial;",
             "varying float vThickmix;",
+            "varying float vSliced;",
+            "varying vec3 vWorldPosition;",
             // "varying float vDrop;",
 
             "varying vec3 vPos_x[2];",
@@ -421,6 +435,8 @@ var Shaderlib = (function() {
                 "vMedial = auxdat.x;",
                 "vCurv = auxdat.y;",
 
+                //"vSliced = float(mpos.y > slicey) * float(doslicey);",
+
                 "vec3 pos, norm;",
                 "mixfunc(mpos, mnorm, pos, norm);",
 
@@ -443,6 +459,10 @@ var Shaderlib = (function() {
                 "#endif",
 
                 "gl_Position = projectionMatrix * modelViewMatrix * vec4( pos, 1.0 );",
+
+                "vWorldPosition = pos;",
+
+                //"vSliced = float( ((dot(pos - sliceyc, sliceyn) > 0.0) && bool(doslicey)) || ((dot(pos - slicexc, slicexn) > 0.0) && bool(doslicex)) );",
 
             "}"
             ].join("\n");
@@ -477,6 +497,18 @@ var Shaderlib = (function() {
             "uniform vec2 dshape[2];",
             "uniform sampler2D data[4];",
 
+            "uniform vec3 slicexn;",
+            "uniform vec3 sliceyn;",
+            "uniform vec3 slicezn;",
+
+            "uniform vec3 slicexc;",
+            "uniform vec3 sliceyc;",
+            "uniform vec3 slicezc;",
+
+            "uniform bool doslicex;",
+            "uniform bool doslicey;",
+            "uniform bool doslicez;",
+
             // "uniform float hatchAlpha;",
             // "uniform vec3 hatchColor;",
             // "uniform sampler2D hatch;",
@@ -489,6 +521,8 @@ var Shaderlib = (function() {
             "varying float vCurv;",
             "varying float vMedial;",
             "varying float vThickmix;",
+            "varying float vSliced;",
+            "varying vec3 vWorldPosition;",
             
             utils.standard_frag_vars,
             utils.rand,
@@ -501,6 +535,21 @@ var Shaderlib = (function() {
                 //Curvature Underlay
                 "float ctmp = clamp(vCurv / smoothness, -0.5, 0.5);", // use limits here too
                 "float curv = clamp(ctmp * contrast + brightness, 0.0, 1.0);",
+                //"if (vSliced > 0.5) discard;",
+                
+                "bool clipx = dot(vWorldPosition - slicexc, slicexn) > 0.0;",
+                "bool clipy = dot(vWorldPosition - sliceyc, sliceyn) > 0.0;",
+                "bool clipz = dot(vWorldPosition - slicezc, slicezn) > 0.0;",
+
+                "if (clipx && doslicex && !doslicey && !doslicez) discard;",
+                "if (clipy && !doslicex && doslicey && !doslicez) discard;",
+                "if (clipz && !doslicex && !doslicey && doslicez) discard;",
+                "if (clipx && clipy && doslicex && doslicey && !doslicez) discard;",
+                "if (clipx && clipz && doslicex && !doslicey && doslicez) discard;",
+                "if (clipy && clipz && !doslicex && doslicey && doslicez) discard;",
+                "if (clipx && clipy && clipz && doslicex && doslicey && doslicez) discard;",
+                //"if( ((dot(vWorldPosition - sliceyc, sliceyn) > 0.0) && bool(doslicey)) && ((dot(vWorldPosition - slicexc, slicexn) > 0.0) && bool(doslicex)) && ((dot(vWorldPosition - slicezc, slicezn) > 0.0) && bool(doslicez)) ) discard;",
+                
                 "vec4 cColor = vec4(vec3(curv), 1.0);", 
 
                 "vec3 coord_x, coord_y;",


### PR DESCRIPTION
This adds the option to clip the brain surface at sliceplanes. This enables simultaneous viewing of surface and deeper subcortical data. (Although to make this really useful we might need a way to have different datasets visible on the surface and sliceplanes, perhaps?)

It adds a new submenu, `clip`, under `sliceplanes`, with boolean toggles for `clip_{x,y,z}` and `flip_{x,y,z}`. The clip toggles hide the surface on one side of the sliceplane, and flip toggles switch which side that is. The sliceplanes can be moved and rotated as normal.

Here's a small script that you can run to test (it works better if you use a subject where the `brainmask.nii.gz` volume is available unlike the default subject S1; in that case replace `'raw'` with `'brainmask'`):
```python
import numpy as np
import cortex

subject = "S1"
anatdata = cortex.db.get_anat(subject, 'raw').get_fdata().T
anatdata[anatdata < 5] = np.nan
anatvol = cortex.Volume(anatdata, subject, 'identity')

cortex.webshow(anatvol)
```

I've also attached a screenshot of what it looks like with a subject where the masked brain is available.
<img width="1328" alt="Screen Shot 2024-10-17 at 15 01 44" src="https://github.com/user-attachments/assets/806db9f6-e6e3-4840-9654-fb9f95a641c2">

I haven't tested how this works with vertex data or RGB data or really anything but what you see. It's a start, anyway :)

