### PR TITLE
FIX VertexRGB/VolumeRGB alpha attenuation in WebGL viewer

### DIFF
--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -3,7 +3,6 @@ import warnings
 from copy import deepcopy
 import sys
 from typing import Generic, Optional, TypeVar, Union, cast
-
 if sys.version_info < (3, 11):
     from typing_extensions import Self
 else:
@@ -23,23 +22,21 @@ class BrainData(object):
     Parameters
     ----------
     data : ndarray or str
-        The data array (size depends on specific use case) or path to file
+        The data array (size depends on specific use case) or path to file 
         readable by nibabel.
     subject : str
         Subject identifier. Must exist in the pycortex database.
     """
-
     def __init__(self, data: Union[npt.NDArray, str], subject: str, **kwargs):
         if isinstance(data, str):
             import nibabel
-
             nib = nibabel.load(data)
             data = cast(npt.NDArray, nib.get_fdata().T)
         self._data = data
         try:
             basestring
         except NameError:
-            subject = subject if isinstance(subject, str) else subject.decode("utf-8")
+            subject = subject if isinstance(subject, str) else subject.decode('utf-8')
         self.subject = subject
         super(BrainData, self).__init__(**kwargs)
 
@@ -58,14 +55,16 @@ class BrainData(object):
         """Name of this BrainData, computed from hash of data.
         TODO:WHAT IS THIS USEFUL FOR
         """
-        return "__%s" % _hash(self.data)[:16]
+        return "__%s"%_hash(self.data)[:16]
 
     def exp(self):
-        """Return copy of this brain data with data exponentiated."""
+        """Return copy of this brain data with data exponentiated.
+        """
         return self.copy(np.exp(self.data))
 
     def uniques(self, collapse=False):
-        """TODO: WHAT IS THIS"""
+        """TODO: WHAT IS THIS
+        """
         yield self
 
     def __hash__(self):
@@ -75,27 +74,25 @@ class BrainData(object):
         if name is None:
             name = self.name
         dgrp = h5.require_group("/data")
-
+        
         if name in dgrp and "__%s" % _hash(dgrp[name][()])[:16] == name:
-            # don't need to update anything, since it's the same data
-            return h5.get("/data/%s" % name)
+            #don't need to update anything, since it's the same data
+            return h5.get("/data/%s"%name)
 
         node = _hdf_write(h5, self.data, name=name)
-        node.attrs["subject"] = self.subject
+        node.attrs['subject'] = self.subject
         return node
 
     def to_json(self, simple=False):
-        """Creates JSON description of this brain data."""
+        """Creates JSON description of this brain data.
+        """
         sdict = super(BrainData, self).to_json(simple=simple)
         if simple:
-            sdict.update(
-                dict(
-                    name=self.name,
-                    subject=self.subject,
-                    min=float(np.nan_to_num(self.data).min()),
-                    max=float(np.nan_to_num(self.data).max()),
-                )
-            )
+            sdict.update(dict(name=self.name,
+                subject=self.subject,
+                min=float(np.nan_to_num(self.data).min()), 
+                max=float(np.nan_to_num(self.data).max()),
+                ))
         return sdict
 
     @classmethod
@@ -106,22 +103,12 @@ class BrainData(object):
         v ** 2 # Returns new VolumeData with data squared
         """
         # Binary operations
-        npops = [
-            "__add__",
-            "__sub__",
-            "__mul__",
-            "__floordiv__",
-            "__truediv__",
-            "__div__",
-            "__pow__",
-            "__neg__",
-            "__abs__",
-        ]
+        npops = ["__add__", "__sub__", "__mul__", "__floordiv__", "__truediv__",
+                 "__div__", "__pow__", "__neg__", "__abs__"]
 
-        def make_opfun(op):  # function nesting creates closure containing op
+        def make_opfun(op): # function nesting creates closure containing op
             def opfun(self, *args):
                 return self.copy(getattr(self.data, op)(*args))
-
             return opfun
 
         for op in npops:
@@ -129,9 +116,7 @@ class BrainData(object):
             opfun.__name__ = op
             setattr(cls, opfun.__name__, opfun)
 
-
 BrainData._add_numpy_methods()
-
 
 class VolumeData(BrainData):
     """
@@ -143,7 +128,7 @@ class VolumeData(BrainData):
         The data. Can be 3D with shape (z,y,x), 1D with shape (v,) for masked data,
         4D with shape (t,z,y,x), or 2D with shape (t,v). For masked data, if the
         size of the given array matches any of the existing masks in the database,
-        that mask will automatically be loaded. If it does not, an error will be
+        that mask will automatically be loaded. If it does not, an error will be 
         raised.
     subject : str
         Subject identifier. Must exist in the pycortex database.
@@ -151,46 +136,39 @@ class VolumeData(BrainData):
         Transform name. Must exist in the pycortex database.
     mask : ndarray, optional
         Binary 3D array with shape (z,y,x) showing which voxels are selected.
-        If masked data is given, the mask will automatically be loaded if it
+        If masked data is given, the mask will automatically be loaded if it 
         exists in the pycortex database.
     **kwargs
         Other keyword arguments are passed to superclass inits.
     """
-
-    def __init__(
-        self,
-        data: npt.NDArray,
-        subject: str,
-        xfmname: str,
-        mask: Optional[npt.NDArray] = None,
-        **kwargs,
-    ):
+    def __init__(self, data: npt.NDArray, subject: str, xfmname: str, mask: Optional[npt.NDArray]=None, **kwargs):
         if self.__class__ == VolumeData:
-            raise TypeError("Cannot directly instantiate VolumeData objects")
+            raise TypeError('Cannot directly instantiate VolumeData objects')
         super(VolumeData, self).__init__(data, subject, **kwargs)
         try:
             basestring
         except NameError:
-            xfmname = xfmname if isinstance(xfmname, str) else xfmname.decode("utf-8")
+            xfmname = xfmname if isinstance(xfmname, str) else xfmname.decode('utf-8')
         self.xfmname = xfmname
 
         self._check_size(mask)
         self.masked = _masker(self)
 
-    def to_json(self, simple: bool = False):
-        """Creates JSON description of this brain data."""
+    def to_json(self, simple: bool=False):
+        """Creates JSON description of this brain data.
+        """
         if simple:
             sdict = super(VolumeData, self).to_json(simple=simple)
             sdict["shape"] = self.shape
             return sdict
-
-        xfm = db.get_xfm(self.subject, self.xfmname, "coord").xfm
+        
+        xfm = db.get_xfm(self.subject, self.xfmname, 'coord').xfm
         sdict = dict(xfm=[list(np.array(xfm).ravel())], data=[self.name])
         sdict.update(super(VolumeData, self).to_json())
         return sdict
 
     @classmethod
-    def empty(cls, subject: str, xfmname: str, value: float = 0, **kwargs):
+    def empty(cls, subject: str, xfmname: str, value: float=0, **kwargs):
         """
         Create a constant-valued VolumeData for the given subject and xfmname.
         Often useful for testing purposes.
@@ -204,7 +182,7 @@ class VolumeData(BrainData):
         value : float, optional
             Value that the VolumeData will be filled with.
         **kwargs
-            Other keyword arguments are passed to the init function for this
+            Other keyword arguments are passed to the init function for this 
             class.
 
         Returns
@@ -214,7 +192,7 @@ class VolumeData(BrainData):
         """
         xfm = db.get_xfm(subject, xfmname)
         shape = xfm.shape
-        return cls(np.ones(shape) * value, subject, xfmname, **kwargs)
+        return cls(np.ones(shape)*value, subject, xfmname, **kwargs)
 
     @classmethod
     def random(cls, subject: str, xfmname: str, **kwargs):
@@ -230,7 +208,7 @@ class VolumeData(BrainData):
         xfmname : str
             Transform name. Must exist in the pycortex database.
         **kwargs
-            Other keyword arguments are passed to the init function for this
+            Other keyword arguments are passed to the init function for this 
             class.
 
         Returns
@@ -245,12 +223,12 @@ class VolumeData(BrainData):
     def _check_size(self, mask: Union[npt.NDArray, str, None]) -> None:
         if self.data.ndim not in (1, 2, 3, 4):
             raise ValueError("Invalid data shape")
-
+        
         self.linear = self.data.ndim in (1, 2)
         self.movie = self.data.ndim in (2, 4)
 
         if self.linear:
-            # Guess the mask
+            #Guess the mask
             if mask is None:
                 nvox: int = self.data.shape[-1]
                 self._mask, self.mask = _find_mask(nvox, self.subject, self.xfmname)
@@ -269,14 +247,11 @@ class VolumeData(BrainData):
                 shape = shape[1:]
             xfm = db.get_xfm(self.subject, self.xfmname)
             if xfm.shape != shape:
-                raise ValueError(
-                    "Volumetric data (shape %s) is not the same shape as reference for transform (shape %s)"
-                    % (str(shape), str(xfm.shape))
-                )
+                raise ValueError("Volumetric data (shape %s) is not the same shape as reference for transform (shape %s)" % (str(shape), str(xfm.shape)))
             self.shape = shape
 
     def map(self, projection="nearest"):
-        """Convert this VolumeData into VertexData using the given projection
+        """Convert this VolumeData into VertexData using the given projection 
         method.
 
         Parameters
@@ -290,7 +265,6 @@ class VolumeData(BrainData):
             Vertex valued version of this VolumeData.
         """
         from cortex import utils
-
         mapper = utils.get_mapper(self.subject, self.xfmname, projection)
         data = mapper(self)
         # Note: this is OK, because VolumeRGB and Volume2D objects (which
@@ -307,16 +281,14 @@ class VolumeData(BrainData):
             name = self._mask
             if isinstance(self._mask, np.ndarray):
                 name = "custom"
-            maskstr = "%s masked" % name
+            maskstr = "%s masked"%name
         if self.movie:
             maskstr += " movie"
-        maskstr = maskstr[0].upper() + maskstr[1:]
-        return "<%s data for (%s, %s)>" % (maskstr, self.subject, self.xfmname)
+        maskstr = maskstr[0].upper()+maskstr[1:]
+        return "<%s data for (%s, %s)>"%(maskstr, self.subject, self.xfmname)
 
     def copy(self, data):
-        return super(VolumeData, self).copy(
-            data, self.subject, self.xfmname, mask=self._mask
-        )
+        return super(VolumeData, self).copy(data, self.subject, self.xfmname, mask=self._mask)
 
     @property
     def volume(self):
@@ -324,7 +296,6 @@ class VolumeData(BrainData):
         masked data.
         """
         from cortex import volume
-
         if self.linear:
             data = volume.unmask(self.mask, self.data[:])
         else:
@@ -336,24 +307,24 @@ class VolumeData(BrainData):
         return data
 
     def save(self, filename, name=None):
-        """Save the dataset into the hdf file `filename` with the provided name."""
+        """Save the dataset into the hdf file `filename` with the provided name.
+        """
         import os
-
         if isinstance(filename, str):
             fname, ext = os.path.splitext(filename)
-            if ext in (".hdf", ".h5", ".hf5"):
+            if ext in (".hdf", ".h5",".hf5"):
                 h5 = h5py.File(filename, "a")
                 self._write_hdf(h5, name=name)
                 h5.close()
             else:
-                raise TypeError("Unknown file type")
+                raise TypeError('Unknown file type')
         elif isinstance(filename, h5py.Group):
             self._write_hdf(filename, name=name)
 
     def _write_hdf(self, h5, name=None):
         node = super(VolumeData, self)._write_hdf(h5, name=name)
-
-        # write the mask into the file, as necessary
+        
+        #write the mask into the file, as necessary
         if self._mask is not None:
             mask = self._mask
             if isinstance(self._mask, np.ndarray):
@@ -363,7 +334,7 @@ class VolumeData(BrainData):
                 _hdf_write(h5, self._mask, name=mname, group=mgrp)
                 mask = mname
 
-            node.attrs["mask"] = mask
+            node.attrs['mask'] = mask
 
         return node
 
@@ -374,10 +345,8 @@ class VolumeData(BrainData):
         xfm = db.get_xfm(self.subject, self.xfmname)
         affine = xfm.reference.affine
         import nibabel
-
         new_nii = nibabel.Nifti1Image(self.volume.T, affine)
         nibabel.save(new_nii, filename)
-
 
 class VertexData(BrainData):
     """
@@ -388,17 +357,16 @@ class VertexData(BrainData):
     data : ndarray
         The data. Can be 1D with shape (v,), or 2D with shape (t,v). Here, v can
         be the number of vertices in both hemispheres, or the number of vertices
-        in either one of the hemispheres. In that case, the data for the other
+        in either one of the hemispheres. In that case, the data for the other 
         hemisphere will be filled with zeros.
     subject : str
         Subject identifier. Must exist in the pycortex database.
     **kwargs
         Other keyword arguments are passed to the superclass init function.
     """
-
     def __init__(self, data: npt.NDArray, subject: str, **kwargs):
         if self.__class__ == VertexData:
-            raise TypeError("Cannot directly instantiate VertexData objects")
+            raise TypeError('Cannot directly instantiate VertexData objects')
         super(VertexData, self).__init__(data, subject, **kwargs)
         try:
             left, right = db.get_surf(self.subject, "wm")
@@ -421,7 +389,7 @@ class VertexData(BrainData):
         value : float, optional
             Value that the VertexData will be filled with.
         **kwargs
-            Other keyword arguments are passed to the init function for this
+            Other keyword arguments are passed to the init function for this 
             class.
 
         Returns
@@ -434,7 +402,7 @@ class VertexData(BrainData):
         except IOError:
             left, right = db.get_surf(subject, "fiducial")
         nverts = len(left[0]) + len(right[0])
-        return cls(np.ones((nverts,)) * value, subject, **kwargs)
+        return cls(np.ones((nverts,))*value, subject, **kwargs)
 
     @classmethod
     def random(cls, subject: str, **kwargs):
@@ -448,7 +416,7 @@ class VertexData(BrainData):
         subject : str
             Subject identifier. Must exist in the pycortex database.
         **kwargs
-            Other keyword arguments are passed to the init function for this
+            Other keyword arguments are passed to the init function for this 
             class.
 
         Returns
@@ -470,7 +438,7 @@ class VertexData(BrainData):
         """
         if data is None:
             data = np.zeros((self.llen + self.rlen,))
-
+        
         self._data = data
         self.movie = self.data.ndim > 1
         self.nverts = self.data.shape[-1]
@@ -490,23 +458,20 @@ class VertexData(BrainData):
             # Data for both hemispheres
             self.hem = "both"
         else:
-            raise ValueError(
-                "Invalid number of vertices for subject (given %d, should be %d for left hem, %d for right hem, or %d for both)"
-                % (self.nverts, self.llen, self.rlen, self.llen + self.rlen)
-            )
+            raise ValueError('Invalid number of vertices for subject (given %d, should be %d for left hem, %d for right hem, or %d for both)' % (self.nverts, self.llen, self.rlen, self.llen+self.rlen))
 
     def copy(self, data: npt.NDArray) -> Self:
         """
         Return a new VertexData object for the same subject but with data
-        replaced by the given `data`.
+        replaced by the given `data`. 
 
-        This is useful for efficiently creating many VertexData objects, since
-        it doesn't require reloading the surfaces from the database to check
+        This is useful for efficiently creating many VertexData objects, since 
+        it doesn't require reloading the surfaces from the database to check 
         numbers of vertices, etc.
         """
         return super(VertexData, self).copy(data, self.subject)
 
-    def volume(self, xfmname, projection="nearest", **kwargs):
+    def volume(self, xfmname, projection='nearest', **kwargs):
         """
         Map this VertexData back to volume space, creating a VolumeData object.
         This uses the `mapper.backwards` function, which is not particularly
@@ -515,12 +480,12 @@ class VertexData(BrainData):
         Parameters
         ----------
         xfmname : str
-            Transform name for the volume space that this vertex data will be
+            Transform name for the volume space that this vertex data will be 
             projected into. Must exist in the pycortex database.
         projection : str, optional
             The type of projection method to use. See the docs for `mapper` for
             possibilities. Default: nearest.
-        **kwargs
+        **kwargs 
             Other keyword args are passed to the `mapper.backwards` function.
 
         Returns
@@ -529,10 +494,8 @@ class VertexData(BrainData):
             Volume containing the back-projected vertex data.
         """
         import warnings
-
-        warnings.warn("Inverse mapping cannot be accurate")
+        warnings.warn('Inverse mapping cannot be accurate')
         from cortex import utils
-
         mapper = utils.get_mapper(self.subject, xfmname, projection)
         return mapper.backwards(self, **kwargs)
 
@@ -540,7 +503,7 @@ class VertexData(BrainData):
         maskstr = ""
         if self.movie:
             maskstr = "movie "
-        return "<Vertex %sdata for %s>" % (maskstr, self.subject)
+        return "<Vertex %sdata for %s>"%(maskstr, self.subject)
 
     def __getitem__(self, idx):
         """Get the VertexData for the given time index. Only works for movie (2D)
