### PR TITLE
Blender flattening support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/_build
 docs/auto_examples
 docs/generated
 docs/colormaps.rst
+
+# Python virtual environment
+.venv

--- a/cortex/blender/__init__.py
+++ b/cortex/blender/__init__.py
@@ -5,6 +5,7 @@ import shutil
 import mda_xdrlib as xdrlib
 import tempfile
 import subprocess as sp
+import site
 
 import numpy as np
 
@@ -16,30 +17,76 @@ from .. import utils
 default_blender = options.config.get('dependency_paths', 'blender')
 
 _base_imports = """import sys
-sys.path.insert(0, '{path}')
-import xdrlib
+for site_dir in {site_dirs}:
+    print("Adding python site directory to sys.path:", site_dir)
+    sys.path.insert(0, site_dir)
+
+import mda_xdrlib as xdrlib
 import blendlib
 import bpy.ops
 from bpy import context as C
 from bpy import data as D
-""".format(path=os.path.split(os.path.abspath(__file__))[0])
+""".format(site_dirs=[
+    os.path.split(os.path.abspath(__file__))[0],
+    *site.getsitepackages(),
+])
 
-def _call_blender(filename, code, blender_path=default_blender):
-    """Call blender, while running the given code. If the filename doesn't exist, save a new file in that location.
+
+def _wrap_code(code, filename):
+    """
+    Wrap code for running in blender
+
+    Parameters
+    ----------
+    code : str
+        code to run in blender
+    filename : str
+        file path for blender file (must end in ".blend")
+    """
+    wrapped_code = _base_imports
+    if not os.path.exists(filename):
+        wrapped_code += "blendlib.clear_all()\n"
+    wrapped_code += code
+    wrapped_code += "\nbpy.ops.wm.save_mainfile(filepath='{fname}')".format(fname=filename)
+    return wrapped_code
+
+
+def _call_blender(filename, code=None, background=True, blender_path=default_blender):
+    """
+    Call blender, while running the given code. If the filename doesn't exist, save a new file in that location.
     New files will be initially cleared by deleting all objects.
+
+    Parameters
+    ----------
+    filename : str
+        file path for blender file (must end in ".blend")
+    code : str, optional
+        code to run in blender. If None, blender will be opened without running any code.
+    background : bool, optional
+        If True, blender will be opened in background mode.
+    blender_path : str, optional
+        Path to blender executable. If None, defaults to the path specified in pycortexconfig file.
     """
     with tempfile.NamedTemporaryFile() as tf:
         print("In new named temp file: %s"%tf.name)
-        startcode = _base_imports
-        endcode = "\nbpy.ops.wm.save_mainfile(filepath='{fname}')".format(fname=filename)
-        cmd = "{blender_path} -b {fname} -P {tfname}".format(blender_path=blender_path, fname=filename, tfname=tf.name)
-        if not os.path.exists(filename):
-            startcode += "blendlib.clear_all()\n"
-            cmd = "{blender_path} -b -P {tfname}".format(blender_path=blender_path, tfname=tf.name)
-        else:
+
+        # Backup
+        if os.path.exists(filename):
             _legacy_blender_backup(filename, blender_path=blender_path)
-        tf.write((startcode+code+endcode).encode())
-        tf.flush()
+
+        # Construct command
+        cmd = blender_path
+        if background:
+            cmd += " -b"
+        if os.path.exists(filename):
+            cmd += " " + filename
+        if code is not None:
+            wrapped_code = _wrap_code(code, filename)
+            tf.write(wrapped_code.encode())
+            tf.flush()
+            cmd += " -P {tfname}".format(tfname=tf.name)
+
+        print(f"Calling blender:\n    {cmd}")
         sp.check_call([w.encode() for w in shlex.split(cmd)],)
 
 
@@ -97,7 +144,7 @@ def _legacy_blender_backup(fname, blender_path=default_blender):
                 shutil.copy(fname, fname_bkup)
 
 
