### PR TITLE
FIX pickerfun Python callback

### DIFF
--- a/cortex/webgl/mixer.html
+++ b/cortex/webgl/mixer.html
@@ -13,6 +13,12 @@
         figure = new jsplot.W2Figure();
         viewer = figure.add(mriview.Viewer, "main", true);
 
+        {% if python_interface %}
+        PickPosition.prototype.callback = function(vec, hemi, ptidx) {
+            $.get("/picker?voxel=" + vec.x + "," + vec.y + "," + vec.z + "&vertex=" + ptidx + "&hemi=" + hemi);
+        };
+        {% end %}
+
         dataviews = dataset.fromJSON({{data}});
         viewer.addData(dataviews);
 

--- a/cortex/webgl/resources/js/facepick.js
+++ b/cortex/webgl/resources/js/facepick.js
@@ -248,10 +248,6 @@ PickPosition.prototype = {
             this.callback(vec, hemi, ptidx);
     },
 
-    callback: function(vec, hemi, ptidx) {
-        $.get("/picker?voxel=" + vec.x + "," + vec.y + "," + vec.z + "&vertex=" + ptidx + "&hemi=" + hemi);
-    },
-
     process_nonpick: function() {
         for (var i = 0; i < this.axes.length; i++) {
             this.markers[this.axes[i].hemi].remove(this.axes[i].group);


### PR DESCRIPTION
This restores the old jQuery mechanism from 77a24b58e00a8e0ecdc9a04342a6a3c225e22e22 . I don't know what the pros/cons are of this versus the `notify` mechanism from legacy (3595800b4b0310a070f28c5fa60e11f3ff10c4a0).

Fixes #598 .