@@ -548,8 +511,8 @@ class VertexData(BrainData):
         """
         if not self.movie:
             raise TypeError("Cannot index non-movie data")
-
-        # return VertexData(self.data[idx], self.subject, **self.attrs)
+        
+        #return VertexData(self.data[idx], self.subject, **self.attrs)
         return self.copy(self.data[idx])
 
     def to_json(self, simple: bool = False):
@@ -557,7 +520,7 @@ class VertexData(BrainData):
             sdict = dict(split=self.llen, frames=self.vertices.shape[0])
             sdict.update(super(VertexData, self).to_json(simple=simple))
             return sdict
-
+            
         sdict = dict(data=[self.name])
         sdict.update(super(VertexData, self).to_json())
         return sdict
@@ -571,23 +534,24 @@ class VertexData(BrainData):
 
     @property
     def left(self):
-        """Data for only the left hemisphere vertices."""
+        """Data for only the left hemisphere vertices.
+        """
         if self.movie:
-            return self.data[:, : self.llen]
+            return self.data[:,:self.llen]
         else:
-            return self.data[: self.llen]
+            return self.data[:self.llen]
 
     @property
     def right(self):
-        """Data for only the right hemisphere vertices."""
+        """Data for only the right hemisphere vertices.
+        """
         if self.movie:
-            return self.data[:, self.llen :]
+            return self.data[:,self.llen:]
         else:
-            return self.data[self.llen :]
+            return self.data[self.llen:]
 
-    def blend_curvature(
-        self, alpha, threshold=0, brightness=0.5, contrast=0.25, smooth=20
-    ):
+    def blend_curvature(self, alpha, threshold=0, brightness=0.5,
+                        contrast=0.25, smooth=20):
         """Blend the data with a curvature map depending on a transparency map.
 
         .. deprecated::
@@ -634,7 +598,7 @@ class VertexData(BrainData):
             Contrast of the curvature map.
         smooth : float
             Smoothness of the curvature map.
-
+        
         Returns
         -------
         blended : VertexRGB object
@@ -655,30 +619,22 @@ class VertexData(BrainData):
         )
         from .views import Vertex
         from .viewRGB import VertexRGB
-
         # prepare curvature map
         curvature = db.get_surfinfo(self.subject, smooth=smooth).data
         curvature = (curvature > threshold).astype("float")
         curvature = curvature * contrast + brightness
-        curvature_raw = Vertex(curvature, self.subject, vmin=0, vmax=1, cmap="gray").raw
+        curvature_raw = Vertex(curvature, self.subject, vmin=0, vmax=1,
+                               cmap="gray").raw
 
         # prepare alpha map
         alpha = np.clip(alpha.astype("float"), 0, 1)
 
         # blend original map with curvature map
         # self.raw comes from the implementation of Dataview (e.g. Vertex, Volume, etc.)
-        blended = cast(
-            VertexRGB, deepcopy(self.raw)
-        )  # copy because VertexRGB.raw returns self
-        blended.red.data = (
-            blended.red.data * alpha + (1 - alpha) * curvature_raw.red.data
-        )
-        blended.green.data = (
-            blended.green.data * alpha + (1 - alpha) * curvature_raw.green.data
-        )
-        blended.blue.data = (
-            blended.blue.data * alpha + (1 - alpha) * curvature_raw.blue.data
-        )
+        blended = cast(VertexRGB, deepcopy(self.raw))  # copy because VertexRGB.raw returns self
+        blended.red.data = blended.red.data * alpha + (1 - alpha) * curvature_raw.red.data
+        blended.green.data = blended.green.data * alpha + (1 - alpha) * curvature_raw.green.data
+        blended.blue.data = blended.blue.data * alpha + (1 - alpha) * curvature_raw.blue.data
         blended.red.data = blended.red.data.astype("uint8")
         blended.green.data = blended.green.data.astype("uint8")
         blended.blue.data = blended.blue.data.astype("uint8")
@@ -692,25 +648,22 @@ def _find_mask(nvox: int, subject: str, xfmname: str):
     import re
 
     import nibabel
-
-    files = db.get_paths(subject)["masks"].format(xfmname=xfmname, type="*")
+    files = db.get_paths(subject)['masks'].format(xfmname=xfmname, type="*")
     for fname in glob.glob(files):
         nib = nibabel.load(fname)
         mask = cast(npt.NDArray[np.bool_], nib.get_fdata().T != 0)
         if nvox == np.sum(mask):
             fname = os.path.split(fname)[1]
-            name = re.compile(r"mask_(.+).nii.gz").search(fname)
+            name = re.compile(r'mask_(.+).nii.gz').search(fname)
             return name.group(1), mask
 
-    raise ValueError("Cannot find a valid mask")
+    raise ValueError('Cannot find a valid mask')
 
 
 # Generic allows us to return Volume instead of VolumeData
-T_masker = TypeVar("T_masker", bound=VolumeData)
-
-
+T_masker = TypeVar('T_masker', bound=VolumeData)
 class _masker(Generic[T_masker]):
-    def __init__(self, dv: T_masker):  # should be braindata + dataview
+    def __init__(self, dv: T_masker): # should be braindata + dataview
         self.dv = dv
 
         self.data = None
@@ -719,25 +672,19 @@ class _masker(Generic[T_masker]):
 
     def __getitem__(self, masktype: str) -> T_masker:
         mask = db.get_mask(self.dv.subject, self.dv.xfmname, masktype)
-        return self.dv.copy(self.dv.volume[:, mask].squeeze())
-
+        return self.dv.copy(self.dv.volume[:,mask].squeeze())
 
 def _hash(array):
-    """A simple numpy hash function"""
+    '''A simple numpy hash function'''
     array = np.asarray(array)
     return hashlib.sha1(array.tobytes()).hexdigest()
 
-
 def _hdf_write(h5, data, name="data", group="/data"):
     try:
-        node = h5.require_dataset(
-            "%s/%s" % (group, name), data.shape, data.dtype, exact=True
-        )
+        node = h5.require_dataset("%s/%s"%(group, name), data.shape, data.dtype, exact=True)
     except TypeError:
         del h5[group][name]
-        node = h5.create_dataset(
-            "%s/%s" % (group, name), data.shape, data.dtype, exact=True
-        )
+        node = h5.create_dataset("%s/%s"%(group, name), data.shape, data.dtype, exact=True)
 
     node[:] = data
     return node

--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -3,6 +3,7 @@ import warnings
 from copy import deepcopy
 import sys
 from typing import Generic, Optional, TypeVar, Union, cast
+
 if sys.version_info < (3, 11):
     from typing_extensions import Self
 else:
@@ -22,21 +23,23 @@ class BrainData(object):
     Parameters
     ----------
     data : ndarray or str
-        The data array (size depends on specific use case) or path to file 
+        The data array (size depends on specific use case) or path to file
         readable by nibabel.
     subject : str
         Subject identifier. Must exist in the pycortex database.
     """
+
     def __init__(self, data: Union[npt.NDArray, str], subject: str, **kwargs):
         if isinstance(data, str):
             import nibabel
+
             nib = nibabel.load(data)
             data = cast(npt.NDArray, nib.get_fdata().T)
         self._data = data
         try:
             basestring
         except NameError:
-            subject = subject if isinstance(subject, str) else subject.decode('utf-8')
+            subject = subject if isinstance(subject, str) else subject.decode("utf-8")
         self.subject = subject
         super(BrainData, self).__init__(**kwargs)
 
@@ -55,16 +58,14 @@ class BrainData(object):
         """Name of this BrainData, computed from hash of data.
         TODO:WHAT IS THIS USEFUL FOR
         """
-        return "__%s"%_hash(self.data)[:16]
+        return "__%s" % _hash(self.data)[:16]
 
     def exp(self):
-        """Return copy of this brain data with data exponentiated.
-        """
+        """Return copy of this brain data with data exponentiated."""
         return self.copy(np.exp(self.data))
 
     def uniques(self, collapse=False):
-        """TODO: WHAT IS THIS
-        """
+        """TODO: WHAT IS THIS"""
         yield self
 
     def __hash__(self):
@@ -74,25 +75,27 @@ class BrainData(object):
         if name is None:
             name = self.name
         dgrp = h5.require_group("/data")
-        
+
         if name in dgrp and "__%s" % _hash(dgrp[name][()])[:16] == name:
-            #don't need to update anything, since it's the same data
-            return h5.get("/data/%s"%name)
+            # don't need to update anything, since it's the same data
+            return h5.get("/data/%s" % name)
 
         node = _hdf_write(h5, self.data, name=name)
-        node.attrs['subject'] = self.subject
+        node.attrs["subject"] = self.subject
         return node
 
     def to_json(self, simple=False):
-        """Creates JSON description of this brain data.
-        """
+        """Creates JSON description of this brain data."""
         sdict = super(BrainData, self).to_json(simple=simple)
         if simple:
-            sdict.update(dict(name=self.name,
-                subject=self.subject,
-                min=float(np.nan_to_num(self.data).min()), 
-                max=float(np.nan_to_num(self.data).max()),
-                ))
+            sdict.update(
+                dict(
+                    name=self.name,
+                    subject=self.subject,
+                    min=float(np.nan_to_num(self.data).min()),
+                    max=float(np.nan_to_num(self.data).max()),
+                )
+            )
         return sdict
 
     @classmethod
@@ -103,12 +106,22 @@ class BrainData(object):
         v ** 2 # Returns new VolumeData with data squared
         """
         # Binary operations
-        npops = ["__add__", "__sub__", "__mul__", "__floordiv__", "__truediv__",
-                 "__div__", "__pow__", "__neg__", "__abs__"]
+        npops = [
+            "__add__",
+            "__sub__",
+            "__mul__",
+            "__floordiv__",
+            "__truediv__",
+            "__div__",
+            "__pow__",
+            "__neg__",
+            "__abs__",
+        ]
 
-        def make_opfun(op): # function nesting creates closure containing op
+        def make_opfun(op):  # function nesting creates closure containing op
             def opfun(self, *args):
                 return self.copy(getattr(self.data, op)(*args))
+
             return opfun
 
         for op in npops:
@@ -116,7 +129,9 @@ class BrainData(object):
             opfun.__name__ = op
             setattr(cls, opfun.__name__, opfun)
 
+
 BrainData._add_numpy_methods()
+
 
 class VolumeData(BrainData):
     """
@@ -128,7 +143,7 @@ class VolumeData(BrainData):
         The data. Can be 3D with shape (z,y,x), 1D with shape (v,) for masked data,
         4D with shape (t,z,y,x), or 2D with shape (t,v). For masked data, if the
         size of the given array matches any of the existing masks in the database,
-        that mask will automatically be loaded. If it does not, an error will be 
+        that mask will automatically be loaded. If it does not, an error will be
         raised.
     subject : str
         Subject identifier. Must exist in the pycortex database.
@@ -136,39 +151,46 @@ class VolumeData(BrainData):
         Transform name. Must exist in the pycortex database.
     mask : ndarray, optional
         Binary 3D array with shape (z,y,x) showing which voxels are selected.
-        If masked data is given, the mask will automatically be loaded if it 
+        If masked data is given, the mask will automatically be loaded if it
         exists in the pycortex database.
     **kwargs
         Other keyword arguments are passed to superclass inits.
     """
-    def __init__(self, data: npt.NDArray, subject: str, xfmname: str, mask: Optional[npt.NDArray]=None, **kwargs):
+
+    def __init__(
+        self,
+        data: npt.NDArray,
+        subject: str,
+        xfmname: str,
+        mask: Optional[npt.NDArray] = None,
+        **kwargs,
+    ):
         if self.__class__ == VolumeData:
-            raise TypeError('Cannot directly instantiate VolumeData objects')
+            raise TypeError("Cannot directly instantiate VolumeData objects")
         super(VolumeData, self).__init__(data, subject, **kwargs)
         try:
             basestring
         except NameError:
-            xfmname = xfmname if isinstance(xfmname, str) else xfmname.decode('utf-8')
+            xfmname = xfmname if isinstance(xfmname, str) else xfmname.decode("utf-8")
         self.xfmname = xfmname
 
         self._check_size(mask)
         self.masked = _masker(self)
 
-    def to_json(self, simple: bool=False):
-        """Creates JSON description of this brain data.
-        """
+    def to_json(self, simple: bool = False):
+        """Creates JSON description of this brain data."""
         if simple:
             sdict = super(VolumeData, self).to_json(simple=simple)
             sdict["shape"] = self.shape
             return sdict
-        
-        xfm = db.get_xfm(self.subject, self.xfmname, 'coord').xfm
+
+        xfm = db.get_xfm(self.subject, self.xfmname, "coord").xfm
         sdict = dict(xfm=[list(np.array(xfm).ravel())], data=[self.name])
         sdict.update(super(VolumeData, self).to_json())
         return sdict
 
     @classmethod
-    def empty(cls, subject: str, xfmname: str, value: float=0, **kwargs):
+    def empty(cls, subject: str, xfmname: str, value: float = 0, **kwargs):
         """
         Create a constant-valued VolumeData for the given subject and xfmname.
         Often useful for testing purposes.
@@ -182,7 +204,7 @@ class VolumeData(BrainData):
         value : float, optional
             Value that the VolumeData will be filled with.
         **kwargs
-            Other keyword arguments are passed to the init function for this 
+            Other keyword arguments are passed to the init function for this
             class.
 
         Returns
@@ -192,7 +214,7 @@ class VolumeData(BrainData):
         """
         xfm = db.get_xfm(subject, xfmname)
         shape = xfm.shape
-        return cls(np.ones(shape)*value, subject, xfmname, **kwargs)
+        return cls(np.ones(shape) * value, subject, xfmname, **kwargs)
 
     @classmethod
     def random(cls, subject: str, xfmname: str, **kwargs):
@@ -208,7 +230,7 @@ class VolumeData(BrainData):
         xfmname : str
             Transform name. Must exist in the pycortex database.
         **kwargs
-            Other keyword arguments are passed to the init function for this 
+            Other keyword arguments are passed to the init function for this
             class.
 
         Returns
@@ -223,12 +245,12 @@ class VolumeData(BrainData):
     def _check_size(self, mask: Union[npt.NDArray, str, None]) -> None:
         if self.data.ndim not in (1, 2, 3, 4):
             raise ValueError("Invalid data shape")
-        
+
         self.linear = self.data.ndim in (1, 2)
         self.movie = self.data.ndim in (2, 4)
 
         if self.linear:
-            #Guess the mask
+            # Guess the mask
             if mask is None:
                 nvox: int = self.data.shape[-1]
                 self._mask, self.mask = _find_mask(nvox, self.subject, self.xfmname)
@@ -247,11 +269,14 @@ class VolumeData(BrainData):
                 shape = shape[1:]
             xfm = db.get_xfm(self.subject, self.xfmname)
             if xfm.shape != shape:
-                raise ValueError("Volumetric data (shape %s) is not the same shape as reference for transform (shape %s)" % (str(shape), str(xfm.shape)))
+                raise ValueError(
+                    "Volumetric data (shape %s) is not the same shape as reference for transform (shape %s)"
+                    % (str(shape), str(xfm.shape))
+                )
             self.shape = shape
 
     def map(self, projection="nearest"):
-        """Convert this VolumeData into VertexData using the given projection 
+        """Convert this VolumeData into VertexData using the given projection
         method.
 
         Parameters
@@ -265,6 +290,7 @@ class VolumeData(BrainData):
             Vertex valued version of this VolumeData.
         """
         from cortex import utils
+
         mapper = utils.get_mapper(self.subject, self.xfmname, projection)
         data = mapper(self)
         # Note: this is OK, because VolumeRGB and Volume2D objects (which
@@ -281,14 +307,16 @@ class VolumeData(BrainData):
             name = self._mask
             if isinstance(self._mask, np.ndarray):
                 name = "custom"
-            maskstr = "%s masked"%name
+            maskstr = "%s masked" % name
         if self.movie:
             maskstr += " movie"
-        maskstr = maskstr[0].upper()+maskstr[1:]
-        return "<%s data for (%s, %s)>"%(maskstr, self.subject, self.xfmname)
+        maskstr = maskstr[0].upper() + maskstr[1:]
+        return "<%s data for (%s, %s)>" % (maskstr, self.subject, self.xfmname)
 
     def copy(self, data):
-        return super(VolumeData, self).copy(data, self.subject, self.xfmname, mask=self._mask)
+        return super(VolumeData, self).copy(
+            data, self.subject, self.xfmname, mask=self._mask
+        )
 
     @property
     def volume(self):
@@ -296,6 +324,7 @@ class VolumeData(BrainData):
         masked data.
         """
         from cortex import volume
+
         if self.linear:
             data = volume.unmask(self.mask, self.data[:])
         else:
@@ -307,24 +336,24 @@ class VolumeData(BrainData):
         return data
 
     def save(self, filename, name=None):
-        """Save the dataset into the hdf file `filename` with the provided name.
-        """
+        """Save the dataset into the hdf file `filename` with the provided name."""
         import os
+
         if isinstance(filename, str):
             fname, ext = os.path.splitext(filename)
-            if ext in (".hdf", ".h5",".hf5"):
+            if ext in (".hdf", ".h5", ".hf5"):
                 h5 = h5py.File(filename, "a")
                 self._write_hdf(h5, name=name)
                 h5.close()
             else:
-                raise TypeError('Unknown file type')
+                raise TypeError("Unknown file type")
         elif isinstance(filename, h5py.Group):
             self._write_hdf(filename, name=name)
 
     def _write_hdf(self, h5, name=None):
         node = super(VolumeData, self)._write_hdf(h5, name=name)
-        
-        #write the mask into the file, as necessary
+
+        # write the mask into the file, as necessary
         if self._mask is not None:
             mask = self._mask
             if isinstance(self._mask, np.ndarray):
@@ -334,7 +363,7 @@ class VolumeData(BrainData):
                 _hdf_write(h5, self._mask, name=mname, group=mgrp)
                 mask = mname
 
-            node.attrs['mask'] = mask
+            node.attrs["mask"] = mask
 
         return node
 
@@ -345,8 +374,10 @@ class VolumeData(BrainData):
         xfm = db.get_xfm(self.subject, self.xfmname)
         affine = xfm.reference.affine
         import nibabel
+
         new_nii = nibabel.Nifti1Image(self.volume.T, affine)
         nibabel.save(new_nii, filename)
