### PR TITLE
FIX deprecated ndarray.tostring() -> tobytes()

### DIFF
--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -628,7 +628,7 @@ class _masker(object):
 
 def _hash(array):
     '''A simple numpy hash function'''
-    return hashlib.sha1(array.tostring()).hexdigest()
+    return hashlib.sha1(array.tobytes()).hexdigest()
 
 def _hdf_write(h5, data, name="data", group="/data"):
     try:

--- a/cortex/formats.pyx
+++ b/cortex/formats.pyx
@@ -184,7 +184,7 @@ def write_stl(filename, object pts, object polys):
     data['f1'] = pts[polys].reshape(-1, 9)
     with open(filename, 'wb') as fp:
         fp.write(struct.pack('80xI', len(polys)))
-        fp.write(data.tostring())
+        fp.write(data.tobytes())
 
 
 

--- a/cortex/freesurfer.py
+++ b/cortex/freesurfer.py
@@ -422,8 +422,8 @@ def write_surf(filename, pts, polys, comment=''):
         fp.write(b'\xff\xff\xfe')
         fp.write((comment+'\n\n').encode())
         fp.write(struct.pack('>2I', len(pts), len(polys)))
-        fp.write(pts.astype(np.float32).byteswap().tostring())
-        fp.write(polys.astype(np.uint32).byteswap().tostring())
+        fp.write(pts.astype(np.float32).byteswap().tobytes())
+        fp.write(polys.astype(np.uint32).byteswap().tobytes())
         fp.write(b'\n')
 
 
@@ -961,7 +961,7 @@ def write_decimated(path, pts, polys):
     with open(path+'.full.patch.3d', 'w') as fp:
         fp.write(struct.pack('>i', -1))
         fp.write(struct.pack('>i', len(dpts)))
-        fp.write(data.tostring())
+        fp.write(data.tobytes())
 
 
 class SpringLayout(object):

--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -47,7 +47,7 @@ class NPEncode(json.JSONEncoder):
                 __class__="NParray",
                 dtype=obj.dtype.descr[0][1], 
                 shape=obj.shape, 
-                data=binascii.b2a_base64(obj.tostring()).decode('utf-8'))
+                data=binascii.b2a_base64(obj.tobytes()).decode('utf-8'))
         elif isinstance(obj, (np.int64, np.int32, np.int16, np.int8,
                               np.uint64, np.uint32, np.uint16, np.uint8)):
             return int(obj)


### PR DESCRIPTION
Changed all instances of ndarray.tostring() to ndarray.tobytes() for compatibility with NumPy 2.3, which removed the deprecated tostring() method.