### PR TITLE
FIX use PIL instead of ImageMagick to trim headless view whitespace

### DIFF
--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -190,20 +190,18 @@ def save_3d_views(
                 )
             time.sleep(1)
 
-            # Trim white edges
+            # Trim transparent edges
             if trim:
                 try:
-                    import subprocess
+                    from PIL import Image
 
-                    retcode = subprocess.call(
-                        ["convert", "-trim", file_name, file_name]
-                    )
-                    if retcode != 0:
-                        print(
-                            f"ImageMagick convert returned non-zero exit code {retcode} when trimming {file_name}."
-                        )
+                    img = Image.open(file_name)
+                    bbox = img.getbbox()
+                    if bbox:
+                        img = img.crop(bbox)
+                        img.save(file_name)
                 except Exception as e:
-                    print(str(e))
+                    print(f"Could not trim {file_name}: {e}")
 
         # For non-headless mode, close the viewer handle explicitly
         # (the headless context manager handles its own teardown)


### PR DESCRIPTION
## Summary
- Replace ImageMagick `convert -trim` subprocess call with PIL `Image.getbbox()` + `crop()` in `save_3d_views`
- Fixes excessive whitespace in headless-rendered views (e.g. the `plot_panels_headless` example) when ImageMagick is not installed, since the old code silently fell back to no trimming
- PIL is already used throughout pycortex, so no new dependency is added

## Test plan
- [x] Ran the full `plot_panels_headless.py` example locally with `headless=True` and verified all individual views, plot_panels, and predefined panel layouts render with tight cropping and no excessive whitespace