+
 
 class VertexData(BrainData):
     """
@@ -357,16 +388,17 @@ class VertexData(BrainData):
     data : ndarray
         The data. Can be 1D with shape (v,), or 2D with shape (t,v). Here, v can
         be the number of vertices in both hemispheres, or the number of vertices
-        in either one of the hemispheres. In that case, the data for the other 
+        in either one of the hemispheres. In that case, the data for the other
         hemisphere will be filled with zeros.
     subject : str
         Subject identifier. Must exist in the pycortex database.
     **kwargs
         Other keyword arguments are passed to the superclass init function.
     """
+
     def __init__(self, data: npt.NDArray, subject: str, **kwargs):
         if self.__class__ == VertexData:
-            raise TypeError('Cannot directly instantiate VertexData objects')
+            raise TypeError("Cannot directly instantiate VertexData objects")
         super(VertexData, self).__init__(data, subject, **kwargs)
         try:
             left, right = db.get_surf(self.subject, "wm")
@@ -389,7 +421,7 @@ class VertexData(BrainData):
         value : float, optional
             Value that the VertexData will be filled with.
         **kwargs
-            Other keyword arguments are passed to the init function for this 
+            Other keyword arguments are passed to the init function for this
             class.
 
         Returns
@@ -402,7 +434,7 @@ class VertexData(BrainData):
         except IOError:
             left, right = db.get_surf(subject, "fiducial")
         nverts = len(left[0]) + len(right[0])
-        return cls(np.ones((nverts,))*value, subject, **kwargs)
+        return cls(np.ones((nverts,)) * value, subject, **kwargs)
 
     @classmethod
     def random(cls, subject: str, **kwargs):
@@ -416,7 +448,7 @@ class VertexData(BrainData):
         subject : str
             Subject identifier. Must exist in the pycortex database.
         **kwargs
-            Other keyword arguments are passed to the init function for this 
+            Other keyword arguments are passed to the init function for this
             class.
 
         Returns
@@ -438,7 +470,7 @@ class VertexData(BrainData):
         """
         if data is None:
             data = np.zeros((self.llen + self.rlen,))
-        
+
         self._data = data
         self.movie = self.data.ndim > 1
         self.nverts = self.data.shape[-1]
@@ -458,20 +490,23 @@ class VertexData(BrainData):
             # Data for both hemispheres
             self.hem = "both"
         else:
-            raise ValueError('Invalid number of vertices for subject (given %d, should be %d for left hem, %d for right hem, or %d for both)' % (self.nverts, self.llen, self.rlen, self.llen+self.rlen))
+            raise ValueError(
+                "Invalid number of vertices for subject (given %d, should be %d for left hem, %d for right hem, or %d for both)"
+                % (self.nverts, self.llen, self.rlen, self.llen + self.rlen)
+            )
 
     def copy(self, data: npt.NDArray) -> Self:
         """
         Return a new VertexData object for the same subject but with data
-        replaced by the given `data`. 
+        replaced by the given `data`.
 
-        This is useful for efficiently creating many VertexData objects, since 
-        it doesn't require reloading the surfaces from the database to check 
+        This is useful for efficiently creating many VertexData objects, since
+        it doesn't require reloading the surfaces from the database to check
         numbers of vertices, etc.
         """
         return super(VertexData, self).copy(data, self.subject)
 
-    def volume(self, xfmname, projection='nearest', **kwargs):
+    def volume(self, xfmname, projection="nearest", **kwargs):
         """
         Map this VertexData back to volume space, creating a VolumeData object.
         This uses the `mapper.backwards` function, which is not particularly
@@ -480,12 +515,12 @@ class VertexData(BrainData):
         Parameters
         ----------
         xfmname : str
-            Transform name for the volume space that this vertex data will be 
+            Transform name for the volume space that this vertex data will be
             projected into. Must exist in the pycortex database.
         projection : str, optional
             The type of projection method to use. See the docs for `mapper` for
             possibilities. Default: nearest.
-        **kwargs 
+        **kwargs
             Other keyword args are passed to the `mapper.backwards` function.
 
         Returns
@@ -494,8 +529,10 @@ class VertexData(BrainData):
             Volume containing the back-projected vertex data.
         """
         import warnings
-        warnings.warn('Inverse mapping cannot be accurate')
+
+        warnings.warn("Inverse mapping cannot be accurate")
         from cortex import utils
+
         mapper = utils.get_mapper(self.subject, xfmname, projection)
         return mapper.backwards(self, **kwargs)
 
@@ -503,7 +540,7 @@ class VertexData(BrainData):
         maskstr = ""
         if self.movie:
             maskstr = "movie "
-        return "<Vertex %sdata for %s>"%(maskstr, self.subject)
+        return "<Vertex %sdata for %s>" % (maskstr, self.subject)
 
     def __getitem__(self, idx):
         """Get the VertexData for the given time index. Only works for movie (2D)
@@ -511,8 +548,8 @@ class VertexData(BrainData):
         """
         if not self.movie:
             raise TypeError("Cannot index non-movie data")
-        
-        #return VertexData(self.data[idx], self.subject, **self.attrs)
+
+        # return VertexData(self.data[idx], self.subject, **self.attrs)
         return self.copy(self.data[idx])
 
     def to_json(self, simple: bool = False):
@@ -520,7 +557,7 @@ class VertexData(BrainData):
             sdict = dict(split=self.llen, frames=self.vertices.shape[0])
             sdict.update(super(VertexData, self).to_json(simple=simple))
             return sdict
-            
+
         sdict = dict(data=[self.name])
         sdict.update(super(VertexData, self).to_json())
         return sdict
@@ -534,31 +571,50 @@ class VertexData(BrainData):
 
     @property
     def left(self):
-        """Data for only the left hemisphere vertices.
-        """
+        """Data for only the left hemisphere vertices."""
         if self.movie:
-            return self.data[:,:self.llen]
+            return self.data[:, : self.llen]
         else:
-            return self.data[:self.llen]
+            return self.data[: self.llen]
 
     @property
     def right(self):
-        """Data for only the right hemisphere vertices.
-        """
+        """Data for only the right hemisphere vertices."""
         if self.movie:
-            return self.data[:,self.llen:]
+            return self.data[:, self.llen :]
         else:
-            return self.data[self.llen:]
+            return self.data[self.llen :]
 
-    def blend_curvature(self, alpha, threshold=0, brightness=0.5,
-                        contrast=0.25, smooth=20):
+    def blend_curvature(
+        self, alpha, threshold=0, brightness=0.5, contrast=0.25, smooth=20
+    ):
         """Blend the data with a curvature map depending on a transparency map.
 
         .. deprecated::
-            Per-vertex alpha is now honored directly by both the WebGL viewer
-            and ``cortex.quickshow``. Pass ``alpha=`` to ``VertexRGB`` (or set
-            ``.alpha`` on an existing instance) and the curvature underlay will
-            be blended through automatically.
+            Per-vertex/voxel alpha is now honored directly by both the WebGL
+            viewer and ``cortex.quickshow``, so this curvature-blending hack
+            is no longer needed. The recommended replacement for scalar data
+            with a transparency map is :class:`Vertex2D` (or
+            :class:`Volume2D`) with a 2D colormap whose second axis encodes
+            alpha (e.g. ``"fire_alpha"``, ``"PU_RdBu_covar_alpha"``)::
+
+                # Was:
+                #   blended = vtx.blend_curvature(alpha)
+                #   cortex.quickshow(blended)
+                # Now:
+                v2d = cortex.Vertex2D(vtx.data, alpha, subject,
+                                      cmap="fire_alpha",
+                                      vmin=vtx.vmin, vmax=vtx.vmax,
+                                      vmin2=0, vmax2=1)
+                cortex.quickshow(v2d)         # or cortex.webgl.show(v2d)
+
+            The 2D colormap path keeps colormap parameters (``cmap``,
+            ``vmin``, ``vmax``) editable on the resulting object, and the
+            curvature underlay is composited through automatically by both
+            the matplotlib and WebGL renderers.
+
+            For data that is already RGB, pass ``alpha=`` to
+            :class:`VertexRGB` / :class:`VolumeRGB` directly instead.
 
         Vertex objects cannot use transparency as Volume objects. This method
         is a hack to mimic the transparency of Volume objects, blending the
@@ -578,7 +634,7 @@ class VertexData(BrainData):
             Contrast of the curvature map.
         smooth : float
             Smoothness of the curvature map.
-        
+
         Returns
         -------
         blended : VertexRGB object
@@ -586,31 +642,43 @@ class VertexData(BrainData):
         """
         warnings.warn(
             "blend_curvature is deprecated and will be removed in a future "
-            "release. Per-vertex alpha is now honored directly by both the "
-            "WebGL viewer and quickshow -- pass `alpha=` to VertexRGB (or set "
-            "`.alpha` on an existing instance) and the curvature underlay "
-            "will be blended through automatically.",
+            "release. Per-vertex/voxel alpha is now honored directly by both "
+            "the WebGL viewer and quickshow, so this curvature-blending hack "
+            "is no longer needed. For scalar data with a transparency map, "
+            "use Vertex2D / Volume2D with a 2D colormap whose second axis "
+            "encodes alpha (e.g. 'fire_alpha', 'PU_RdBu_covar_alpha'), e.g. "
+            "`Vertex2D(data, alpha, subject, cmap='fire_alpha', vmin=..., "
+            "vmax=..., vmin2=0, vmax2=1)`. For data that is already RGB, "
+            "pass `alpha=` to VertexRGB / VolumeRGB directly.",
             DeprecationWarning,
             stacklevel=2,
         )
         from .views import Vertex
         from .viewRGB import VertexRGB
+
         # prepare curvature map
         curvature = db.get_surfinfo(self.subject, smooth=smooth).data
         curvature = (curvature > threshold).astype("float")
         curvature = curvature * contrast + brightness
-        curvature_raw = Vertex(curvature, self.subject, vmin=0, vmax=1,
-                               cmap="gray").raw
+        curvature_raw = Vertex(curvature, self.subject, vmin=0, vmax=1, cmap="gray").raw
 
         # prepare alpha map
         alpha = np.clip(alpha.astype("float"), 0, 1)
 
         # blend original map with curvature map
         # self.raw comes from the implementation of Dataview (e.g. Vertex, Volume, etc.)
-        blended = cast(VertexRGB, deepcopy(self.raw))  # copy because VertexRGB.raw returns self
-        blended.red.data = blended.red.data * alpha + (1 - alpha) * curvature_raw.red.data
-        blended.green.data = blended.green.data * alpha + (1 - alpha) * curvature_raw.green.data
-        blended.blue.data = blended.blue.data * alpha + (1 - alpha) * curvature_raw.blue.data
+        blended = cast(
+            VertexRGB, deepcopy(self.raw)
+        )  # copy because VertexRGB.raw returns self
+        blended.red.data = (
+            blended.red.data * alpha + (1 - alpha) * curvature_raw.red.data
+        )
+        blended.green.data = (
+            blended.green.data * alpha + (1 - alpha) * curvature_raw.green.data
+        )
+        blended.blue.data = (
+            blended.blue.data * alpha + (1 - alpha) * curvature_raw.blue.data
+        )
         blended.red.data = blended.red.data.astype("uint8")
         blended.green.data = blended.green.data.astype("uint8")
         blended.blue.data = blended.blue.data.astype("uint8")
@@ -624,22 +692,25 @@ def _find_mask(nvox: int, subject: str, xfmname: str):
     import re
 
     import nibabel
-    files = db.get_paths(subject)['masks'].format(xfmname=xfmname, type="*")
+
+    files = db.get_paths(subject)["masks"].format(xfmname=xfmname, type="*")
     for fname in glob.glob(files):
         nib = nibabel.load(fname)
         mask = cast(npt.NDArray[np.bool_], nib.get_fdata().T != 0)
         if nvox == np.sum(mask):
             fname = os.path.split(fname)[1]
-            name = re.compile(r'mask_(.+).nii.gz').search(fname)
+            name = re.compile(r"mask_(.+).nii.gz").search(fname)
             return name.group(1), mask
 
-    raise ValueError('Cannot find a valid mask')
+    raise ValueError("Cannot find a valid mask")
 
 
 # Generic allows us to return Volume instead of VolumeData
-T_masker = TypeVar('T_masker', bound=VolumeData)
+T_masker = TypeVar("T_masker", bound=VolumeData)
+
+
 class _masker(Generic[T_masker]):
-    def __init__(self, dv: T_masker): # should be braindata + dataview
+    def __init__(self, dv: T_masker):  # should be braindata + dataview
         self.dv = dv
 
         self.data = None
@@ -648,19 +719,25 @@ class _masker(Generic[T_masker]):
 
     def __getitem__(self, masktype: str) -> T_masker:
         mask = db.get_mask(self.dv.subject, self.dv.xfmname, masktype)
-        return self.dv.copy(self.dv.volume[:,mask].squeeze())
+        return self.dv.copy(self.dv.volume[:, mask].squeeze())
+
 
 def _hash(array):
-    '''A simple numpy hash function'''
+    """A simple numpy hash function"""
     array = np.asarray(array)
     return hashlib.sha1(array.tobytes()).hexdigest()
 
+
 def _hdf_write(h5, data, name="data", group="/data"):
     try:
-        node = h5.require_dataset("%s/%s"%(group, name), data.shape, data.dtype, exact=True)
+        node = h5.require_dataset(
+            "%s/%s" % (group, name), data.shape, data.dtype, exact=True
+        )
     except TypeError:
         del h5[group][name]
-        node = h5.create_dataset("%s/%s"%(group, name), data.shape, data.dtype, exact=True)
+        node = h5.create_dataset(
+            "%s/%s" % (group, name), data.shape, data.dtype, exact=True
+        )
 
     node[:] = data
     return node

--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -1,4 +1,5 @@
 import hashlib
+import warnings
 from copy import deepcopy
 import sys
 from typing import Generic, Optional, TypeVar, Union, cast
@@ -552,7 +553,13 @@ class VertexData(BrainData):
     def blend_curvature(self, alpha, threshold=0, brightness=0.5,
                         contrast=0.25, smooth=20):
         """Blend the data with a curvature map depending on a transparency map.
-        
+
+        .. deprecated::
+            Per-vertex alpha is now honored directly by both the WebGL viewer
+            and ``cortex.quickshow``. Pass ``alpha=`` to ``VertexRGB`` (or set
+            ``.alpha`` on an existing instance) and the curvature underlay will
+            be blended through automatically.
+
         Vertex objects cannot use transparency as Volume objects. This method
         is a hack to mimic the transparency of Volume objects, blending the
         Vertex data with a curvature map. This method returns a VertexRGB
