### PR TITLE
FIX deprecated scipy APIs

### DIFF
--- a/cortex/polyutils/surface.py
+++ b/cortex/polyutils/surface.py
@@ -8,10 +8,16 @@ from scipy.spatial import distance
 from scipy import sparse
 import scipy.sparse.linalg
 
+try:
+    from scipy.sparse.linalg import factorized as _factorized
+except ImportError:
+    # This API was deprecated in SciPy 1.8.0.
+    # https://docs.scipy.org/doc/scipy-1.16.1/release/1.8.0-notes.html#clear-split-between-public-and-private-api
+    from scipy.sparse.linalg.dsolve import factorized as _factorized
+
 from . import exact_geodesic
 from . import subsurface
 from .misc import _memo
-
 
 class Surface(exact_geodesic.ExactGeodesicMixin, subsurface.SubsurfaceMixin):
     """Represents a single cortical hemisphere surface. Can be the white matter surface,
@@ -217,7 +223,7 @@ class Surface(exact_geodesic.ExactGeodesicMixin, subsurface.SubsurfaceMixin):
         npt = len(D)
         lfac = sparse.dia_matrix((D,[0]), (npt,npt)) - factor * (W-V)
         goodrows = np.nonzero(~np.array(lfac.sum(0) == 0).ravel())[0]
-        lfac_solver = sparse.linalg.factorized(lfac[goodrows][:,goodrows])
+        lfac_solver = _factorized(lfac[goodrows][:,goodrows])
         to_smooth = scalars.copy()
         for _ in range(iterations):
             from_smooth = lfac_solver((D * to_smooth)[goodrows])
@@ -313,7 +319,7 @@ class Surface(exact_geodesic.ExactGeodesicMixin, subsurface.SubsurfaceMixin):
             from scikits.sparse.cholmod import cholesky
             factorize = lambda x: cholesky(x).solve_A
         except ImportError:
-            factorize = sparse.linalg.factorized
+            factorize = _factorized
             
         B, D, W, V = self.laplace_operator
         npt = len(D)
@@ -457,7 +463,7 @@ class Surface(exact_geodesic.ExactGeodesicMixin, subsurface.SubsurfaceMixin):
             # Exclude rows with zero weight (these break the sparse LU)
             goodrows = np.nonzero(~np.array(lfac.sum(0) == 0).ravel())[0]
             self._goodrows = goodrows
-            self._rlfac_solvers[m] = sparse.linalg.factorized(lfac[goodrows][:,goodrows])
+            self._rlfac_solvers[m] = _factorized(lfac[goodrows][:,goodrows])
 
         # Solve system to get u, the heat values
         u0 = np.zeros((npt,)) # initial heat values
@@ -518,8 +524,8 @@ class Surface(exact_geodesic.ExactGeodesicMixin, subsurface.SubsurfaceMixin):
             # Exclude rows with zero weight (these break the sparse LU)
             goodrows = np.nonzero(~np.array(lfac.sum(0) == 0).ravel())[0]
             self._goodrows = goodrows
-            self._rlfac_solvers[m] = sparse.linalg.factorized(lfac[goodrows][:,goodrows])
-            self._nLC_solvers[m] = sparse.linalg.factorized(nLC[goodrows][:,goodrows])
+            self._rlfac_solvers[m] = _factorized(lfac[goodrows][:,goodrows])
+            self._nLC_solvers[m] = _factorized(nLC[goodrows][:,goodrows])
 
         # I. "Integrate the heat flow ̇u = ∆u for some fixed time t"
         # ---------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 future
 numpy
-scipy>=1.8.0
+scipy
 tornado>=4.3
 shapely
 lxml


### PR DESCRIPTION
[SciPy 1.8.0](https://docs.scipy.org/doc/scipy-1.16.1/release/1.8.0-notes.html#clear-split-between-public-and-private-api) deprecated the use of of several internal APIs in favor of a consistent public API. This PR uses the new public API, and enforces a minimum version of SciPy to make sure it exists.

If we want to maintain support for SciPy < 1.8.0 (released Feb. 2022), we can add additional logic.