### PR TITLE
Update braindata.py

### DIFF
--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -628,7 +628,7 @@ class _masker(object):
 
 def _hash(array):
     '''A simple numpy hash function'''
-    return hashlib.sha1(array.tostring()).hexdigest()
+    return hashlib.sha1(array.tobytes()).hexdigest()
 
 def _hdf_write(h5, data, name="data", group="/data"):
     try:


### PR DESCRIPTION
in the _hash function, the deprecated tostring() function was used to hash the array. Changed to tobytes() and seems to produce a reasonable hash.  Tested, and now produces a working webgl rendering, where it threw an error before.