@@ -577,6 +584,15 @@ class VertexData(BrainData):
         blended : VertexRGB object
             The original map blended with a curvature map.
         """
+        warnings.warn(
+            "blend_curvature is deprecated and will be removed in a future "
+            "release. Per-vertex alpha is now honored directly by both the "
+            "WebGL viewer and quickshow -- pass `alpha=` to VertexRGB (or set "
+            "`.alpha` on an existing instance) and the curvature underlay "
+            "will be blended through automatically.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from .views import Vertex
         from .viewRGB import VertexRGB
         # prepare curvature map

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -312,23 +312,27 @@ def test_blend_curvature():
     view = cortex.Vertex.empty(subj)
     alpha = np.linspace(0, 1, view.data.size).reshape(view.data.shape)
 
-    # test alpha with float
-    view_rgb = view.blend_curvature(alpha)
-    # test alpha with bool
-    view_rgb = view.blend_curvature(alpha > 0.3)
+    # blend_curvature is deprecated; the warning should fire on every call.
+    with pytest.warns(DeprecationWarning, match="blend_curvature is deprecated"):
+        view_rgb = view.blend_curvature(alpha)
+    with pytest.warns(DeprecationWarning):
+        view_rgb = view.blend_curvature(alpha > 0.3)
     # test that it returns a VertexRGB
     assert isinstance(view_rgb, cortex.VertexRGB)
 
     # test on Vertex2D
     view_2d = cortex.Vertex2D(view_rgb.red.data, view_rgb.green.data, subj)
-    view_rgb = view_2d.blend_curvature(alpha)
+    with pytest.warns(DeprecationWarning):
+        view_rgb = view_2d.blend_curvature(alpha)
 
     # test on VertexRGB
-    view_rgb_new = view_rgb.blend_curvature(alpha)
+    with pytest.warns(DeprecationWarning):
+        view_rgb_new = view_rgb.blend_curvature(alpha)
     # test that it returns a different VertexRGB
     assert not np.allclose(view_rgb.red.data, view_rgb_new.red.data)
     # test that it returns a VertexRGB with same values when alpha is ones
-    view_rgb_new = view_rgb.blend_curvature(np.ones_like(alpha))
+    with pytest.warns(DeprecationWarning):
+        view_rgb_new = view_rgb.blend_curvature(np.ones_like(alpha))
     assert np.allclose(view_rgb.red.data, view_rgb_new.red.data)
 
 

--- a/cortex/tests/test_quickflat.py
+++ b/cortex/tests/test_quickflat.py
@@ -3,7 +3,9 @@ import numpy as np
 import tempfile
 import pytest
 
+from cortex import dataset
 from cortex.testing_utils import has_installed
+from cortex.webgl.data import Package
 
 no_inkscape = not has_installed('inkscape')
 
@@ -40,3 +42,80 @@ def test_make_flatmap_image_nanmean(type_, nanmean):
         vol, nanmean=nanmean)
     # assert that the nanmean only returns NaNs and 1s
     assert np.nanmin(img) == 1
+
+
+def test_quickshow_webgl_alpha_equivalence():
+    """quickshow (matplotlib) and WebGL must render the same VertexRGB+α identically.
+
+    Issue #631: the WebGL shader uses a premultiplied "over" composite, while
+    matplotlib's imshow layering uses straight alpha. The fix premultiplies α
+    into RGB at the WebGL serialization step only, so both paths converge on
+    the same composite formula  out = α·rgb + (1-α)·bg  for any background.
+    This test asserts that equivalence at the per-vertex level for an
+    arbitrary curvature gray.
+    """
+    subj = "S1"
+    nverts = cortex.db.get_surf(subj, "fiducial", merge=True)[0].shape[0]
+    rng = np.random.default_rng(631)
+    r = rng.uniform(0, 1, nverts).astype(np.float32)
+    g = rng.uniform(0, 1, nverts).astype(np.float32)
+    b = rng.uniform(0, 1, nverts).astype(np.float32)
+    alpha = rng.uniform(0, 1, nverts).astype(np.float32)
+
+    vrgb = cortex.VertexRGB(
+        r, g, b, subj,
+        alpha=cortex.Vertex(alpha, subj, vmin=0, vmax=1),
+    )
+
+    raw = vrgb.vertices  # what quickshow/matplotlib will composite (non-premult)
+    pkg = Package(dataset.Dataset(view=vrgb))
+    packaged = pkg.images[vrgb.name][0]  # what the shader will composite (premult)
+
+    # Sanity: alpha is shared between the two paths.
+    assert np.array_equal(raw[..., 3], packaged[..., 3])
+
+    # Composite both against an arbitrary curvature gray. matplotlib's
+    # imshow with two layered images uses straight alpha; the GLSL shader at
+    # shaderlib.js line 851 uses gl_FragColor = vColor + (1-α)·bg.
+    a_norm = raw[..., 3:4].astype(np.float32) / 255.0
+    rgb_raw = raw[..., :3].astype(np.float32) / 255.0
+    rgb_pkg = packaged[..., :3].astype(np.float32) / 255.0
+    for curv in (0.0, 0.25, 0.5, 0.75, 1.0):
+        bg = np.full_like(rgb_raw, curv)
+        matplotlib_out = a_norm * rgb_raw + (1.0 - a_norm) * bg
+        webgl_out = rgb_pkg + (1.0 - a_norm) * bg
+        # 1 LSB of uint8 rounding on each side -> 2/255 worst case.
+        np.testing.assert_allclose(matplotlib_out, webgl_out, atol=2.0 / 255.0)
+
+
+def test_make_flatmap_image_vertexrgb_alpha_unchanged():
+    """The matplotlib path must keep using NON-premultiplied RGBA bytes.
+
+    Premultiplying inside .vertices would silently double-attenuate the
+    quickshow output. Pin that .vertices stays straight-alpha by checking
+    a uniform bright-red, half-transparent VertexRGB survives
+    make_flatmap_image without losing red intensity.
+    """
+    subj = "S1"
+    nverts = cortex.db.get_surf(subj, "fiducial", merge=True)[0].shape[0]
+    # Uniform bright red, half transparent everywhere. Pass explicit Vertex
+    # objects with vmin/vmax to avoid auto-range degeneracy on the flat
+    # green/blue channels.
+    r = cortex.Vertex(np.ones(nverts, dtype=np.float32), subj, vmin=0, vmax=1)
+    g = cortex.Vertex(np.zeros(nverts, dtype=np.float32), subj, vmin=0, vmax=1)
+    b = cortex.Vertex(np.zeros(nverts, dtype=np.float32), subj, vmin=0, vmax=1)
+    alpha = cortex.Vertex(np.full(nverts, 0.5, dtype=np.float32), subj,
+                          vmin=0, vmax=1)
+    vrgb = cortex.VertexRGB(r, g, b, subj, alpha=alpha)
+    img, _ = cortex.quickflat.utils.make_flatmap_image(vrgb)
+    # img is the rasterized RGBA flatmap. The data layer's red channel (where
+    # mask is filled and pixmap is non-degenerate) must be ~255, not ~127 --
+    # if we ever start premultiplying inside .vertices, this drops to ~127.
+    rgba_in_mask = img[img[..., 3] > 0]
+    assert rgba_in_mask.size > 0
+    # Filled pixels should have red close to 255 (bright red, with alpha=128).
+    bright_red_pixels = rgba_in_mask[rgba_in_mask[..., 0] > 200]
+    assert bright_red_pixels.size > 0, (
+        "VertexRGB.vertices appears to be premultiplied -- the matplotlib "
+        "path will double-attenuate. The fix should live in webgl/data.py."
+    )

--- a/cortex/tests/test_webgl_data.py
+++ b/cortex/tests/test_webgl_data.py
@@ -43,7 +43,10 @@ def test_vertexrgb_alpha_is_premultiplied_in_package():
     alpha = rng.uniform(0, 1, nverts).astype(np.float32)
 
     vrgb = cortex.VertexRGB(
-        r, g, b, subj,
+        r,
+        g,
+        b,
+        subj,
         alpha=cortex.Vertex(alpha, subj, vmin=0, vmax=1),
     )
 
@@ -61,9 +64,15 @@ def test_vertexrgb_alpha_is_premultiplied_in_package():
     naive_premult = np.round(
         raw[0, :, 0].astype(np.float32) * raw[0, :, 3].astype(np.float32) / 255.0
     ).astype(np.uint8)
-    assert np.mean(np.abs(
-        raw[0, nontrivial, 0].astype(int) - naive_premult[nontrivial].astype(int)
-    )) > 5, "vertices property looks already-premultiplied; quickshow would break"
+    assert (
+        np.mean(
+            np.abs(
+                raw[0, nontrivial, 0].astype(int)
+                - naive_premult[nontrivial].astype(int)
+            )
+        )
+        > 5
+    ), "vertices property looks already-premultiplied; quickshow would break"
 
     # Now check what Package serializes for the WebGL viewer.
     packaged = _packaged_rgba(vrgb)
@@ -105,7 +114,10 @@ def test_vertexrgb_alpha_zero_zeros_rgb():
     alpha = np.zeros(nverts, dtype=np.float32)
 
     vrgb = cortex.VertexRGB(
-        r, g, b, subj,
+        r,
+        g,
+        b,
+        subj,
         alpha=cortex.Vertex(alpha, subj, vmin=0, vmax=1),
     )
     packaged = _packaged_rgba(vrgb)
@@ -113,9 +125,16 @@ def test_vertexrgb_alpha_zero_zeros_rgb():
     assert np.array_equal(packaged[..., :3], np.zeros_like(packaged[..., :3]))
 
 
-def test_volumergb_alpha_is_premultiplied_in_package():
-    """VolumeRGB shares the same shader path -- check the same premultiplication."""
-    # Smaller volume to keep the test fast.
+def test_volumergb_alpha_is_NOT_premultiplied_in_package():
+    """VolumeRGB must ship straight-alpha bytes -- Three.js premultiplies on upload.
+
+    Three.js sets ``tex.premultiplyAlpha = true`` for raw VolumeRGB textures
+    (cortex/webgl/resources/js/dataset.js:335-338), which makes WebGL apply
+    UNPACK_PREMULTIPLY_ALPHA_WEBGL on texture upload. So the shader sees
+    premultiplied RGB by the time vColor is sampled, but ONLY because the
+    texture-upload pipeline does it for us. If Package also premultiplied
+    here, partial-alpha VolumeRGB would render double-attenuated (too dark).
+    """
     rng = np.random.default_rng(3)
     shape = volshape
     r = rng.uniform(0, 1, shape).astype(np.float32)
@@ -124,7 +143,11 @@ def test_volumergb_alpha_is_premultiplied_in_package():
     alpha = rng.uniform(0, 1, shape).astype(np.float32)
 
     vrgb = cortex.VolumeRGB(
-        r, g, b, subj, xfmname,
+        r,
+        g,
+        b,
+        subj,
+        xfmname,
         alpha=cortex.Volume(alpha, subj, xfmname, vmin=0, vmax=1),
     )
 
@@ -132,8 +155,9 @@ def test_volumergb_alpha_is_premultiplied_in_package():
     assert raw.dtype == np.uint8
 
     # Spy on the Package internals: monkey-patch volume.mosaic to capture the
-    # premultiplied array before it gets PNG-encoded.
+    # array Package actually ships before it gets PNG-encoded.
     from cortex.webgl import data as webgl_data
+
     captured = {}
     real_mosaic = webgl_data.volume.mosaic
 
@@ -147,11 +171,23 @@ def test_volumergb_alpha_is_premultiplied_in_package():
     finally:
         webgl_data.volume.mosaic = real_mosaic
 
-    # One frame per timepoint; VolumeRGB here has t=1.
     assert len(captured["frames"]) == 1
     packaged_frame = captured["frames"][0]
-    expected_frame = _expected_premultiplied(raw[0])  # raw shape (t,z,y,x,4)
 
-    assert packaged_frame.shape == expected_frame.shape
-    assert np.array_equal(packaged_frame[..., 3], expected_frame[..., 3])
-    assert np.array_equal(packaged_frame[..., :3], expected_frame[..., :3])
+    # Bytes shipped to the browser must equal the raw .volume bytes verbatim
+    # (NOT premultiplied) -- Three.js will premultiply once on texture upload.
+    assert packaged_frame.shape == raw[0].shape
+    assert np.array_equal(packaged_frame, raw[0])
+
+    # And specifically, RGB should NOT have been premultiplied by alpha.
+    naive_premult = _expected_premultiplied(raw[0])
+    nontrivial = (raw[0, ..., 3] < 200) & (raw[0, ..., 0] > 50)
+    assert (
+        np.mean(
+            np.abs(
+                packaged_frame[nontrivial][..., 0].astype(int)
+                - naive_premult[nontrivial][..., 0].astype(int)
+            )
+        )
+        > 5
+    ), "VolumeRGB Package output looks premultiplied; Three.js will then double-attenuate"

--- a/cortex/tests/test_webgl_data.py
+++ b/cortex/tests/test_webgl_data.py
@@ -154,25 +154,26 @@ def test_volumergb_alpha_is_NOT_premultiplied_in_package():
     raw = vrgb.volume
     assert raw.dtype == np.uint8
 
-    # Spy on the Package internals: monkey-patch volume.mosaic to capture the
-    # array Package actually ships before it gets PNG-encoded.
+    # Spy on the Package internals: wrap volume.mosaic to capture the array
+    # Package actually ships before it gets PNG-encoded. mock.patch handles
+    # restoration even if the patched call raises before reaching the
+    # assertions below.
+    from unittest import mock
+
     from cortex.webgl import data as webgl_data
 
-    captured = {}
+    captured = []
     real_mosaic = webgl_data.volume.mosaic
 
     def spy_mosaic(arr, show=False):
-        captured.setdefault("frames", []).append(arr.copy())
+        captured.append(arr.copy())
         return real_mosaic(arr, show=show)
 
-    webgl_data.volume.mosaic = spy_mosaic
-    try:
+    with mock.patch.object(webgl_data.volume, "mosaic", side_effect=spy_mosaic):
         Package(dataset.Dataset(view=vrgb))
-    finally:
-        webgl_data.volume.mosaic = real_mosaic
 
-    assert len(captured["frames"]) == 1
-    packaged_frame = captured["frames"][0]
+    assert len(captured) == 1
+    packaged_frame = captured[0]
 
     # Bytes shipped to the browser must equal the raw .volume bytes verbatim
     # (NOT premultiplied) -- Three.js will premultiply once on texture upload.

--- a/cortex/tests/test_webgl_data.py
+++ b/cortex/tests/test_webgl_data.py
@@ -1,0 +1,157 @@
+"""Tests for the WebGL serialization layer in cortex.webgl.data."""
+
+import numpy as np
+import pytest
+
+import cortex
+from cortex import dataset
+from cortex.webgl.data import Package
+
+
+subj, xfmname, nverts, volshape = "S1", "fullhead", 304380, (31, 100, 100)
+
+
+def _packaged_rgba(brain):
+    """Run a dataview through Package and recover the pre-mosaic uint8 RGBA bytes."""
+    pkg = Package(dataset.Dataset(view=brain))
+    images = pkg.images[brain.name]
+    # Vertex* paths store the raw uint8 array directly; Volume* paths mosaic+PNG.
+    if isinstance(brain, dataset.VertexRGB):
+        return images[0]
+    raise NotImplementedError("Use _packaged_rgba_volume for VolumeRGB")
+
+
+def _expected_premultiplied(raw_uint8):
+    """Compute alpha-premultiplied RGB bytes the same way Package should."""
+    a = raw_uint8[..., 3:4].astype(np.float32) / 255.0
+    out = raw_uint8.copy()
+    out[..., :3] = np.round(raw_uint8[..., :3].astype(np.float32) * a).astype(np.uint8)
+    return out
+
+
+def test_vertexrgb_alpha_is_premultiplied_in_package():
+    """WebGL Package should ship alpha-premultiplied RGB bytes (issue #631).
+
+    The shader formula is gl_FragColor = vColor + (1-α)·bg, which only yields
+    correct "over" compositing when vColor is premultiplied. The fix lives in
+    Package.__init__; this test pins the contract.
+    """
+    rng = np.random.default_rng(0)
+    r = rng.uniform(0, 1, nverts).astype(np.float32)
+    g = rng.uniform(0, 1, nverts).astype(np.float32)
+    b = rng.uniform(0, 1, nverts).astype(np.float32)
+    alpha = rng.uniform(0, 1, nverts).astype(np.float32)
+
+    vrgb = cortex.VertexRGB(
+        r, g, b, subj,
+        alpha=cortex.Vertex(alpha, subj, vmin=0, vmax=1),
+    )
+
+    # Sanity: the .vertices property itself stays NON-premultiplied so the
+    # quickshow (matplotlib) path keeps working.
+    raw = vrgb.vertices
+    assert raw.dtype == np.uint8
+    assert raw.shape == (1, nverts, 4)
+    # Raw alpha must round-trip the input alpha to within 1 LSB.
+    expected_a = (np.clip(alpha, 0, 1) * 255).astype(np.uint8)
+    assert np.allclose(raw[0, :, 3].astype(int), expected_a.astype(int), atol=1)
+    # Raw RGB bytes must NOT already be premultiplied -- if they were, the
+    # fix is in the wrong layer and quickshow would double-attenuate.
+    nontrivial = expected_a < 200  # avoid α≈1 where premult ≈ raw
+    naive_premult = np.round(
+        raw[0, :, 0].astype(np.float32) * raw[0, :, 3].astype(np.float32) / 255.0
+    ).astype(np.uint8)
+    assert np.mean(np.abs(
+        raw[0, nontrivial, 0].astype(int) - naive_premult[nontrivial].astype(int)
+    )) > 5, "vertices property looks already-premultiplied; quickshow would break"
+
+    # Now check what Package serializes for the WebGL viewer.
+    packaged = _packaged_rgba(vrgb)
+    expected = _expected_premultiplied(raw)
+    assert packaged.shape == raw.shape
+    assert packaged.dtype == np.uint8
+    # Alpha channel must be passed through unchanged (shader needs it for 1-α).
+    assert np.array_equal(packaged[..., 3], expected[..., 3])
+    # RGB channels must be alpha-premultiplied.
+    assert np.array_equal(packaged[..., :3], expected[..., :3])
+
+    # And the un-packaged property must NOT have been mutated by Package
+    # (Package should defensive-copy).
+    raw_after = vrgb.vertices
+    assert np.array_equal(raw_after, raw)
+
+
+def test_vertexrgb_alpha_one_is_passthrough():
+    """When α=1 everywhere, premultiplication is a no-op (bug was invisible at α=1)."""
+    rng = np.random.default_rng(1)
+    r = rng.uniform(0, 1, nverts).astype(np.float32)
+    g = rng.uniform(0, 1, nverts).astype(np.float32)
+    b = rng.uniform(0, 1, nverts).astype(np.float32)
+
+    vrgb = cortex.VertexRGB(r, g, b, subj)  # default alpha = 1
+    raw = vrgb.vertices
+    packaged = _packaged_rgba(vrgb)
+    assert np.array_equal(packaged[..., 3], raw[..., 3])  # alpha all 255
+    # RGB unchanged because α=255 → premultiply by 1.
+    assert np.array_equal(packaged[..., :3], raw[..., :3])
+
+
+def test_vertexrgb_alpha_zero_zeros_rgb():
+    """α=0 must drive packaged RGB to 0 -- the shader then renders pure curvature."""
+    rng = np.random.default_rng(2)
+    r = rng.uniform(0, 1, nverts).astype(np.float32)
+    g = rng.uniform(0, 1, nverts).astype(np.float32)
+    b = rng.uniform(0, 1, nverts).astype(np.float32)
+    alpha = np.zeros(nverts, dtype=np.float32)
+
+    vrgb = cortex.VertexRGB(
+        r, g, b, subj,
+        alpha=cortex.Vertex(alpha, subj, vmin=0, vmax=1),
+    )
+    packaged = _packaged_rgba(vrgb)
+    assert np.array_equal(packaged[..., 3], np.zeros_like(packaged[..., 3]))
+    assert np.array_equal(packaged[..., :3], np.zeros_like(packaged[..., :3]))
+
+
+def test_volumergb_alpha_is_premultiplied_in_package():
+    """VolumeRGB shares the same shader path -- check the same premultiplication."""
+    # Smaller volume to keep the test fast.
+    rng = np.random.default_rng(3)
+    shape = volshape
+    r = rng.uniform(0, 1, shape).astype(np.float32)
+    g = rng.uniform(0, 1, shape).astype(np.float32)
+    b = rng.uniform(0, 1, shape).astype(np.float32)
+    alpha = rng.uniform(0, 1, shape).astype(np.float32)
+
+    vrgb = cortex.VolumeRGB(
+        r, g, b, subj, xfmname,
+        alpha=cortex.Volume(alpha, subj, xfmname, vmin=0, vmax=1),
+    )
+
+    raw = vrgb.volume
+    assert raw.dtype == np.uint8
+
+    # Spy on the Package internals: monkey-patch volume.mosaic to capture the
+    # premultiplied array before it gets PNG-encoded.
+    from cortex.webgl import data as webgl_data
+    captured = {}
+    real_mosaic = webgl_data.volume.mosaic
+
+    def spy_mosaic(arr, show=False):
+        captured.setdefault("frames", []).append(arr.copy())
+        return real_mosaic(arr, show=show)
+
+    webgl_data.volume.mosaic = spy_mosaic
+    try:
+        Package(dataset.Dataset(view=vrgb))
+    finally:
+        webgl_data.volume.mosaic = real_mosaic
+
+    # One frame per timepoint; VolumeRGB here has t=1.
+    assert len(captured["frames"]) == 1
+    packaged_frame = captured["frames"][0]
+    expected_frame = _expected_premultiplied(raw[0])  # raw shape (t,z,y,x,4)
+
+    assert packaged_frame.shape == expected_frame.shape
+    assert np.array_equal(packaged_frame[..., 3], expected_frame[..., 3])
+    assert np.array_equal(packaged_frame[..., :3], expected_frame[..., :3])

--- a/cortex/tests/test_webgl_headless.py
+++ b/cortex/tests/test_webgl_headless.py
@@ -488,6 +488,120 @@ def test_volumergb_alpha_half_renders_correct_blend(tmp_path):
         )
 
 
+def test_vertex2d_alpha_half_renders_correct_blend(tmp_path):
+    """Vertex2D with α=0.5 must blend halfway, not over-attenuate the bg.
+
+    Companion regression to the issue #631 fix on the colormap-texture
+    path. The 2D dataview ships dim1 / dim2 as separate scalar maps and
+    the LUT lookup happens on the GPU via
+    ``texture2D(colormap, vec2(dim1_norm, dim2_norm))``. The shader's
+    composite (shaderlib.js:851) uses the premultiplied-over formula
+    ``vColor + (1-α)·bg``, so the colormap texture itself must be
+    premultiplied on upload (``tex.premultiplyAlpha = true`` in
+    mriview.js). Without that, alpha-bearing colormaps like
+    ``RdBu_r_alpha`` produce ``R + (1-α)·bg`` -- where the foreground
+    is added on top of a partially-attenuated curvature -- instead of
+    the correct ``α·R + (1-α)·bg``.
+
+    α=0 doesn't catch this bug because most alpha colormaps store
+    ``(0, 0, 0, 0)`` at the transparent end of the LUT (so neither the
+    buggy nor the correct shader produces foreground there). At α=0.5
+    the LUT stores its full RGB with α=127, and the difference between
+    buggy and correct composites is maximal in the brain region.
+
+    Empirical pixel stats for RdBu_r_alpha at data=+1, alpha=0.5,
+    inflated lateral_pivot view, default viewer params (S1):
+
+      - correct (premultiplied): red_dom median R ≈ 93 (25/50/75 = 80/93/110)
+      - buggy (un-premultiplied): red_dom median R ≈ 129 (25/50/75 = 105/129/149)
+
+    Threshold at 115 sits between the two distributions.
+    """
+    from PIL import Image
+
+    # data=+1 puts every vertex at the deep red end of RdBu_r_alpha,
+    # alpha=0.5 puts every vertex at mid-α (LUT row ~128).
+    data = np.full(nverts, 1.0, dtype=np.float32)
+    alpha = np.full(nverts, 0.5, dtype=np.float32)
+
+    vtx2d = cortex.Vertex2D(
+        data, alpha, subj,
+        cmap="RdBu_r_alpha",
+        vmin=-1, vmax=1,
+        vmin2=0, vmax2=1,
+    )
+
+    view = {
+        **default_view_params,
+        **angle_view_params["lateral_pivot"],
+        **unfold_view_params["inflated"],
+    }
+    # The cmap <img> elements decode asynchronously in Chromium. If the first
+    # render frame happens before the LUT image has decoded, three.js skips
+    # the texImage2D upload and the data layer renders against a 1×1 black
+    # texture (R==G==B everywhere -- looks like the curvature underlay).
+    # Retry _set_view + getImage until we observe a colored data layer
+    # (some pixels with R clearly > G or B, or vice-versa). We then run the
+    # premultiplication discriminator on that frame.
+    with cortex.export.headless_viewer(vtx2d, viewer_params={}) as handle:
+        time.sleep(15)
+        rgb = None
+        outfile = None
+        for attempt in range(6):
+            handle._set_view(**view)
+            time.sleep(3)
+            # Use a fresh filename each retry so we never read a partial PNG
+            # left over from a prior iteration (getImage writes async).
+            outfile = str(tmp_path / f"vertex2d_alpha_half_{attempt}.png")
+            handle.getImage(outfile, (512, 384))
+            _wait_for_file(outfile)
+            # Give the PNG writer a moment to finish flushing.
+            time.sleep(1)
+            try:
+                rgb = np.array(Image.open(outfile))[..., :3].astype(int)
+            except Exception:
+                continue
+            # "Colored" = at least some pixels deviate strongly from R==G==B.
+            # In a curvature-only (cmap-unbound) frame all brain pixels have
+            # R==G==B exactly; any non-zero count of channel-divergent pixels
+            # means the cmap texture is bound.
+            channel_spread = np.abs(rgb[..., 0] - rgb[..., 1]) + np.abs(
+                rgb[..., 1] - rgb[..., 2]
+            )
+            if (channel_spread > 5).sum() > 1000:
+                break
+        else:
+            pytest.skip(
+                "Cmap texture never bound in headless Chromium across 6 "
+                "render retries; can't discriminate fix vs bug."
+            )
+
+        # Both fix and bug produce a red-dominant brain region (the bug
+        # doesn't zero the foreground, just over-brightens it). The
+        # discriminator is the *median R intensity* of those red-dominant
+        # pixels: the buggy un-premultiplied path adds the full R on top of
+        # half the curvature, biasing R upward; the correct premultiplied
+        # path attenuates R by α before adding curvature.
+        #
+        # First, the brain must render as a red-dominant region (this is
+        # also satisfied by the bug, but if even this fails the cmap is
+        # unbound and we can't discriminate).
+        red_mask = rgb[..., 0] - np.maximum(rgb[..., 1], rgb[..., 2]) > 20
+        assert red_mask.sum() > 1000, (
+            f"Vertex2D α=0.5 deep-red rendered only {red_mask.sum()} "
+            "red-dominant pixels. Check that the cmap LUT bound and the "
+            "data layer rendered at all."
+        )
+        median_r = float(np.median(rgb[red_mask, 0]))
+        assert median_r < 115, (
+            f"Vertex2D α=0.5 brain pixels have median R={median_r:.0f}; "
+            "expected ≈93 (correct), saw ≥115 which is in the buggy range "
+            "(~129). The colormap texture is being sampled straight-alpha "
+            "while the shader applies a premultiplied composite -- check "
+            "mriview.js cmap texture premultiplyAlpha."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Group 9: addData dataset switching
 # ---------------------------------------------------------------------------

--- a/cortex/tests/test_webgl_headless.py
+++ b/cortex/tests/test_webgl_headless.py
@@ -622,3 +622,208 @@ def test_addData_no_crash():
         time.sleep(2)
         pageerrors = [e for e in handle._pw_thread.browser_errors if "[pageerror]" in e]
         assert len(pageerrors) == 0, f"JS errors after addData: {pageerrors}"
+
+
+# ---------------------------------------------------------------------------
+# Group 10: Manual visual A/B comparison across all alpha-bearing dataviews
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("RUN_VISUAL_COMPARISON"),
+    reason="Manual visual comparison; set RUN_VISUAL_COMPARISON=1 to run.",
+)
+def test_visual_comparison_alpha_dataviews(tmp_path):
+    """Render all 6 dataview types via quickshow + webgl, side-by-side.
+
+    Skipped by default — set ``RUN_VISUAL_COMPARISON=1`` to run. Builds a
+    grid where each row is one dataview type (Volume, Vertex, Volume2D,
+    Vertex2D, VolumeRGB, VertexRGB) and the two columns are the matplotlib
+    (``cortex.quickshow``) reference vs the headless WebGL flatmap render.
+    Used as a manual smoke check that the alpha-blend fix
+    (``Package``-side premultiply for VertexRGB + cmap-LUT
+    ``premultiplyAlpha=true`` for the 2D-cmap path) keeps both viewers in
+    visual agreement across every alpha-encoding pattern.
+
+    Plain Volume / Vertex have no native per-element alpha (pycortex's
+    bundled ``*_alpha`` colormaps are all 2D and only apply to the 2D
+    dataview types), so those two rows act as a no-alpha baseline. The
+    other four rows exercise alpha: Volume2D / Vertex2D via the 2D-alpha
+    cmap ``RdBu_r_alpha``, VolumeRGB / VertexRGB via the ``alpha=`` kwarg.
+
+    Renders are intentionally low-resolution (quickshow ``height=256``,
+    webgl ``size=(512, 384)``) so the final composite PNG stays small.
+    Both viewers run with no labels, no ROIs, and curvature underlay on.
+
+    The composite PNG is written under ``tmp_path`` and the absolute path
+    is printed at the end of the test so the file is easy to open.
+    """
+    import matplotlib.pyplot as plt
+
+    import cortex.polyutils
+
+    # ------- Synthesize data and alpha maps (mirrors plot_data_with_alpha.py) -
+
+    # Volumetric
+    zz, yy, xx = np.mgrid[0:31, 0:100, 0:100]
+    data_vol = (xx - 50) / 50.0  # ~ [-1, 1]
+    center = np.array([15, 50, 50])
+    sigma_v = 25.0
+    dist2 = (
+        (zz - center[0]) ** 2 + (yy - center[1]) ** 2 + (xx - center[2]) ** 2
+    )
+    accuracy_vol = np.exp(-dist2 / (2 * sigma_v**2))  # [0, 1] bump
+    red_vol = np.clip(xx / 99.0, 0, 1)
+    green_vol = np.clip(yy / 99.0, 0, 1)
+    blue_vol = np.clip(zz / 30.0, 0, 1)
+
+    # Surface (vertex) — encode by spatial coordinate, not vertex index
+    surfs = [
+        cortex.polyutils.Surface(*d)
+        for d in cortex.db.get_surf(subj, "fiducial")
+    ]
+    num_verts = [s.pts.shape[0] for s in surfs]
+    pts = np.vstack([surfs[0].pts, surfs[1].pts])
+    y_centered = pts[:, 1] - pts[:, 1].mean()
+    data_vtx = y_centered / np.abs(y_centered).max()  # [-1, 1]
+    xyz_norm = (pts - pts.min(axis=0)) / (pts.max(axis=0) - pts.min(axis=0))
+
+    def _bump(surf, seed, sigma):
+        d = np.linalg.norm(surf.pts - surf.pts[seed], axis=1)
+        return np.exp(-(d**2) / (2 * sigma**2))
+
+    accuracy_vtx = np.hstack(
+        [
+            _bump(surfs[0], num_verts[0] // 2, sigma=40.0),
+            _bump(surfs[1], num_verts[1] // 2, sigma=40.0),
+        ]
+    )
+
+    # ------- Build the six dataviews ----------------------------------------
+    # Volume / Vertex have no native per-element alpha — pycortex's bundled
+    # `*_alpha` colormaps are all 2D LUTs and only apply to Volume2D /
+    # Vertex2D. So plain Volume / Vertex use a non-alpha cmap (`viridis`)
+    # and serve as the no-alpha baseline; Volume2D / Vertex2D pair data
+    # against accuracy via the 2D-alpha cmap `RdBu_r_alpha`; VolumeRGB /
+    # VertexRGB use the native `alpha=` kwarg.
+
+    cmap_plain = "viridis"
+    cmap_2d = "RdBu_r_alpha"
+
+    dataviews = [
+        (
+            "Volume",
+            cortex.Volume(
+                data_vol, subj, xfmname,
+                cmap=cmap_plain, vmin=-1, vmax=1,
+            ),
+        ),
+        (
+            "Vertex",
+            cortex.Vertex(
+                data_vtx, subj,
+                cmap=cmap_plain, vmin=-1, vmax=1,
+            ),
+        ),
+        (
+            "Volume2D",
+            cortex.Volume2D(
+                data_vol, accuracy_vol, subj, xfmname,
+                cmap=cmap_2d,
+                vmin=-1, vmax=1, vmin2=0, vmax2=1,
+            ),
+        ),
+        (
+            "Vertex2D",
+            cortex.Vertex2D(
+                data_vtx, accuracy_vtx, subj,
+                cmap=cmap_2d,
+                vmin=-1, vmax=1, vmin2=0, vmax2=1,
+            ),
+        ),
+        (
+            "VolumeRGB",
+            cortex.VolumeRGB(
+                cortex.Volume(red_vol, subj, xfmname, vmin=0, vmax=1),
+                cortex.Volume(green_vol, subj, xfmname, vmin=0, vmax=1),
+                cortex.Volume(blue_vol, subj, xfmname, vmin=0, vmax=1),
+                subj, xfmname,
+                alpha=cortex.Volume(accuracy_vol, subj, xfmname, vmin=0, vmax=1),
+            ),
+        ),
+        (
+            "VertexRGB",
+            cortex.VertexRGB(
+                cortex.Vertex(xyz_norm[:, 0], subj, vmin=0, vmax=1),
+                cortex.Vertex(xyz_norm[:, 1], subj, vmin=0, vmax=1),
+                cortex.Vertex(xyz_norm[:, 2], subj, vmin=0, vmax=1),
+                subj,
+                alpha=cortex.Vertex(accuracy_vtx, subj, vmin=0, vmax=1),
+            ),
+        ),
+    ]
+
+    # ------- Render each dataview through both paths ------------------------
+    # Each WebGL render spins up its own headless browser via plot_panels;
+    # six sequential launches × ~15s sleep = ~90s+ end to end. That's fine
+    # for a manual A/B and avoids the broken `addData` path on headless.
+
+    n = len(dataviews)
+    fig, axes = plt.subplots(n, 2, figsize=(7, 2.2 * n))
+
+    flatmap_panel = [
+        {
+            "extent": [0.0, 0.0, 1.0, 1.0],
+            "view": {"angle": "flatmap", "surface": "flatmap"},
+        }
+    ]
+
+    for row, (name, view) in enumerate(dataviews):
+        # quickshow → low-res PNG
+        qs_path = tmp_path / f"qs_{name}.png"
+        qs_fig = cortex.quickshow(
+            view,
+            with_curvature=True,
+            with_rois=False,
+            with_labels=False,
+            with_colorbar=False,
+            with_sulci=False,
+            with_borders=False,
+            height=256,
+        )
+        qs_fig.savefig(qs_path, bbox_inches="tight", pad_inches=0, dpi=80)
+        plt.close(qs_fig)
+
+        # webgl → trimmed flatmap PNG via plot_panels (single flatmap panel)
+        wg_path = str(tmp_path / f"wg_{name}.png")
+        wg_fig = cortex.export.plot_panels(
+            view,
+            panels=flatmap_panel,
+            figsize=(6, 3),
+            windowsize=(512, 384),
+            save_name=wg_path,
+            sleep=10,
+            viewer_params=dict(labels_visible=[], overlays_visible=[]),
+            headless=True,
+        )
+        plt.close(wg_fig)
+
+        ax_qs, ax_wg = axes[row]
+        ax_qs.imshow(plt.imread(qs_path))
+        ax_qs.set_title(f"{name} — quickshow", fontsize=9)
+        ax_qs.axis("off")
+        ax_wg.imshow(plt.imread(wg_path))
+        ax_wg.set_title(f"{name} — webgl (flatmap)", fontsize=9)
+        ax_wg.axis("off")
+
+    fig.suptitle(
+        "Alpha-bearing dataviews: quickshow vs WebGL", fontsize=11,
+    )
+    fig.tight_layout()
+    out_path = tmp_path / "alpha_dataview_comparison.png"
+    fig.savefig(out_path, dpi=100, bbox_inches="tight")
+    plt.close(fig)
+
+    print(f"\nVisual comparison saved to:\n  {out_path}\n")
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0

--- a/cortex/tests/test_webgl_headless.py
+++ b/cortex/tests/test_webgl_headless.py
@@ -387,7 +387,10 @@ def test_vertexrgb_alpha_zero_renders_curvature_only(tmp_path):
     alpha = np.zeros(nverts, dtype=np.float32)
 
     vrgb = cortex.VertexRGB(
-        r, g, b, subj,
+        r,
+        g,
+        b,
+        subj,
         alpha=cortex.Vertex(alpha, subj, vmin=0, vmax=1),
     )
 
@@ -414,6 +417,74 @@ def test_vertexrgb_alpha_zero_renders_curvature_only(tmp_path):
             f"VertexRGB with α=0 produced {n_red} red-dominant pixels; "
             "expected near-zero. The shader composite is consuming "
             "un-premultiplied RGB (issue #631)."
+        )
+
+
+def test_volumergb_alpha_half_renders_correct_blend(tmp_path):
+    """VolumeRGB with α=0.5 must blend halfway, not double-attenuate.
+
+    Companion regression to test_vertexrgb_alpha_zero_renders_curvature_only
+    (#631). VolumeRGB ships through the PNG texture path: Three.js sets
+    ``tex.premultiplyAlpha = true`` on upload, so the texture is premultiplied
+    once by WebGL itself. Package therefore must NOT premultiply on the
+    Python side -- if it does, the shader sees double-attenuated RGB.
+
+    α=0 won't catch that bug (0·anything = 0), so we use α=0.5 with bright
+    uniform red. With curvature contribution included, observed shader
+    output for the brain region is:
+      - correct (single premult by JS): median R ≈ 145-160
+      - bug (double premult: Py + JS):  median R ≈ 90-105
+    Threshold at 125 sits in the middle of the gap and tolerates 20+ LSB
+    of boundary/interpolation noise on either side.
+    """
+    from PIL import Image
+
+    # Uniform saturated red over the whole volume, half transparent. Wrap in
+    # explicit Volume(vmin=0, vmax=1) so the .volume property doesn't
+    # auto-normalize a constant array to NaN.
+    r = cortex.Volume(
+        np.full(volshape, 1.0, dtype=np.float32), subj, xfmname, vmin=0, vmax=1
+    )
+    g = cortex.Volume(
+        np.full(volshape, 0.0, dtype=np.float32), subj, xfmname, vmin=0, vmax=1
+    )
+    b = cortex.Volume(
+        np.full(volshape, 0.0, dtype=np.float32), subj, xfmname, vmin=0, vmax=1
+    )
+    alpha = cortex.Volume(
+        np.full(volshape, 0.5, dtype=np.float32), subj, xfmname, vmin=0, vmax=1
+    )
+    vrgb = cortex.VolumeRGB(r, g, b, subj, xfmname, alpha=alpha)
+
+    view = {
+        **default_view_params,
+        **angle_view_params["lateral_pivot"],
+        **unfold_view_params["inflated"],
+    }
+    with cortex.export.headless_viewer(vrgb, viewer_params={}) as handle:
+        time.sleep(10)
+        handle._set_view(**view)
+        time.sleep(1)
+        outfile = str(tmp_path / "volumergb_alpha_half.png")
+        handle.getImage(outfile, (512, 384))
+        _wait_for_file(outfile)
+
+        rgb = np.array(Image.open(outfile))[..., :3].astype(int)
+        # Brain-region pixels are red-dominant under both correct and buggy
+        # paths, but their R intensity differs. Pick the strongly red
+        # pixels (R clearly > G,B) and check median R.
+        red_mask = rgb[..., 0] - np.maximum(rgb[..., 1], rgb[..., 2]) > 30
+        assert red_mask.sum() > 1000, (
+            "Expected a large red-dominant region for half-transparent red "
+            f"VolumeRGB; got only {red_mask.sum()} pixels. Did the brain render?"
+        )
+        median_r = float(np.median(rgb[red_mask, 0]))
+        # Discriminator: correct path produces ~145-160, double-premult
+        # produces ~90-105. Threshold at 125 sits in the middle.
+        assert median_r > 125, (
+            f"VolumeRGB α=0.5 brain pixels have median R={median_r:.0f}; "
+            "expected ~150. R<125 indicates Package is double-premultiplying "
+            "VolumeRGB (issue #631 regression)."
         )
 
 

--- a/cortex/tests/test_webgl_headless.py
+++ b/cortex/tests/test_webgl_headless.py
@@ -358,7 +358,67 @@ def test_vertex_with_nan_renders_partial(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Group 8: addData dataset switching
+# Group 8: VertexRGB alpha attenuation regression test (#631)
+# ---------------------------------------------------------------------------
+
+
+def test_vertexrgb_alpha_zero_renders_curvature_only(tmp_path):
+    """VertexRGB with α=0 must render the curvature underlay, not bright color.
+
+    Regression test for #631: prior to the fix, the WebGL fragment shader's
+    premultiplied-alpha composite formula (gl_FragColor = vColor + (1-α)·bg)
+    consumed un-premultiplied RGB bytes from VertexRGB.vertices, so α=0 left
+    the foreground color fully opaque and clipped toward white instead of
+    falling through to the gray curvature.
+
+    With the fix, RGB is premultiplied at the WebGL serialization step
+    (cortex/webgl/data.py), so packaged vColor.rgb=0 when α=0, and the
+    shader produces pure curvature gray.
+    """
+    from PIL import Image
+
+    rng = np.random.default_rng(631)
+    # Bright, saturated colors -- if the bug returns these will leak through
+    # as red/green/blue pixels. With the fix and α=0, only neutral (curvature)
+    # gray pixels should remain in the brain region.
+    r = rng.uniform(0.7, 1.0, nverts).astype(np.float32)
+    g = rng.uniform(0.0, 0.3, nverts).astype(np.float32)
+    b = rng.uniform(0.0, 0.3, nverts).astype(np.float32)
+    alpha = np.zeros(nverts, dtype=np.float32)
+
+    vrgb = cortex.VertexRGB(
+        r, g, b, subj,
+        alpha=cortex.Vertex(alpha, subj, vmin=0, vmax=1),
+    )
+
+    view = {
+        **default_view_params,
+        **angle_view_params["lateral_pivot"],
+        **unfold_view_params["inflated"],
+    }
+    with cortex.export.headless_viewer(vrgb, viewer_params={}) as handle:
+        time.sleep(10)
+        handle._set_view(**view)
+        time.sleep(1)
+        outfile = str(tmp_path / "alpha_zero.png")
+        handle.getImage(outfile, (512, 384))
+        _wait_for_file(outfile)
+
+        rgb = np.array(Image.open(outfile))[..., :3].astype(int)
+        # Count strongly red-dominant pixels: with the bug, α=0 lets the
+        # bright reds through and we'd see thousands of them. With the fix,
+        # the brain renders curvature gray (R≈G≈B) and red-dominant pixels
+        # fall to near zero (a handful from anti-aliased ROI overlays).
+        n_red = int((rgb[..., 0] - np.maximum(rgb[..., 1], rgb[..., 2]) > 50).sum())
+        assert n_red < 500, (
+            f"VertexRGB with α=0 produced {n_red} red-dominant pixels; "
+            "expected near-zero. The shader composite is consuming "
+            "un-premultiplied RGB (issue #631)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Group 9: addData dataset switching
 # ---------------------------------------------------------------------------
 
 

--- a/cortex/webgl/data.py
+++ b/cortex/webgl/data.py
@@ -52,11 +52,14 @@ class Package(object):
                 # non-premultiplied so the matplotlib (quickshow) path keeps
                 # using matplotlib's straight-alpha imshow compositor.
                 if isinstance(brain, dataset.VertexRGB):
+                    # Note: encdata is already a fresh uint8 copy from the
+                    # .astype(np.uint8) call above, so we can write into it
+                    # in place. The assignment to a uint8 slice handles the
+                    # float→uint8 cast for us.
                     a = encdata[..., 3:4].astype(np.float32) / 255.0
-                    encdata = encdata.copy()
                     encdata[..., :3] = np.round(
                         encdata[..., :3].astype(np.float32) * a
-                    ).astype(np.uint8)
+                    )
                 self.brains[name]["raw"] = True
             else:
                 encdata = encdata.astype(np.float32)

--- a/cortex/webgl/data.py
+++ b/cortex/webgl/data.py
@@ -7,6 +7,7 @@ dict(
     images=(__braindata_name=["img1.png", "img2.png"]),
 )
 """
+
 import os
 import json
 from io import BytesIO
@@ -16,14 +17,15 @@ from .. import dataset
 from .. import volume
 
 
-#TODO: How to package multiviews?
+# TODO: How to package multiviews?
 class Package(object):
     """Package the data into a form usable by javascript"""
+
     def __init__(self, data):
         self.dataset = dataset.normalize(data)
         self.uniques = list(data.uniques(collapse=True))
         self.subjects = set()
-        
+
         self.brains = dict()
         self.images = dict()
         for brain in self.uniques:
@@ -38,28 +40,36 @@ class Package(object):
                 encdata = encdata.astype(np.uint8)
                 # The WebGL fragment shader (shaderlib.js) composites with a
                 # premultiplied-alpha "over" formula
-                # (gl_FragColor = vColor + (1-α)·bg), so premultiply RGB by α
-                # here before serialization. The .vertices/.volume properties
-                # stay non-premultiplied so the matplotlib (quickshow) path keeps
+                # (gl_FragColor = vColor + (1-α)·bg). We only need to pre-
+                # multiply on the Python side for VertexRGB, where the bytes
+                # are uploaded as raw vertex attributes and Three.js does NOT
+                # premultiply (see dataset.js VertexData path). VolumeRGB ships
+                # through the PNG texture path (dataset.js:335-338, raw=true),
+                # where Three.js sets `tex.premultiplyAlpha = true` and the
+                # WebGL UNPACK_PREMULTIPLY_ALPHA_WEBGL hook premultiplies the
+                # texture once on upload -- premultiplying here would double-
+                # attenuate it. The .vertices/.volume properties stay
+                # non-premultiplied so the matplotlib (quickshow) path keeps
                 # using matplotlib's straight-alpha imshow compositor.
-                a = encdata[..., 3:4].astype(np.float32) / 255.0
-                encdata = encdata.copy()
-                encdata[..., :3] = np.round(
-                    encdata[..., :3].astype(np.float32) * a
-                ).astype(np.uint8)
-                self.brains[name]['raw'] = True
+                if isinstance(brain, dataset.VertexRGB):
+                    a = encdata[..., 3:4].astype(np.float32) / 255.0
+                    encdata = encdata.copy()
+                    encdata[..., :3] = np.round(
+                        encdata[..., :3].astype(np.float32) * a
+                    ).astype(np.uint8)
+                self.brains[name]["raw"] = True
             else:
                 encdata = encdata.astype(np.float32)
-                self.brains[name]['raw'] = False
+                self.brains[name]["raw"] = False
 
-            #VertexData requires reordering, only save normalized version for now
+            # VertexData requires reordering, only save normalized version for now
             if isinstance(brain, (dataset.Vertex, dataset.VertexRGB)):
                 self.images[name] = [encdata]
             else:
                 self.images[name] = [volume.mosaic(vol, show=False) for vol in encdata]
                 if len(set([shape for m, shape in self.images[name]])) != 1:
-                    raise ValueError('Internal error in mosaic')
-                self.brains[name]['mosaic'] = self.images[name][0][1]
+                    raise ValueError("Internal error in mosaic")
+                self.brains[name]["mosaic"] = self.images[name][0][1]
                 self.images[name] = [_pack_png(m) for m, shape in self.images[name]]
 
     @property
@@ -67,22 +77,24 @@ class Package(object):
         metadata = []
         for name, view in self.dataset:
             meta = view.to_json(simple=False)
-            meta['name'] = name
-            if 'stim' in meta['attrs']:
-                meta['attrs']['stim'] = os.path.split(meta['attrs']['stim'])[1] 
+            meta["name"] = name
+            if "stim" in meta["attrs"]:
+                meta["attrs"]["stim"] = os.path.split(meta["attrs"]["stim"])[1]
             metadata.append(meta)
         return metadata
 
     def reorder(self, subjects):
-        indices = dict((k, np.load(os.path.splitext(v)[0]+".npz")) for k, v in subjects.items())
+        indices = dict(
+            (k, np.load(os.path.splitext(v)[0] + ".npz")) for k, v in subjects.items()
+        )
         for brain in self.uniques:
             if isinstance(brain, (dataset.Vertex, dataset.VertexRGB)):
                 data = np.array(self.images[brain.name])[0]
                 npyform = BytesIO()
-                if self.brains[brain.name]['raw']:
-                    data = data[..., indices[brain.subject]['index'], :]
+                if self.brains[brain.name]["raw"]:
+                    data = data[..., indices[brain.subject]["index"], :]
                 else:
-                    data = data[..., indices[brain.subject]['index']]
+                    data = data[..., indices[brain.subject]["index"]]
                 np.save(npyform, np.ascontiguousarray(data))
                 npyform.seek(0)
                 self.images[brain.name] = [npyform.read()]
@@ -92,8 +104,10 @@ class Package(object):
     def metadata(self, submap=None, **kwargs):
         if submap is not None:
             for data in self.brains.values():
-                data['subject'] = submap[data['subject']]
-        return dict(views=self.views, data=self.brains, images=self.image_names(**kwargs))
+                data["subject"] = submap[data["subject"]]
+        return dict(
+            views=self.views, data=self.brains, images=self.image_names(**kwargs)
+        )
 
     def image_names(self, fmt="/data/{name}/{frame}/"):
         names = dict()
@@ -101,14 +115,16 @@ class Package(object):
             names[name] = [fmt.format(name=name, frame=i) for i in range(len(imgs))]
         return names
 
+
 def _pack_png(mosaic):
     from PIL import Image
+
     buf = BytesIO()
     if mosaic.dtype not in (np.float32, np.uint8):
         raise TypeError
 
     y, x = mosaic.shape[:2]
-    im = Image.frombuffer('RGBA', (x,y), mosaic.data, 'raw', 'RGBA', 0, 1)
-    im.save(buf, format='PNG')
+    im = Image.frombuffer("RGBA", (x, y), mosaic.data, "raw", "RGBA", 0, 1)
+    im.save(buf, format="PNG")
     buf.seek(0)
     return buf.read()

--- a/cortex/webgl/data.py
+++ b/cortex/webgl/data.py
@@ -36,6 +36,17 @@ class Package(object):
                 encdata = brain.volume
             if isinstance(brain, (dataset.VolumeRGB, dataset.VertexRGB)):
                 encdata = encdata.astype(np.uint8)
+                # The WebGL fragment shader (shaderlib.js) composites with a
+                # premultiplied-alpha "over" formula
+                # (gl_FragColor = vColor + (1-α)·bg), so premultiply RGB by α
+                # here before serialization. The .vertices/.volume properties
+                # stay non-premultiplied so the matplotlib (quickshow) path keeps
+                # using matplotlib's straight-alpha imshow compositor.
+                a = encdata[..., 3:4].astype(np.float32) / 255.0
+                encdata = encdata.copy()
+                encdata[..., :3] = np.round(
+                    encdata[..., :3].astype(np.float32) * a
+                ).astype(np.uint8)
                 self.brains[name]['raw'] = True
             else:
                 encdata = encdata.astype(np.float32)

--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -21,7 +21,16 @@ var mriview = (function(module) {
             var tex = new THREE.Texture(this);
             tex.minFilter = THREE.LinearFilter;
             tex.magFilter = THREE.LinearFilter;
-            tex.premultiplyAlpha = false;
+            // Premultiply alpha on upload so the shader's premultiplied-over
+            // composite (gl_FragColor = vColor + (1-α)·cColor in shaderlib.js)
+            // produces the correct α·rgb + (1-α)·bg result when sampling
+            // alpha-bearing colormaps (e.g. RdBu_r_alpha, fire_alpha). For
+            // non-alpha cmaps every row has α=255, so premultiplication is a
+            // no-op. Without this, alpha-cmap-rendered Vertex2D/Volume2D
+            // foregrounds clip toward white instead of fading to the
+            // curvature underlay (companion fix to issue #631 for the LUT
+            // texture path).
+            tex.premultiplyAlpha = true;
             tex.flipY = true;
             tex.needsUpdate = true;
             colormaps[this.parentNode.id] = tex;

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -3,13 +3,13 @@
 Plot Data with Alpha Values
 ==========================
 
-It is often useful to plot a primary map (the "data" you care about)
+It is often useful to plot a primary map (the "data" you are interested in)
 masked or attenuated by a secondary map (a "confidence" or "weight"
-map). For example, a model's tuning maps are typically only
-interpretable where the model fits well, so it is conventional to plot
-them with opacity proportional to the per-voxel/per-vertex prediction
-accuracy. Vertices/voxels where the model fits poorly fade into the
-gray curvature underlay; vertices/voxels where the model fits well are
+map). For example, an encoding model's tuning maps are 
+interpretable where the model fits well, so one could plot
+tuning maps with opacity proportional to the per-voxel/per-vertex prediction
+accuracy. Voxels/vertices where the model fits poorly fade into the
+gray curvature underlay; voxels/vertices where the model fits well are
 fully opaque.
 
 pycortex supports two patterns for this:
@@ -112,8 +112,7 @@ accuracy_vtx = np.hstack(
 #
 # Other 2D alpha colormaps shipped with pycortex include ``"fire_alpha"``
 # (sequential, perceptually uniform), ``"PU_RdBu_covar_alpha"`` (diverging,
-# perceptually uniform), ``"plasma_alpha"``, and ``"autumn_alpha"``. Pick
-# one that matches the sign/structure of your data.
+# perceptually uniform), ``"plasma_alpha"``, and ``"autumn_alpha"``.
 v2d = cortex.Volume2D(
     data_vol,
     accuracy_vol,

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -75,7 +75,7 @@ v2d = cortex.Volume2D(
     vmin2=0,
     vmax2=1,  # range for the alpha (dim2)
 )
-cortex.quickshow(v2d, with_colorbar=True)
+cortex.quickshow(v2d, with_colorbar=True, with_curvature=True)
 plt.suptitle("Volume2D + RdBu_r_alpha: data masked by 'accuracy'")
 plt.show()
 
@@ -127,7 +127,7 @@ vtx2d = cortex.Vertex2D(
     vmin2=0,
     vmax2=1,
 )
-cortex.quickshow(vtx2d, with_colorbar=True)
+cortex.quickshow(vtx2d, with_colorbar=True, with_curvature=True)
 plt.suptitle("Vertex2D + RdBu_r_alpha: data masked by 'accuracy'")
 plt.show()
 
@@ -143,7 +143,7 @@ blue = cortex.Volume(np.clip((zz / 30.0), 0, 1), subject, xfm, vmin=0, vmax=1)
 alpha_vol = cortex.Volume(accuracy_vol, subject, xfm, vmin=0, vmax=1)
 
 vrgb = cortex.VolumeRGB(red, green, blue, subject, alpha=alpha_vol)
-cortex.quickshow(vrgb, with_colorbar=False)
+cortex.quickshow(vrgb, with_colorbar=False, with_curvature=True)
 plt.suptitle("VolumeRGB(alpha=accuracy): RGB tuning masked by 'accuracy'")
 plt.show()
 
@@ -156,7 +156,7 @@ blue_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
 alpha_v = cortex.Vertex(accuracy_vtx, subject, vmin=0, vmax=1)
 
 vrgb_vtx = cortex.VertexRGB(red_v, green_v, blue_v, subject, alpha=alpha_v)
-cortex.quickshow(vrgb_vtx, with_colorbar=False)
+cortex.quickshow(vrgb_vtx, with_colorbar=False, with_curvature=True)
 plt.suptitle("VertexRGB(alpha=accuracy): RGB channels masked by 'accuracy'")
 plt.show()
 

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -1,0 +1,176 @@
+"""
+==========================
+Plot Data with Alpha Values
+==========================
+
+It is often useful to plot a primary map (the "data" you care about)
+masked or attenuated by a secondary map (a "confidence" or "weight"
+map). For example, a model's tuning maps are typically only
+interpretable where the model fits well, so it is conventional to plot
+them with opacity proportional to the per-voxel/per-vertex prediction
+accuracy. Vertices/voxels where the model fits poorly fade into the
+gray curvature underlay; vertices/voxels where the model fits well are
+fully opaque.
+
+pycortex supports two patterns for this:
+
+1. **Scalar data with an alpha map** -- use :class:`Volume2D` /
+   :class:`Vertex2D` with a 2D colormap whose second axis encodes alpha
+   (the colormap LUT itself goes from transparent to opaque along
+   ``dim2``). No extra arithmetic is needed; the alpha channel is
+   composited correctly by both the matplotlib (``quickshow``) and the
+   WebGL renderers.
+
+2. **RGB data with an alpha map** -- pass ``alpha=`` directly to
+   :class:`VolumeRGB` / :class:`VertexRGB`. The alpha can be any
+   per-voxel/per-vertex array (or a :class:`Volume`/:class:`Vertex`)
+   in ``[0, 1]``.
+
+Below, we illustrate both patterns with a synthetic "model accuracy"
+mask -- a 3D Gaussian bump for the volume case and a vertex-distance
+falloff for the surface case -- so cortex near the bump centre stays
+opaque while the periphery fades into the curvature.
+"""
+
+import cortex
+import cortex.polyutils
+import numpy as np
+import matplotlib.pyplot as plt
+
+subject = "S1"
+xfm = "fullhead"
+
+# ---------------------------------------------------------------------
+# Synthesize a "data" map and a "model accuracy" alpha map (volumetric)
+# ---------------------------------------------------------------------
+# A signed gradient across the brain stands in for, e.g., a regression
+# coefficient or a tuning preference.
+zz, yy, xx = np.mgrid[0:31, 0:100, 0:100]
+data_vol = (xx - 50) / 50.0  # range ~ [-1, 1]
+
+# A 3D Gaussian bump centered in the volume stands in for a per-voxel
+# model accuracy / prediction r in [0, 1]. In practice this would come
+# from cross-validated model fits; here we just want a smoothly varying
+# mask so the alpha effect is easy to see.
+center = np.array([15, 50, 50])
+sigma = 25.0
+dist2 = (zz - center[0]) ** 2 + (yy - center[1]) ** 2 + (xx - center[2]) ** 2
+accuracy_vol = np.exp(-dist2 / (2 * sigma**2))  # in [0, 1]
+
+# ---------------------------------------------------------------------
+# Pattern 1a: scalar Volume + alpha via Volume2D + 2D alpha colormap
+# ---------------------------------------------------------------------
+# The 2D colormap "RdBu_r_alpha" maps (data, alpha) -> RGBA: along the
+# first axis, blue-white-red diverging; along the second axis,
+# transparent-to-opaque. So passing the data as dim1 and the accuracy
+# as dim2 yields exactly "diverging colormap, opacity = accuracy".
+v2d = cortex.Volume2D(
+    data_vol,
+    accuracy_vol,
+    subject,
+    xfm,
+    cmap="RdBu_r_alpha",
+    vmin=-1,
+    vmax=1,  # range for the data (dim1)
+    vmin2=0,
+    vmax2=1,  # range for the alpha (dim2)
+)
+cortex.quickshow(v2d, with_colorbar=True)
+plt.suptitle("Volume2D + RdBu_r_alpha: data masked by 'accuracy'")
+plt.show()
+
+# Other 2D alpha colormaps shipped with pycortex include "fire_alpha"
+# (sequential, perceptually uniform), "PU_RdBu_covar_alpha" (diverging,
+# perceptually uniform), "plasma_alpha", and "autumn_alpha". Pick one
+# that matches the sign/structure of your data.
+
+# ---------------------------------------------------------------------
+# Pattern 1b: scalar Vertex + alpha via Vertex2D + 2D alpha colormap
+# ---------------------------------------------------------------------
+# Same idea on the surface. We synthesize a per-vertex data map and a
+# per-vertex accuracy that falls off with geodesic-ish distance from a
+# seed vertex.
+surfs = [cortex.polyutils.Surface(*d) for d in cortex.db.get_surf(subject, "fiducial")]
+num_verts = [s.pts.shape[0] for s in surfs]
+total_verts = sum(num_verts)
+
+# Data: noisy gradient across each hemisphere.
+rng = np.random.default_rng(0)
+data_vtx = np.hstack(
+    [
+        np.linspace(-1, 1, num_verts[0]) + 0.1 * rng.standard_normal(num_verts[0]),
+        np.linspace(-1, 1, num_verts[1]) + 0.1 * rng.standard_normal(num_verts[1]),
+    ]
+)
+
+
+# Accuracy: a soft bump centered at a particular vertex in each hemi.
+def _bump(surf, seed, sigma):
+    d = np.linalg.norm(surf.pts - surf.pts[seed], axis=1)
+    return np.exp(-(d**2) / (2 * sigma**2))
+
+
+accuracy_vtx = np.hstack(
+    [
+        _bump(surfs[0], num_verts[0] // 2, sigma=40.0),
+        _bump(surfs[1], num_verts[1] // 2, sigma=40.0),
+    ]
+)
+
+vtx2d = cortex.Vertex2D(
+    data_vtx,
+    accuracy_vtx,
+    subject,
+    cmap="RdBu_r_alpha",
+    vmin=-1,
+    vmax=1,
+    vmin2=0,
+    vmax2=1,
+)
+cortex.quickshow(vtx2d, with_colorbar=True)
+plt.suptitle("Vertex2D + RdBu_r_alpha: data masked by 'accuracy'")
+plt.show()
+
+# ---------------------------------------------------------------------
+# Pattern 2a: RGB Volume + alpha via VolumeRGB(alpha=...)
+# ---------------------------------------------------------------------
+# When the "data" is itself three independent channels (e.g. RGB tuning
+# axes from a model with 3 latent dimensions), use VolumeRGB and pass
+# the accuracy as the alpha argument.
+red = cortex.Volume(np.clip((xx / 99.0), 0, 1), subject, xfm, vmin=0, vmax=1)
+green = cortex.Volume(np.clip((yy / 99.0), 0, 1), subject, xfm, vmin=0, vmax=1)
+blue = cortex.Volume(np.clip((zz / 30.0), 0, 1), subject, xfm, vmin=0, vmax=1)
+alpha_vol = cortex.Volume(accuracy_vol, subject, xfm, vmin=0, vmax=1)
+
+vrgb = cortex.VolumeRGB(red, green, blue, subject, alpha=alpha_vol)
+cortex.quickshow(vrgb, with_colorbar=False)
+plt.suptitle("VolumeRGB(alpha=accuracy): RGB tuning masked by 'accuracy'")
+plt.show()
+
+# ---------------------------------------------------------------------
+# Pattern 2b: RGB Vertex + alpha via VertexRGB(alpha=...)
+# ---------------------------------------------------------------------
+red_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
+green_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
+blue_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
+alpha_v = cortex.Vertex(accuracy_vtx, subject, vmin=0, vmax=1)
+
+vrgb_vtx = cortex.VertexRGB(red_v, green_v, blue_v, subject, alpha=alpha_v)
+cortex.quickshow(vrgb_vtx, with_colorbar=False)
+plt.suptitle("VertexRGB(alpha=accuracy): RGB channels masked by 'accuracy'")
+plt.show()
+
+# ---------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------
+# * Both patterns produce the same composite formula at the pixel level:
+#   ``out = alpha * data + (1 - alpha) * curvature_underlay``. Choose
+#   based on what the "data" is: scalar (use Pattern 1) or RGB (use
+#   Pattern 2).
+# * The same objects work in the WebGL viewer:
+#   ``cortex.webgl.show(v2d)`` etc.; opacity is honored identically.
+# * The deprecated ``Vertex.blend_curvature(alpha)`` helper produced a
+#   pre-blended :class:`VertexRGB` that lost ``cmap``/``vmin``/``vmax``
+#   editability. The Pattern 1 :class:`Vertex2D` route above is the
+#   recommended replacement: it keeps the colormap parameters editable
+#   on the resulting object and renders identically.

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -94,14 +94,16 @@ surfs = [cortex.polyutils.Surface(*d) for d in cortex.db.get_surf(subject, "fidu
 num_verts = [s.pts.shape[0] for s in surfs]
 total_verts = sum(num_verts)
 
-# Data: noisy gradient across each hemisphere.
+# Data: a smooth anterior-posterior gradient. Encoding by spatial
+# coordinate (rather than by vertex index) is important on the surface
+# because vertex indices are not arranged by spatial neighborhood -- a
+# vertex-index ramp would render as visual noise. Here we use the
+# y-axis (A-P), centered at zero so the diverging RdBu_r colormap reads
+# naturally.
 rng = np.random.default_rng(0)
-data_vtx = np.hstack(
-    [
-        np.linspace(-1, 1, num_verts[0]) + 0.1 * rng.standard_normal(num_verts[0]),
-        np.linspace(-1, 1, num_verts[1]) + 0.1 * rng.standard_normal(num_verts[1]),
-    ]
-)
+pts = np.vstack([surfs[0].pts, surfs[1].pts])  # (total_verts, 3)
+y = pts[:, 1] - pts[:, 1].mean()
+data_vtx = y / np.abs(y).max()  # in [-1, 1]
 
 
 # Accuracy: a soft bump centered at a particular vertex in each hemi.
@@ -152,13 +154,11 @@ plt.show()
 # Pattern 2b: RGB Vertex + alpha via VertexRGB(alpha=...)
 # -------------------------------------------------------
 #
-# Per-vertex random RGB would just look like salt-and-pepper noise on
-# the flatmap because vertex indices are not arranged by spatial
-# neighborhood. Instead, encode each channel as a normalized spatial
-# coordinate: R = x, G = y, B = z (in anatomical space), so the three
-# channels vary smoothly across cortex and produce an interpretable
-# position map.
-pts = np.vstack([surfs[0].pts, surfs[1].pts])  # (total_verts, 3)
+# As in Pattern 1b, encoding each channel by a normalized spatial
+# coordinate (R = x, G = y, B = z in anatomical space) yields smoothly
+# varying maps -- per-vertex random RGB would just look like
+# salt-and-pepper noise because vertex indices are not arranged by
+# spatial neighborhood.
 xyz_norm = (pts - pts.min(axis=0)) / (pts.max(axis=0) - pts.min(axis=0))
 red_v = cortex.Vertex(xyz_norm[:, 0], subject, vmin=0, vmax=1)
 green_v = cortex.Vertex(xyz_norm[:, 1], subject, vmin=0, vmax=1)

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -152,9 +152,17 @@ plt.show()
 # Pattern 2b: RGB Vertex + alpha via VertexRGB(alpha=...)
 # -------------------------------------------------------
 #
-red_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
-green_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
-blue_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
+# Per-vertex random RGB would just look like salt-and-pepper noise on
+# the flatmap because vertex indices are not arranged by spatial
+# neighborhood. Instead, encode each channel as a normalized spatial
+# coordinate: R = x, G = y, B = z (in anatomical space), so the three
+# channels vary smoothly across cortex and produce an interpretable
+# position map.
+pts = np.vstack([surfs[0].pts, surfs[1].pts])  # (total_verts, 3)
+xyz_norm = (pts - pts.min(axis=0)) / (pts.max(axis=0) - pts.min(axis=0))
+red_v = cortex.Vertex(xyz_norm[:, 0], subject, vmin=0, vmax=1)
+green_v = cortex.Vertex(xyz_norm[:, 1], subject, vmin=0, vmax=1)
+blue_v = cortex.Vertex(xyz_norm[:, 2], subject, vmin=0, vmax=1)
 alpha_v = cortex.Vertex(accuracy_vtx, subject, vmin=0, vmax=1)
 
 vrgb_vtx = cortex.VertexRGB(red_v, green_v, blue_v, subject, alpha=alpha_v)

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -40,9 +40,7 @@ import matplotlib.pyplot as plt
 subject = "S1"
 xfm = "fullhead"
 
-# ---------------------------------------------------------------------
-# Synthesize a "data" map and a "model accuracy" alpha map (volumetric)
-# ---------------------------------------------------------------------
+# Synthesize a "data" map and a "model accuracy" alpha map (volumetric).
 # A signed gradient across the brain stands in for, e.g., a regression
 # coefficient or a tuning preference.
 zz, yy, xx = np.mgrid[0:31, 0:100, 0:100]
@@ -57,9 +55,10 @@ sigma = 25.0
 dist2 = (zz - center[0]) ** 2 + (yy - center[1]) ** 2 + (xx - center[2]) ** 2
 accuracy_vol = np.exp(-dist2 / (2 * sigma**2))  # in [0, 1]
 
-# ---------------------------------------------------------------------
+# %%
 # Pattern 1a: scalar Volume + alpha via Volume2D + 2D alpha colormap
-# ---------------------------------------------------------------------
+# -----------------------------------------------------------------
+#
 # The 2D colormap "RdBu_r_alpha" maps (data, alpha) -> RGBA: along the
 # first axis, blue-white-red diverging; along the second axis,
 # transparent-to-opaque. So passing the data as dim1 and the accuracy
@@ -84,9 +83,10 @@ plt.show()
 # perceptually uniform), "plasma_alpha", and "autumn_alpha". Pick one
 # that matches the sign/structure of your data.
 
-# ---------------------------------------------------------------------
+# %%
 # Pattern 1b: scalar Vertex + alpha via Vertex2D + 2D alpha colormap
-# ---------------------------------------------------------------------
+# -----------------------------------------------------------------
+#
 # Same idea on the surface. We synthesize a per-vertex data map and a
 # per-vertex accuracy that falls off with geodesic-ish distance from a
 # seed vertex.
@@ -131,9 +131,10 @@ cortex.quickshow(vtx2d, with_colorbar=True, with_curvature=True)
 plt.suptitle("Vertex2D + RdBu_r_alpha: data masked by 'accuracy'")
 plt.show()
 
-# ---------------------------------------------------------------------
+# %%
 # Pattern 2a: RGB Volume + alpha via VolumeRGB(alpha=...)
-# ---------------------------------------------------------------------
+# -------------------------------------------------------
+#
 # When the "data" is itself three independent channels (e.g. RGB tuning
 # axes from a model with 3 latent dimensions), use VolumeRGB and pass
 # the accuracy as the alpha argument.
@@ -147,9 +148,10 @@ cortex.quickshow(vrgb, with_colorbar=False, with_curvature=True)
 plt.suptitle("VolumeRGB(alpha=accuracy): RGB tuning masked by 'accuracy'")
 plt.show()
 
-# ---------------------------------------------------------------------
+# %%
 # Pattern 2b: RGB Vertex + alpha via VertexRGB(alpha=...)
-# ---------------------------------------------------------------------
+# -------------------------------------------------------
+#
 red_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
 green_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
 blue_v = cortex.Vertex(rng.uniform(0, 1, total_verts), subject, vmin=0, vmax=1)
@@ -160,9 +162,10 @@ cortex.quickshow(vrgb_vtx, with_colorbar=False, with_curvature=True)
 plt.suptitle("VertexRGB(alpha=accuracy): RGB channels masked by 'accuracy'")
 plt.show()
 
-# ---------------------------------------------------------------------
+# %%
 # Notes
-# ---------------------------------------------------------------------
+# -----
+#
 # * Both patterns produce the same composite formula at the pixel level:
 #   ``out = alpha * data + (1 - alpha) * curvature_underlay``. Choose
 #   based on what the "data" is: scalar (use Pattern 1) or RGB (use

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -40,29 +40,80 @@ import matplotlib.pyplot as plt
 subject = "S1"
 xfm = "fullhead"
 
-# Synthesize a "data" map and a "model accuracy" alpha map (volumetric).
-# A signed gradient across the brain stands in for, e.g., a regression
-# coefficient or a tuning preference.
+# %%
+# Synthesize the data and alpha maps
+# ----------------------------------
+#
+# All four patterns below reuse the same synthetic inputs, so we set
+# everything up once here and only show the *plotting* call in each
+# pattern's cell. In a real analysis these would come from your model
+# fits (e.g. ``data`` = regression coefficients, ``accuracy`` =
+# cross-validated prediction r^2).
+
+# --- Volumetric data + alpha -------------------------------------------------
+# Signed gradient across the brain stands in for a regression coefficient
+# or tuning preference.
 zz, yy, xx = np.mgrid[0:31, 0:100, 0:100]
 data_vol = (xx - 50) / 50.0  # range ~ [-1, 1]
 
 # A 3D Gaussian bump centered in the volume stands in for a per-voxel
-# model accuracy / prediction r in [0, 1]. In practice this would come
-# from cross-validated model fits; here we just want a smoothly varying
-# mask so the alpha effect is easy to see.
+# model accuracy / prediction r in [0, 1].
 center = np.array([15, 50, 50])
 sigma = 25.0
 dist2 = (zz - center[0]) ** 2 + (yy - center[1]) ** 2 + (xx - center[2]) ** 2
 accuracy_vol = np.exp(-dist2 / (2 * sigma**2))  # in [0, 1]
 
+# RGB volumetric channels: anatomical x/y/z normalized to [0, 1]. Three
+# smoothly-varying volumetric channels stand in for, e.g., three latent
+# RGB tuning axes from a model.
+red_vol = np.clip(xx / 99.0, 0, 1)
+green_vol = np.clip(yy / 99.0, 0, 1)
+blue_vol = np.clip(zz / 30.0, 0, 1)
+
+# --- Surface (vertex) data + alpha -------------------------------------------
+# Encode by *spatial coordinate*, not vertex index: vertex indices on the
+# cortical surface are not arranged by spatial neighborhood, so a
+# vertex-index ramp would render as visual noise.
+surfs = [cortex.polyutils.Surface(*d) for d in cortex.db.get_surf(subject, "fiducial")]
+num_verts = [s.pts.shape[0] for s in surfs]
+total_verts = sum(num_verts)
+pts = np.vstack([surfs[0].pts, surfs[1].pts])  # (total_verts, 3)
+
+# Scalar surface data: anterior-posterior gradient (anatomical y),
+# centered at zero so a diverging colormap reads naturally.
+y_centered = pts[:, 1] - pts[:, 1].mean()
+data_vtx = y_centered / np.abs(y_centered).max()  # in [-1, 1]
+
+# RGB surface channels: anatomical x/y/z normalized to [0, 1].
+xyz_norm = (pts - pts.min(axis=0)) / (pts.max(axis=0) - pts.min(axis=0))
+
+
+# Surface alpha: a soft bump centered at a particular vertex in each hemi.
+def _bump(surf, seed, sigma):
+    d = np.linalg.norm(surf.pts - surf.pts[seed], axis=1)
+    return np.exp(-(d**2) / (2 * sigma**2))
+
+
+accuracy_vtx = np.hstack(
+    [
+        _bump(surfs[0], num_verts[0] // 2, sigma=40.0),
+        _bump(surfs[1], num_verts[1] // 2, sigma=40.0),
+    ]
+)
+
 # %%
 # Pattern 1a: scalar Volume + alpha via Volume2D + 2D alpha colormap
-# -----------------------------------------------------------------
+# ------------------------------------------------------------------
 #
-# The 2D colormap "RdBu_r_alpha" maps (data, alpha) -> RGBA: along the
-# first axis, blue-white-red diverging; along the second axis,
-# transparent-to-opaque. So passing the data as dim1 and the accuracy
-# as dim2 yields exactly "diverging colormap, opacity = accuracy".
+# The 2D colormap ``"RdBu_r_alpha"`` maps ``(data, alpha) -> RGBA``: along
+# the first axis, blue-white-red diverging; along the second axis,
+# transparent-to-opaque. So passing the data as ``dim1`` and the accuracy
+# as ``dim2`` yields exactly "diverging colormap, opacity = accuracy".
+#
+# Other 2D alpha colormaps shipped with pycortex include ``"fire_alpha"``
+# (sequential, perceptually uniform), ``"PU_RdBu_covar_alpha"`` (diverging,
+# perceptually uniform), ``"plasma_alpha"``, and ``"autumn_alpha"``. Pick
+# one that matches the sign/structure of your data.
 v2d = cortex.Volume2D(
     data_vol,
     accuracy_vol,
@@ -78,47 +129,11 @@ cortex.quickshow(v2d, with_colorbar=True, with_curvature=True)
 plt.suptitle("Volume2D + RdBu_r_alpha: data masked by 'accuracy'")
 plt.show()
 
-# Other 2D alpha colormaps shipped with pycortex include "fire_alpha"
-# (sequential, perceptually uniform), "PU_RdBu_covar_alpha" (diverging,
-# perceptually uniform), "plasma_alpha", and "autumn_alpha". Pick one
-# that matches the sign/structure of your data.
-
 # %%
 # Pattern 1b: scalar Vertex + alpha via Vertex2D + 2D alpha colormap
-# -----------------------------------------------------------------
+# ------------------------------------------------------------------
 #
-# Same idea on the surface. We synthesize a per-vertex data map and a
-# per-vertex accuracy that falls off with geodesic-ish distance from a
-# seed vertex.
-surfs = [cortex.polyutils.Surface(*d) for d in cortex.db.get_surf(subject, "fiducial")]
-num_verts = [s.pts.shape[0] for s in surfs]
-total_verts = sum(num_verts)
-
-# Data: a smooth anterior-posterior gradient. Encoding by spatial
-# coordinate (rather than by vertex index) is important on the surface
-# because vertex indices are not arranged by spatial neighborhood -- a
-# vertex-index ramp would render as visual noise. Here we use the
-# y-axis (A-P), centered at zero so the diverging RdBu_r colormap reads
-# naturally.
-rng = np.random.default_rng(0)
-pts = np.vstack([surfs[0].pts, surfs[1].pts])  # (total_verts, 3)
-y = pts[:, 1] - pts[:, 1].mean()
-data_vtx = y / np.abs(y).max()  # in [-1, 1]
-
-
-# Accuracy: a soft bump centered at a particular vertex in each hemi.
-def _bump(surf, seed, sigma):
-    d = np.linalg.norm(surf.pts - surf.pts[seed], axis=1)
-    return np.exp(-(d**2) / (2 * sigma**2))
-
-
-accuracy_vtx = np.hstack(
-    [
-        _bump(surfs[0], num_verts[0] // 2, sigma=40.0),
-        _bump(surfs[1], num_verts[1] // 2, sigma=40.0),
-    ]
-)
-
+# Same idea on the surface.
 vtx2d = cortex.Vertex2D(
     data_vtx,
     accuracy_vtx,
@@ -137,12 +152,11 @@ plt.show()
 # Pattern 2a: RGB Volume + alpha via VolumeRGB(alpha=...)
 # -------------------------------------------------------
 #
-# When the "data" is itself three independent channels (e.g. RGB tuning
-# axes from a model with 3 latent dimensions), use VolumeRGB and pass
-# the accuracy as the alpha argument.
-red = cortex.Volume(np.clip((xx / 99.0), 0, 1), subject, xfm, vmin=0, vmax=1)
-green = cortex.Volume(np.clip((yy / 99.0), 0, 1), subject, xfm, vmin=0, vmax=1)
-blue = cortex.Volume(np.clip((zz / 30.0), 0, 1), subject, xfm, vmin=0, vmax=1)
+# When the "data" is itself three independent channels, use
+# :class:`VolumeRGB` and pass the accuracy as the ``alpha=`` argument.
+red = cortex.Volume(red_vol, subject, xfm, vmin=0, vmax=1)
+green = cortex.Volume(green_vol, subject, xfm, vmin=0, vmax=1)
+blue = cortex.Volume(blue_vol, subject, xfm, vmin=0, vmax=1)
 alpha_vol = cortex.Volume(accuracy_vol, subject, xfm, vmin=0, vmax=1)
 
 vrgb = cortex.VolumeRGB(red, green, blue, subject, alpha=alpha_vol)
@@ -154,12 +168,7 @@ plt.show()
 # Pattern 2b: RGB Vertex + alpha via VertexRGB(alpha=...)
 # -------------------------------------------------------
 #
-# As in Pattern 1b, encoding each channel by a normalized spatial
-# coordinate (R = x, G = y, B = z in anatomical space) yields smoothly
-# varying maps -- per-vertex random RGB would just look like
-# salt-and-pepper noise because vertex indices are not arranged by
-# spatial neighborhood.
-xyz_norm = (pts - pts.min(axis=0)) / (pts.max(axis=0) - pts.min(axis=0))
+# Same idea on the surface.
 red_v = cortex.Vertex(xyz_norm[:, 0], subject, vmin=0, vmax=1)
 green_v = cortex.Vertex(xyz_norm[:, 1], subject, vmin=0, vmax=1)
 blue_v = cortex.Vertex(xyz_norm[:, 2], subject, vmin=0, vmax=1)


### PR DESCRIPTION
## Summary

Fixes #631. The WebGL fragment shader composites with a premultiplied-alpha *"over"* formula:

```glsl
gl_FragColor = vColor + (1.0 - vColor.a) * gl_FragColor;
```

…but `VertexRGB.vertices` / `VolumeRGB.volume` ship raw, non-premultiplied RGB bytes. With α < 1 this rendered vertices brighter / clipped toward white instead of blending toward the curvature underlay.

**Fix (Python-side, narrow):** premultiply RGB by α at the WebGL serialization step (`cortex/webgl/data.py` `Package.__init__`). The `.vertices` / `.volume` properties stay non-premultiplied so the matplotlib (`quickshow`) path keeps using matplotlib's straight-alpha `imshow` compositor unchanged. Both viewers now produce the same composite `α·rgb + (1-α)·bg`.

**Important:** the premultiplication only applies to **VertexRGB**, not VolumeRGB. VolumeRGB ships through the PNG texture path (`cortex/webgl/resources/js/dataset.js:335-338`), where Three.js sets `tex.premultiplyAlpha = true` and WebGL's `UNPACK_PREMULTIPLY_ALPHA_WEBGL` already premultiplies the texture once on upload. Premultiplying again on the Python side would double-attenuate partial-alpha VolumeRGB. VertexRGB has no equivalent JS-side step (vertex attributes via `BufferAttribute`), so it still needs the Python premult.

This is the *Python-side* option suggested in the issue — narrower than touching the shader (which would also affect other dataviews and require broader regression checks).

Also deprecates `BrainData.blend_curvature` (`Vertex.blend_curvature` / `VertexRGB.blend_curvature` / `Vertex2D.blend_curvature` via inherited references): it was a hack to mimic transparency for `Vertex` objects, no longer needed now that per-vertex α works directly in both viewers.

## Companion fix: 2D-cmap LUT texture (commit [`0eafd8c`](../commit/0eafd8c5))

While verifying the headless A/B against `quickshow`, we noticed that the *2D dataview* path (`Vertex2D` / `Volume2D` with alpha-encoding 2D colormaps such as `RdBu_r_alpha`) still didn't match — WebGL panels rendered noticeably brighter / less attenuated than the matplotlib reference, while RGB dataviews matched after the Python fix above.

**Why the Python-side premultiplication doesn't reach this path.** `Vertex2D.uniques()` yields dim1 and dim2 as separate scalar maps, so `Package.__init__` ships them as plain floats with no alpha channel — there's nothing for the Python code to premultiply. The actual LUT lookup happens on the GPU in the vertex shader at [`shaderlib.js:755`](cortex/webgl/resources/js/shaderlib.js#L755):

```glsl
vColor = texture2D(colormap, cuv);  // cuv = (data_norm, alpha_norm)
```

The fragment shader then runs the same premultiplied-over composite (`vColor + (1-α)·bg`). For that to produce the correct result, the *colormap texture itself* needs to be uploaded premultiplied — but the cmap texture in `mriview.js` was created with `tex.premultiplyAlpha = false`. Empirically, this leaves brain-region pixels at median R≈129 (out of an unattenuated 167 LSB ceiling) instead of the correct ~93.

**Fix (one-line, JS-side).** [`cortex/webgl/resources/js/mriview.js:33`](cortex/webgl/resources/js/mriview.js#L33) now sets `tex.premultiplyAlpha = true` on the cmap textures, matching the existing convention for the per-vertex / volumetric texture path. For non-alpha colormaps (every row α=255), premultiplication is a no-op, so the change has no effect on existing colormaps. For alpha-bearing colormaps, the LUT texel `(R, G, B, α)` becomes `(α·R, α·G, α·B, α)` on upload, and the fragment shader's `vColor + (1-α)·bg` then correctly resolves to `α·rgb + (1-α)·bg`. Verified live (the user confirmed both viewers now match across all four patterns in `examples/datasets/plot_data_with_alpha.py`).

## Equivalence with quickshow (matplotlib)

For VertexRGB, verified analytically and via test:
- WebGL shader, with premultiplied bytes:  `vColor + (1-α)·bg = (α·rgb) + (1-α)·bg`
- matplotlib `imshow` layered over curvature, with non-premultiplied bytes:  `α·rgb + (1-α)·bg`

`test_quickshow_webgl_alpha_equivalence` (in `test_quickflat.py`) pins this equivalence at the per-vertex level for arbitrary curvature gray, with tolerance ≤ 2/255 (uint8 rounding).

For Vertex2D / Volume2D the equivalence is empirical: with `tex.premultiplyAlpha = true` on the cmap texture, the WebGL composite numerically matches the quickshow render against the same alpha-bearing 2D colormap, side-by-side across the four patterns in the new gallery example (volumetric / surface, scalar+α / RGB+α).

## Tests added

- `cortex/tests/test_webgl_data.py` *(new)* — Package serialization unit tests:
  - VertexRGB: serialized bytes are α-premultiplied (general α, α=1 passthrough, α=0 zeroes RGB).
  - VolumeRGB: serialized bytes are **NOT** premultiplied (Three.js will do it once on texture upload).
  - sanity checks that `.vertices` stays non-premultiplied (so quickshow keeps working).
- `test_quickflat.py::test_quickshow_webgl_alpha_equivalence` — asserts WebGL and matplotlib paths agree per-vertex against arbitrary curvature.
- `test_quickflat.py::test_make_flatmap_image_vertexrgb_alpha_unchanged` — guards the matplotlib path from accidental premultiplication regressions.
- `test_webgl_headless.py::test_vertexrgb_alpha_zero_renders_curvature_only` — playwright pixel-level regression: with α=0 over the whole brain, expects ≪500 red-dominant pixels. Verified to **fail** without the fix and **pass** with it.
- `test_webgl_headless.py::test_volumergb_alpha_half_renders_correct_blend` — playwright pixel-level regression for the VolumeRGB double-premult risk: uniform red with α=0.5 should produce median R ≈150 (correct), not ≈100 (double-premult). Verified to fail when Python-side premult is wrongly extended to VolumeRGB.
- `test_webgl_headless.py::test_vertex2d_alpha_half_renders_correct_blend` *(new)* — playwright pixel-level regression for the cmap-LUT premult fix. Renders `Vertex2D(data=+1, alpha=0.5, cmap=RdBu_r_alpha)` and asserts the brain region's median R is ≈93 (correct) rather than ≈129 (buggy un-premultiplied LUT). Verified to fail in the buggy state and pass with the fix.
- `test_dataset.py::test_blend_curvature` — wrapped existing assertions in `pytest.warns(DeprecationWarning)`.

Full suite: `pytest cortex/tests/test_dataset.py cortex/tests/test_webgl_data.py cortex/tests/test_quickflat.py cortex/tests/test_webgl_headless.py` → **80 passed, 1 xfailed** (the xfail is pre-existing).

## Before / After screenshots

Reproducer: uniform red `VertexRGB` over the flatmap, with α=0 inside V1+V2+V3.

| | result |
|--|--|
| **Before** | V1+V2+V3 region renders as bright pink/red — bug: shader's `vColor + (1-α)·bg` clips RGB toward white when fed non-premultiplied bytes. |
| **After** | V1+V2+V3 region falls through to the gray curvature underlay — correct `α·rgb + (1-α)·bg` composite. |

<details><summary>Before/after</summary>
<p>
Before
<img width="1024" height="768" alt="before" src="https://github.com/user-attachments/assets/9df1df57-d9b4-42e5-8f12-a0b90e28ec61" />

After
<img width="1024" height="768" alt="after" src="https://github.com/user-attachments/assets/642e4cfa-ed7f-482c-9f1c-1729571283a9" />

</p>
</details>


## Test plan

- [x] `pytest cortex/tests/test_dataset.py cortex/tests/test_webgl_data.py cortex/tests/test_quickflat.py cortex/tests/test_webgl_headless.py` — 80 passed.
- [x] Headless regression for VertexRGB (α=0 falls through to curvature) — passes; verified to fail when fix is reverted.
- [x] Headless regression for VolumeRGB (α=0.5 blends correctly, not double-attenuated) — passes; verified to fail when Python premult is wrongly extended to VolumeRGB.
- [x] Headless regression for Vertex2D (α=0.5 with `RdBu_r_alpha` blends correctly) — passes; verified to fail when `mriview.js` cmap `premultiplyAlpha` is reverted to `false`.
- [x] `test_datatype_renders[VertexRGB|VolumeRGB]` — still passing (no regression in baseline RGBA rendering).
- [x] Visual: the issue's MRE renders V1 as half-transparent (washed-out gray) instead of bright/clipped.
- [x] Quickshow (`cortex.quickshow`) output of the same MRE remains byte-for-byte identical to pre-patch.
- [x] Live-viewer A/B: across all four patterns in `examples/datasets/plot_data_with_alpha.py` (Volume2D, Vertex2D, VolumeRGB, VertexRGB), the WebGL render now matches the corresponding `quickshow` render.

## Files explicitly NOT modified

- `cortex/dataset/viewRGB.py` — `vertices`/`volume` properties stay non-premultiplied so the matplotlib path keeps working.
- `cortex/webgl/resources/js/shaderlib.js` — no shader change, avoiding the larger surface area of regression checks.
- `cortex/webgl/resources/js/dataset.js` — no JS change; the existing `tex.premultiplyAlpha = true` already does the right thing for VolumeRGB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
