### PR TITLE
Fix save_3d_views crashing IPython/Jupyter kernels

### DIFF
--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -292,7 +292,7 @@ class WebApp(threading.Thread):
     def stop(self):
         print("Stopping server")
         self.server.stop()
-        tornado.ioloop.IOLoop.current().stop()
+        self.ioloop.stop()
 
     def send(self, **msg):
         if not isinstance(msg, str):


### PR DESCRIPTION
Fixes #601. My guess is that `tornado.ioloop.IOLoop.current()` returns something different if it's being run in a Jupyter notebook, since Jupyter itself uses tornado.