### PR TITLE
Python 3.13 compatibility, and upgrade to Cython 3

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
-        pip install wheel numpy "cython<3.0" pillow
+        pip install wheel numpy cython
         pip install -q ipython Sphinx sphinx-gallery numpydoc
         pip install -e . --no-build-isolation
         python -c 'import cortex; print(cortex.__full_version__)'

--- a/.github/workflows/install_from_wheel.yml
+++ b/.github/workflows/install_from_wheel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
       max-parallel: 5
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
-        pip install setuptools build wheel numpy "cython<3.0"
+        pip install setuptools build wheel numpy cython
 
     - name: Create the wheel
       run: python setup.py bdist_wheel

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
       max-parallel: 5
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y inkscape
         pip install --upgrade pip
-        pip install wheel setuptools numpy "cython<3.0"
+        pip install wheel setuptools numpy cython
         # force using latest nibabel
         pip install -U nibabel
         pip install -e . --no-build-isolation

--- a/cortex/blender/__init__.py
+++ b/cortex/blender/__init__.py
@@ -2,7 +2,7 @@ import os
 import re
 import shlex
 import shutil
-import xdrlib
+import mda_xdrlib as xdrlib
 import tempfile
 import subprocess as sp
 

--- a/cortex/blender/blendlib.py
+++ b/cortex/blender/blendlib.py
@@ -2,7 +2,7 @@
 It provides utility functions for adding meshes and saving them to communicate with the rest of pycortex
 """
 import struct
-import xdrlib
+import mda_xdrlib as xdrlib
 import tempfile
 
 import bpy.ops

--- a/cortex/openctm.pyx
+++ b/cortex/openctm.pyx
@@ -2,7 +2,7 @@ import sys
 import numpy as np
 
 cimport cython
-cimport openctm
+from . cimport openctm
 cimport numpy as np
 
 uvmaps = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute, according to PEP518
 # specification.
-requires = ["setuptools", "build", "numpy", "cython<3.0", "wheel"]
+requires = ["setuptools", "build", "numpy", "cython", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,4 @@ build-backend = "setuptools.build_meta"
 skip = '.git,*.pdf,*.svg,*.css,*.min.*,*.gii,resources,OpenCTM-1.0.3,filestore,build,_build'
 check-hidden = true
 # ignore-regex = ''
-ignore-words-list = 'nd,acount,anormal,fpt,coo,transpart,FO'
+ignore-words-list = 'nd,acount,anormal,fpt,coo,transpart,FO,lins'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ nibabel>=2.1
 networkx>=2.1
 imageio
 looseversion
+mda_xdrlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ lxml
 html5lib
 h5py
 numexpr
-cython<3.0
+cython
 matplotlib
 pillow
 nibabel>=2.1

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ ctm = Extension('cortex.openctm', [
             define_macros=[
                 ('LZMA_PREFIX_CTM', None),
                 ('OPENCTM_BUILD', None),
+                ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),
                 #('__DEBUG_', None),
             ]
         )


### PR DESCRIPTION
It managed to compile on Python 3.12 and 3.13 and run through the tests, but I haven't checked if the webviewer still works yet.

This should fix #563 .