-def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh="hemi", blender_path=default_blender):
+def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh="hemi", blender_path=None):
     """Add data as vertex colors to blender mesh
     
     Useful to add localizer data for help in placing flatmap cuts
@@ -117,6 +164,8 @@ def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh=
     mesh : string
         ...
     """
+    blender_path = blender_path or default_blender
+
     if isinstance(braindata, dataset.Dataset):
         for view_name, data in braindata.views.items():
             add_cutdata(fname, data, name=view_name, projection=projection, mesh=mesh)
@@ -162,10 +211,12 @@ def add_cutdata(fname, braindata, name="retinotopy", projection="nearest", mesh=
     return 
 
 
-def gii_cut(fname, subject, hemi, blender_path=default_blender):
+def gii_cut(fname, subject, hemi, blender_path=None):
     '''
     Add gifti surface to blender
     '''
+    blender_path = blender_path or default_blender
+
     from ..database import db
     hemis = dict(lh='left',
                  rh='right')
@@ -194,16 +245,24 @@ def gii_cut(fname, subject, hemi, blender_path=default_blender):
         _call_blender(fname, code, blender_path=blender_path)
 
 
-def fs_cut(fname, subject, hemi, freesurfer_subject_dir=None, blender_path=default_blender):
-    """Cut freesurfer surface using blender interface
+def fs_cut_init(fname, subject, hemi, freesurfer_subject_dir=None, blender_path=None):
+    """Initialize a blender object from a freesurfer volume.
 
     Parameters
     ----------
     fname : str
         file path for new .blend file (must end in ".blend")
-
-    if `freesurfer_subject_dir` is None, it defaults to SUBJECTS_DIR environment variable
+    subject : str
+        subject name
+    hemi : str
+        hemisphere name (lh or rh)
+    freesurfer_subject_dir : str
+        path to freesurfer subject directory. If None, it defaults to SUBJECTS_DIR environment variable
+    blender_path : str
+        path to blender executable. If None, it defaults to the path specified in pycortexconfig file.
     """
+    blender_path = blender_path or default_blender
+    
     wpts, polys, curv = freesurfer.get_surf(subject, hemi, 'smoothwm', freesurfer_subject_dir=freesurfer_subject_dir)
     ipts, _, _ = freesurfer.get_surf(subject, hemi, 'inflated', freesurfer_subject_dir=freesurfer_subject_dir)
     rcurv = np.clip(((-curv + .6) / 1.2), 0, 1)
@@ -225,8 +284,29 @@ def fs_cut(fname, subject, hemi, freesurfer_subject_dir=None, blender_path=defau
         """.format(tfname=tf.name)
         _call_blender(fname, code, blender_path=blender_path)
 
+
+def fs_cut_open(fname, blender_path=None):
+    """Open a blender file in blender for the manual cut
+
+    Parameters
+    ----------
+    fname : str
+        file path for blender file (must end in ".blend")
+    blender_path : str
+        path to blender executable. If None, it defaults to the path specified in pycortexconfig file.
+    """
+    blender_path = blender_path or default_blender
+    
+    _call_blender(fname, background=False, blender_path=blender_path)
+
+
 def write_patch(bname, pname, mesh="hemi", blender_path=default_blender):
-    """Write out the mesh 'mesh' in the blender file 'bname' into patch file 'pname'
+    """Deprecated: please use write_volume_patch instead"""
+    return write_volume_patch(bname, pname, "hemi", mesh, blender_path)
+
+
+def write_volume_patch(bname, pname, hemi, mesh="hemi", blender_path=None):
+    """Write volume patch in freesurfer format.
     This is a necessary step for flattening the surface in freesurfer
 
     Parameters
@@ -235,11 +315,18 @@ def write_patch(bname, pname, mesh="hemi", blender_path=default_blender):
         blender file name that contains the mesh
     pname : str
         name of patch file to be saved
+    hemi : str
+        hemisphere name (lh or rh)
     mesh : str
         name of mesh in blender file
+    blender_path : str, optional
+        path to blender executable. If None, it defaults to the path specified in pycortexconfig file.
     """
+    blender_path = blender_path or default_blender
+
     p = xdrlib.Packer()
     p.pack_string(pname.encode())
+    p.pack_string(hemi.encode())
     p.pack_string(mesh.encode())
     with tempfile.NamedTemporaryFile() as tf:
         tf.write(p.get_buffer())
@@ -247,8 +334,49 @@ def write_patch(bname, pname, mesh="hemi", blender_path=default_blender):
         code = """with open('{tfname}', 'rb') as fp:
             u = xdrlib.Unpacker(fp.read())
             pname = u.unpack_string().decode('utf-8')
+            hemi = u.unpack_string().decode('utf-8')
             mesh = u.unpack_string().decode('utf-8')
-            blendlib.save_patch(pname, mesh)
+            blendlib.write_volume_patch(pname, hemi, mesh)
         """.format(tfname=tf.name)
         _call_blender(bname, code, blender_path=blender_path)
+    return True
 
+def write_flat_patch(bname, pname, hemi, mesh="hemi", method="MINIMUM_STRETCH", blender_path=None):
+    """Write flat patch in freesurfer format.
+    This is a necessary step for flattening the surface in freesurfer
+
+    Parameters
+    ----------
+    bname : str
+        blender file name that contains the mesh
+    pname : str
+        name of patch file to be saved
+    hemi : str
+        hemisphere name (lh or rh)
+    mesh : str
+        name of mesh in blender file
+    method : str
+        method to use for UV unwrap. One of 'CONFORMAL', 'ANGLE_BASED', 'MINIMUM_STRETCH'.
+    blender_path : str, optional
+        path to blender executable. If None, it defaults to the path specified in pycortexconfig file.
+    """
+    blender_path = blender_path or default_blender
+
+    p = xdrlib.Packer()
+    p.pack_string(pname.encode())
+    p.pack_string(hemi.encode())
+    p.pack_string(mesh.encode())
+    p.pack_string(method.encode())
+    with tempfile.NamedTemporaryFile() as tf:
+        tf.write(p.get_buffer())
+        tf.flush()
+        code = """with open('{tfname}', 'rb') as fp:
+            u = xdrlib.Unpacker(fp.read())
+            pname = u.unpack_string().decode('utf-8')
+            hemi = u.unpack_string().decode('utf-8')
+            mesh = u.unpack_string().decode('utf-8')
+            method = u.unpack_string().decode('utf-8')
+            blendlib.write_flat_patch(pname, hemi, mesh, method)
+        """.format(tfname=tf.name)
+        _call_blender(bname, code, blender_path=blender_path)
+    return True

--- a/cortex/blender/blendlib.py
+++ b/cortex/blender/blendlib.py
@@ -1,9 +1,14 @@
-"""This module is intended to be imported directly by blender.
-It provides utility functions for adding meshes and saving them to communicate with the rest of pycortex
+"""
+This module is intended to be imported directly by blender.
+It provides utility functions for adding meshes and saving them to communicate with the rest of pycortex.
+
+Read more about Blender Python API here: https://docs.blender.org/api/current/index.html.
 """
 import struct
 import mda_xdrlib as xdrlib
 import tempfile
+import time
+import math
 
 import bpy.ops
 from bpy import context as C
@@ -131,7 +136,7 @@ def add_shapekey(shape, name=None):
         key.data[i].co = shape[i]
     return key
 
-def write_patch(filename, pts, edges=None):
+def _write_patch(filename, pts, edges=None):
     """Writes a patch file that is readable by freesurfer.
     
     Parameters
@@ -154,8 +159,56 @@ def write_patch(filename, pts, edges=None):
                 fp.write(struct.pack('>i3f', -i-1, *pt))
             else:
                 fp.write(struct.pack('>i3f', i+1, *pt))
+    print("Wrote freesurfer patch to %s"%filename)
 
-def _get_pts_edges(mesh):
+def _circularize_uv_coords(pts, u_min, u_max, v_min, v_max):
+    """Transform UV coordinates into a circular shape while preserving relative positions.
+    
+    Parameters
+    ----------
+    pts : dict
+        Dictionary mapping vertex indices to (u, v, z) coordinates
+    u_min, u_max, v_min, v_max : float
+        Original bounds of the UV coordinates
+        
+    Returns
+    -------
+    dict
+        Dictionary mapping vertex indices to new (u, v, z) coordinates
+    """
+    # Convert to normalized coordinates in [-1, 1] range
+    u_center = (u_max + u_min) / 2
+    v_center = (v_max + v_min) / 2
+    u_scale = (u_max - u_min) / 2
+    v_scale = (v_max - v_min) / 2
+    
+    new_pts = {}
+    for idx, (u, v, z) in pts.items():
+        # Normalize coordinates
+        u_norm = (u - u_center) / u_scale
+        v_norm = (v - v_center) / v_scale
+        
+        # Convert to polar coordinates
+        r = math.sqrt(u_norm**2 + v_norm**2)
+        theta = math.atan2(v_norm, u_norm)
+        
+        # Normalize radius to create perfect circle
+        # Use square root to preserve area/density
+        r = math.sqrt(r)
+        
+        # Convert back to Cartesian coordinates
+        u_new = r * math.cos(theta)
+        v_new = r * math.sin(theta)
+        
+        # Scale back to original range
+        u_new = u_new * u_scale + u_center
+        v_new = v_new * v_scale + v_center
+        
+        new_pts[idx] = (u_new, v_new, z)
+    
+    return new_pts
+
+def _get_geometry(mesh, hemi, flatten, method=None):
     """Function called within blender to get non-cut vertices & edges
 
     Operates on a mesh object within an open instance of blender. 
@@ -164,10 +217,26 @@ def _get_pts_edges(mesh):
     ----------
     mesh : str
         name of mesh to cut
+    hemi : str
+        hemisphere name (lh or rh)
+    flatten : bool
+        if True, returns flattened coordinates using UV unwrap
+    method : str
+        method to use for UV unwrap. One of 'CONFORMAL', 'ANGLE_BASED', 'MINIMUM_STRETCH'.
+
+    Returns
+    -------
+    verts : set
+        set of vertex indices
+    pts : list
+        list of (vertex_index, flattened_coordinates) tuples
+    edges : set
+        set of edge vertex indices
     """
     if isinstance(mesh, str):
         mesh = D.meshes[mesh]
 
+    # Collect edge vertex indices
     bpy.ops.object.mode_set(mode='OBJECT')
     bpy.ops.object.mode_set(mode='EDIT')
     bpy.ops.mesh.select_all(action='DESELECT')
@@ -175,30 +244,33 @@ def _get_pts_edges(mesh):
     bpy.ops.mesh.select_non_manifold()
     bpy.ops.object.mode_set(mode='OBJECT')
 
-    mwall_edge = set()
+    edge_vertex_idxs = set()  # Medial wall in standard case
     for edge in mesh.edges:
         if edge.select:
-            mwall_edge.add(edge.vertices[0])
-            mwall_edge.add(edge.vertices[1])
+            edge_vertex_idxs.add(edge.vertices[0])
+            edge_vertex_idxs.add(edge.vertices[1])
 
+    # Collect seam vertex indices & select seams
     bpy.ops.object.mode_set(mode='EDIT') 
     C.tool_settings.mesh_select_mode = True, False, False
     bpy.ops.mesh.select_all(action='DESELECT')
     bpy.ops.object.mode_set(mode='OBJECT')
-    seam = set()
+    seam_vertex_idxs = set()
     for edge in mesh.edges:
         if edge.use_seam:
-            seam.add(edge.vertices[0])
-            seam.add(edge.vertices[1])
+            seam_vertex_idxs.add(edge.vertices[0])
+            seam_vertex_idxs.add(edge.vertices[1])
             edge.select = True
 
+    # Expand seam selection & collect expanded vertex indices
     bpy.ops.object.mode_set(mode='EDIT') 
     bpy.ops.mesh.select_more()
     bpy.ops.object.mode_set(mode='OBJECT')
-    smore = set()
+    expanded_seam_vertex_idxs = set()
     for i, vert in enumerate(mesh.vertices):
         if vert.select:
-            smore.add(i)
+            expanded_seam_vertex_idxs.add(i)
+
     # Leave cuts (+ area around them) selected.
     # Uncomment the next lines to revert to previous behavior
     # (deselecting everything)
@@ -206,26 +278,93 @@ def _get_pts_edges(mesh):
     # bpy.ops.mesh.select_all(action='DESELECT')
     # bpy.ops.object.mode_set(mode='OBJECT')
 
-    fverts = set()
-    if hasattr(mesh, "polygons"):
-        faces = mesh.polygons
-    else:
-        faces = mesh.faces
-    for face in faces:
-        fverts.add(face.vertices[0])
-        fverts.add(face.vertices[1])
-        fverts.add(face.vertices[2])
+    face_vertices = set()
+    for face in getattr(mesh, "polygons", getattr(mesh, "faces", None)):
+        face_vertices.add(face.vertices[0])
+        face_vertices.add(face.vertices[1])
+        face_vertices.add(face.vertices[2])
 
-    print("exported %d faces"%len(fverts))
-    edges = mwall_edge | (smore - seam)
-    verts = fverts - seam
+    verts = face_vertices - seam_vertex_idxs
     pts = [(v, D.shape_keys['Key'].key_blocks['inflated'].data[v].co) for v in verts]
+    edges = edge_vertex_idxs | (expanded_seam_vertex_idxs - seam_vertex_idxs)
+
+    if flatten:
+        # Scales
+        u_coords, v_coords = [u for _, (u, _, _) in pts], [v for _, (_, v, _) in pts]
+        u_min, u_max, v_min, v_max = min(u_coords), max(u_coords), min(v_coords), max(v_coords)
+        print("u_min: %f, u_max: %f, v_min: %f, v_max: %f"%(u_min, u_max, v_min, v_max))
+
+        if not mesh.uv_layers:
+            mesh.uv_layers.new(name="FlattenUV")
+        
+        print("UV unwrapping mesh with method %s (may take a few minutes)..."%method)
+        start = time.time()
+        bpy.ops.object.mode_set(mode='EDIT')
+        bpy.ops.mesh.select_all(action='SELECT')
+        bpy.ops.uv.unwrap(method=method, margin=0.001)
+        bpy.ops.object.mode_set(mode='OBJECT')
+        end = time.time()
+        print("UV unwrapping mesh took %.1f seconds" % (end - start))
+        
+        print("Collecting coordinates for %d verts..."%len(verts))
+        start = time.time()
+        pts = {}
+        for loop in mesh.loops:
+            if loop.vertex_index in verts:
+                coords2d = mesh.uv_layers.active.data[loop.index].uv
+                u_scaled = coords2d[0] * (u_max - u_min) + u_min
+                v_scaled = coords2d[1] * (v_max - v_min) + v_min
+                
+                if hemi == "rh":
+                    # Rotate 180 degrees clockwise
+                    u_center = (u_max + u_min) / 2
+                    v_center = (v_max + v_min) / 2
+                    u_rotated = 2 * u_center - u_scaled
+                    v_rotated = 2 * v_center - v_scaled
+                    pts[loop.vertex_index] = (u_rotated, v_rotated, 0.0)
+                else:
+                    pts[loop.vertex_index] = (u_scaled, v_scaled, 0.0)
+        
+        # Circularize the UV coordinates
+        print("Circularizing UV coordinates...")
+        pts = _circularize_uv_coords(pts, u_min, u_max, v_min, v_max)
+        
+        pts = sorted(pts.items(), key=lambda x: x[0])
+        end = time.time()
+        print("Collecting coordinates took %.1f seconds" % (end - start))
+
+    print("Collected geometry. verts: %d, pts: %d, edges: %d"%(len(verts), len(pts), len(edges)))
     return verts, pts, edges
 
-def save_patch(fname, mesh='hemi'):
-    """Saves patch to file that can be read by freesurfer"""
-    verts, pts, edges = _get_pts_edges(mesh)
-    write_patch(fname, pts, edges)
+
+def save_patch(fname, mesh="hemi"):
+    """Deprecated: please use write_volume_patch instead"""
+    return write_volume_patch(fname, "lh", mesh)
+
+
+def write_volume_patch(fname, hemi, mesh="hemi"):
+    """Write mesh patch in freesurfer format"""
+    _, pts, edges = _get_geometry(mesh, hemi, flatten=False)
+    _write_patch(fname, pts, edges)
+
+
+def write_flat_patch(fname, hemi, mesh="hemi", method="MINIMUM_STRETCH"):
+    """Write flat patch in freesurfer format
+    
+    Parameters
+    ----------
+    fname : str
+        Output filename
+    hemi : str
+        hemisphere name (lh or rh)
+    mesh : str
+        Name of the mesh to flatten
+    method : str
+        UV unwrapping method to use
+    """
+    _, pts, edges = _get_geometry(mesh, hemi, flatten=True, method=method)
+    _write_patch(fname, pts, edges)
+
 
 def read_xdr(filename):
     with open(filename, "rb") as fp:

--- a/cortex/freesurfer.py
+++ b/cortex/freesurfer.py
@@ -283,6 +283,9 @@ def import_flat(fs_subject, patch, hemis=['lh', 'rh'], cx_subject=None,
         List of hemispheres to import. Defaults to both hemispheres.
     cx_subject : str
         Pycortex subject name
+    flat_type : str
+        Type of flatmap to import. Defaults to 'freesurfer'.
+        Can be 'freesurfer', 'slim', or 'blender'.
     freesurfer_subject_dir : str
         directory for freesurfer subjects. None defaults to environment variable
         $SUBJECTS_DIR
@@ -308,15 +311,19 @@ def import_flat(fs_subject, patch, hemis=['lh', 'rh'], cx_subject=None,
 
     from . import formats
     for hemi in hemis:
-        if flat_type == 'freesurfer':
-            pts, polys, _ = get_surf(fs_subject, hemi, "patch", patch+".flat", freesurfer_subject_dir=freesurfer_subject_dir)
-            # Reorder axes: X, Y, Z instead of Y, X, Z
-            flat = pts[:, [1, 0, 2]]
-            # Flip Y axis upside down
-            flat[:, 1] = -flat[:, 1]
+        if flat_type in ['freesurfer', 'blender']:
+            surf_path = (patch + ".flat") if (flat_type == 'freesurfer') else (patch + ".flat.blender")
+            pts, polys, _ = get_surf(fs_subject, hemi, "patch", surf_path, freesurfer_subject_dir=freesurfer_subject_dir)
+
+            if flat_type == 'freesurfer':
+                # Reorder axes: X, Y, Z instead of Y, X, Z
+                flat = pts[:, [1, 0, 2]]
+                # Flip Y axis upside down
+                flat[:, 1] = -flat[:, 1]
+            else:
+                flat = pts
         elif flat_type == 'slim':
-            flat_file = get_paths(fs_subject, hemi, type='slim',
-                                  freesurfer_subject_dir=freesurfer_subject_dir)
+            flat_file = get_paths(fs_subject, hemi, type='slim', freesurfer_subject_dir=freesurfer_subject_dir)
             flat_file = flat_file.format(name=patch + ".flat")
             flat, polys = formats.read_obj(flat_file)
 

--- a/cortex/segment.py
+++ b/cortex/segment.py
@@ -155,7 +155,7 @@ def cut_surface(cx_subject, hemi, name='flatten', fs_subject=None, data=None,
         Name of Freesurfer subject directory. None defaults to SUBJECTS_DIR
         environment variable
     flatten_with : str
-        'freesurfer' or 'SLIM' - 'freesurfer' (default) uses freesurfer's 
+        One of 'freesurfer','SLIM', or 'blender' - 'freesurfer' (default) uses freesurfer's 
         `mris_flatten` function to flatten the cut surface. 'SLIM' uses
         the SLIM algorithm, which takes much less time but tends to leave
         more distortions in the flatmap. SLIM is an optional dependency, and 

--- a/examples/quickstart/fmri_flattening.ipynb
+++ b/examples/quickstart/fmri_flattening.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Functional MRI pial flattening in 20 minutes\n",
+    "\n",
+    "This notebook demonstrates how to use PyCortex to:\n",
+    "1. Cut and flatten brain surfaces in under 20 minutes;\n",
+    "2. Preview flattened surface in under 10 seconds;\n",
+    "3. Visualize BOLD fMRI data on the flattened surfaces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "You will need to run auto"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 1. Reconcile subject's anatomy with Freesurfer\n",
+    "\n",
+    "Make sure you have fully reconciled the subject's. Detailed guidance is out of scope for this notebook, but roughly you should've run these lines:\n",
+    "\n",
+    "```\n",
+    "recon-all -autorecon1 -s sub-01\n",
+    "recon-all -autorecon2 -s sub-01\n",
+    "recon-all -autorecon3 -s sub-01\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2. Install Python dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cortex\n",
+    "import nibabel as nib\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Align Function MRI to Anatomical\n",
+    "\n",
+    "`cortex.align.automatic` perform automatic alignment using Freesurfer's boundary-based registration. It is fully automated. This should take ~1 minute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bold_nii_gz_path = \"path to bold.nii.gz\"\n",
+    "cortex.align.automatic(\n",
+    "    subject=\"sub-01\",\n",
+    "    xfmname=\"full\",\n",
+    "    reference=bold_nii_gz_path,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Surface Cutting and Flattening\n",
+    "\n",
+    "`cortex.segment.cut_surface` performs surface cutting. It is semi-automatic, meaning it requires a bit of manual work. It will start Blender for us to manually specify the cuts. Make sure Blender is installed on your system.\n",
+    "\n",
+    "#### A. Left hemisphere\n",
+    "\n",
+    "Let's start with the left hemisphere.\n",
+    "\n",
+    "Please follow [this guide](https://www.youtube.com/watch?v=D4tylQ_mMuM) on cuts. This will take ~15 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cortex.segment.cut_surface(\n",
+    "    \"sub-01\",\n",
+    "    \"lh\",\n",
+    "    name=\"exp\",\n",
+    "    flatten_with=\"blender\",\n",
+    "    method=\"CONFORMAL\",\n",
+    "    recache=True,\n",
+    "    do_import_subject=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### B. Right hemisphere\n",
+    "\n",
+    "Then repeat the same for the right hemisphere.\n",
+    "\n",
+    "This will take another ~5 minutes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Right hemisphere\n",
+    "cortex.segment.cut_surface(\n",
+    "    \"sub-01\",\n",
+    "    \"rh\",\n",
+    "    name=\"exp\",\n",
+    "    flatten_with=\"blender\",\n",
+    "    method=\"CONFORMAL\",\n",
+    "    recache=True,\n",
+    "    auto_overwrite=True,\n",
+    "    do_import_subject=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Visualize fMRI\n",
+    "\n",
+    "Now we'll load the BOLD fMRI data and prepare it for visualization. We'll compute the temporal mean of the BOLD signal to create a static visualization.\n",
+    "\n",
+    "Then we can use `cortex.quickshow` to visualize the BOLD data on the flattened surfaces using pycortex.\n",
+    "\n",
+    "This will take 30 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load functional data\n",
+    "bold_path = \"path to bold.nii.gz\"\n",
+    "img = nib.load(bold_path)\n",
+    "data = img.get_fdata()\n",
+    "\n",
+    "# Compute temporal mean\n",
+    "mean_vol = np.mean(data, axis=3)\n",
+    "\n",
+    "# Transpose to match expected orientation (96,96,76) → (76,96,96)\n",
+    "mean_vol = np.transpose(mean_vol, (2, 0, 1))\n",
+    "\n",
+    "# Select cuboid\n",
+    "cuboid = np.array([[0, 20, 0], [50, 70, 70]])  # (2, 3) as a pair of (min, max) voxels\n",
+    "print(mean_vol.shape)\n",
+    "cuboid_slice = tuple(slice(*span) for span in cuboid.transpose())\n",
+    "mean_vol_filtered = np.zeros_like(mean_vol)\n",
+    "mean_vol_filtered[cuboid_slice] = mean_vol[cuboid_slice]\n",
+    "mean_vol = mean_vol_filtered\n",
+    "\n",
+    "\n",
+    "# Create Volume object for visualization\n",
+    "vol = cortex.Volume(\n",
+    "    mean_vol,\n",
+    "    subject=\"sub-01\",\n",
+    "    depth=1,\n",
+    "    height=512,\n",
+    "    xfmname=\"full\",\n",
+    "    vmin=np.min(mean_vol),\n",
+    "    vmax=np.max(mean_vol),\n",
+    ")\n",
+    "\n",
+    "# Display the visualization\n",
+    "cortex.quickshow(vol, with_colorbar=True, recache=True)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
### What

This PR adds a 3rd mode of flattening that is based on Blender's UV unwrap. This mode will reduce time to flatten while producing decent quality unwraps.

- [x] Implemented flattening logic that uses conformal UV unwrap in `cortex.blender.blendlib.py`. It follows the same selection as for the volume mesh. This is accessible via `write_flat_patch`.
  - To avoid confusion between the new flat patch `write_flat_patch` and the old one, renamed `save_patch` into `write_volume_patch`.
  - Renamed `_get_pts_edges` into `_get_geometry` for clarity. Added clarifying logging and elapsed time tracking. Extended docstring.
- [x] Fix for Python 3.13+: allow blender access Python site directory to search for `mda_xdrlib` that was removed from Python 3.13.
- [x] Refactored `cortex.blender._call_blender to support non-code calls to Blender to reduces confusion and improves code clarity. Refactored `fs_cut` into `fs_cut_init` and added a new `fs_cut_open` to improve clarity. Extended docstring.
- [x] Rewrote `cut_surface` for clarity. Onboarded to `recache` flag to support forced generation.
- [x] Record a tutorial video walking users through the process of cutting. Should follow the gallantlab.org approach to cutting.
- [x] Add python notebook for the end-to-end rendering of fMRI.
- [x] Update docs with the guidance.
  - Fixed the existing docs confusing `”` and `"` which may result into code examples not running properly.
- [ ] Address the PR feedback.

### Why

While `freesurfer` mode has been used for a long time, it lacks debuggability and may require a number of iterations and a degree of patience in order to get things working. The new mode is added to timebox the flattening process by making it faster and more predictable by leveraging UV unwrap preview in Blender.

### [Tutorial video](https://www.youtube.com/watch?v=D4tylQ_mMuM)

As different labs may approach cuts slightly differently, created and edited a [tutorial video](https://www.youtube.com/watch?v=D4tylQ_mMuM) instruction that follows the style of gallantlab.org. The used anatomy was taken from [Horikawa, T., Cowen, A. S., Keltner, D., & Kamitani, Y. (2020). The neural representation of visually evoked emotion is high-dimensional, categorical, and distributed across transmodal brain regions.](https://www.sciencedirect.com/science/article/pii/S2589004220302455?ref=pdf_download&fr=RR-2&rr=95089e98cee0f79b).

### Docs update

Added a new section on the cuts. When rendered looks as follows:

<img width="472" alt="image" src="https://github.com/user-attachments/assets/3179cfe2-bf1f-4319-9784-0a10cba0c35b" />
