### PR TITLE
feat: add config option for uniform lighting

### DIFF
--- a/cortex/defaults.cfg
+++ b/cortex/defaults.cfg
@@ -124,6 +124,7 @@ filter = url(#dropshadow)
 voxlines = false
 voxline_color = #FFFFFF
 voxline_width = 0.01
+uniform_illumination = false  # Overwrites emissive, specular, and diffuse to have uniform lighting
 specularity = 1.0
 overlayscale = 1
 anim_speed = 2

--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -76,6 +76,13 @@ var mriview = (function(module) {
             }
         ]);
 
+        // Update uniform values based on the uniform illumination option
+        if (viewopts.uniform_illumination == 'true') {
+            this.uniforms.diffuse.value.set(0, 0, 0); // Set diffuse to 0
+            this.uniforms.specular.value.set(0, 0, 0); // Set specular to 0
+            this.uniforms.emissive.value.set(1, 1, 1); // Set emissive to 1
+        }
+
         this.ui = (new jsplot.Menu()).add({
             unfold: {action:[this, "setMix", 0., 1.]},
             pivot: {action:[this, "setPivot", -180, 180]},


### PR DESCRIPTION
Discussed in #560, this adds a simple option to enforce uniform lighting (no shadows or specularity) within pycortex webgl viewers. This is turned on by adding `uniform_illumination = true` to the user config file.

This option is set to `false` by default, so lighting should remain as it currently is unless this option is changed to `true`.