### PR TITLE
MNT CI and README maintenance

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -43,6 +43,7 @@ jobs:
         python -c 'import cortex; print(cortex.__full_version__)'
 
     - name: Build documents
+      timeout-minutes: 20
       run: |
         cd docs && make html && cd ..
         touch docs/_build/html/.nojekyll

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:  # Manual trigger for publishing docs
 
 jobs:
   build-docs:
@@ -47,7 +48,7 @@ jobs:
         touch docs/_build/html/.nojekyll
 
     - name: Publish to gh-pages if tagged
-      if: startsWith(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags') || github.event_name == 'workflow_dispatch'
       uses: JamesIves/github-pages-deploy-action@v4.8.0
       with:
         branch: gh-pages

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/cache@v5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py', '**/pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 
@@ -39,8 +39,16 @@ jobs:
         pip install -U nibabel
         pip install -q ipython Sphinx sphinx-gallery numpydoc # TODO: move to pyproject.toml
         pip install -e . --no-build-isolation --group dev
-        playwright install --with-deps --only-shell chromium
         python -c 'import cortex; print(cortex.__full_version__)'
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('**/pyproject.toml') }}
+
+    - name: Install Playwright Chromium
+      run: playwright install --with-deps --only-shell chromium
 
     - name: Build documents
       timeout-minutes: 20

--- a/.github/workflows/install_from_wheel.yml
+++ b/.github/workflows/install_from_wheel.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/cache@v5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py', '**/pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  workflow_dispatch:  # Manual trigger for testing TestPyPI
 
 jobs:
   build:
@@ -43,7 +42,6 @@ jobs:
 
   publish-to-pypi:
     name: Publish to PyPI
-    if: github.event_name == 'release'  # Skip on manual workflow_dispatch
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -61,25 +59,3 @@ jobs:
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-testpypi:
-    name: Publish to TestPyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/pycortex
-    permissions:
-      id-token: write  # Required for trusted publishing
-
-    steps:
-    - name: Download distribution artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: python-package-distributions
-        path: dist/
-
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,7 +42,7 @@ jobs:
         python -c 'import cortex; print(cortex.__full_version__)'
 
     - name: Test with pytest
-      timeout-minutes: 10  # in case webviewer tests hang
+      timeout-minutes: 20  # in case webviewer tests hang
       run: |
         pip install -e . --no-build-isolation --group dev
         playwright install --with-deps --only-shell chromium

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/cache@v5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py', '**/pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 
@@ -39,14 +39,21 @@ jobs:
         # force using latest nibabel
         pip install -U nibabel
         pip install -e '.[headless]' --no-build-isolation
+        pip install -e . --no-build-isolation --group dev
         python -c 'import cortex; print(cortex.__full_version__)'
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('**/pyproject.toml') }}
+
+    - name: Install Playwright Chromium
+      run: playwright install --with-deps --only-shell chromium
 
     - name: Test with pytest
       timeout-minutes: 20  # in case webviewer tests hang
-      run: |
-        pip install -e . --no-build-isolation --group dev
-        playwright install --with-deps --only-shell chromium
-        pytest --cov=./
+      run: pytest --cov=./
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 pycortex
 ========
 [![Build Status](https://github.com/gallantlab/pycortex/actions/workflows/run_tests.yml/badge.svg)](https://github.com/gallantlab/pycortex/actions/workflows/run_tests.yml)
+[![codecov](https://codecov.io/gh/gallantlab/pycortex/branch/main/graph/badge.svg)](https://codecov.io/gh/gallantlab/pycortex)
+[![PyPI](https://img.shields.io/pypi/v/pycortex)](https://pypi.org/project/pycortex/)
 [![Python version](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/release/python)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 pycortex
 ========
 [![Build Status](https://github.com/gallantlab/pycortex/actions/workflows/run_tests.yml/badge.svg)](https://github.com/gallantlab/pycortex/actions/workflows/run_tests.yml)
-[![Python version](https://img.shields.io/badge/python-3.6%2B-blue)](https://www.python.org/downloads/release/python)
+[![Python version](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/release/python)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
 
 


### PR DESCRIPTION
## Summary
- Increase pytest step timeout from 10 to 20 minutes
- Remove TestPyPI publishing job and `workflow_dispatch` trigger from `publish.yml`
- Update Python version badge from 3.6+ to 3.10+
- Add codecov and PyPI badges to README
- Add manual trigger (`workflow_dispatch`) for gh-pages deployment

## Test plan
- [ ] Verify `run_tests.yml` timeout is 20 minutes
- [ ] Verify `publish.yml` only triggers on release and publishes to PyPI only
- [x] Verify README badges render correctly
- [ ] Verify `build_docs.yml` can be manually triggered to deploy to gh-pages