### PR TITLE
FIX WebGL viewer hover/click readout for Vertex2D / Volume2D (#634)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ docs/colormaps.rst
 
 # Git worktrees
 .worktrees
+
+# Claude Code working directory (per-worktree scratch: launchers, verify
+# scripts, plans). Not part of the project.
+.claude

--- a/cortex/webgl/resources/js/facepick.js
+++ b/cortex/webgl/resources/js/facepick.js
@@ -82,8 +82,27 @@ function PickPosition(surf, posdata) {
 PickPosition.prototype = {
     //Set the transform for any voxels
     apply: function(dataview) {
-        if (dataview)
-            this.xfm.set.apply(this.xfm, dataview.xfm);
+        if (dataview) {
+            if (dataview.xfm) {
+                // For 2D volume dataviews, dataview.xfm is [xfm_dim1, xfm_dim2];
+                // both share xfmname (enforced server-side), so dim1's transform
+                // is correct for picker -> voxel conversion. For 1D volume,
+                // dataview.xfm is a flat 16-element array. Mirror the dataset.js
+                // volxfm length check (see VolumeData.init).
+                var xfm = (dataview.xfm.length === 16) ? dataview.xfm : dataview.xfm[0];
+                this.xfm.set.apply(this.xfm, xfm);
+            } else {
+                // Vertex dataviews have no xfm. Setting the matrix to NaN
+                // suppresses voxel-axis marker rendering (Three.js culls NaN
+                // positions). This mirrors the implicit pre-existing
+                // behavior where `set.apply(xfm, undefined)` invoked
+                // `Matrix4.set()` with no args, leaving the matrix
+                // un-numerable — voxel markers don't belong on a vertex
+                // view (you're picking a vertex, not a voxel).
+                this.xfm.set(NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN,
+                             NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN);
+            }
+        }
 
         for (var i = 0; i < this.axes.length; i++) {
             var ax = this.axes[i];

--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -1,11 +1,16 @@
 var mriview = (function(module) {
     var grid_shapes = [null, [1,1], [2, 1], [3, 1], [2, 2], [2, 2], [3, 2], [3, 2]];
 
-    // Returns true iff every VolumeData entry in `data` shares the same
-    // shape, mosaic, and numslices as data[0]. The hover/click value
-    // readout for 2D volume views reuses data[0]'s mouse_index across
-    // all dims and is only correct under that condition.
-    module.volumeGeomsMatch = function (data) {
+    // Returns true iff every VolumeData entry in `dataview.data` shares the
+    // same shape, mosaic, and numslices, AND every dim's transform matches
+    // dim0's. The hover/click value readout for 2D volume views computes
+    // mouse_index from dim0's voxel coordinate (via picker.xfm = dim0 xfm)
+    // and reuses it across all dims; that is only correct when both shape/
+    // mosaic AND the transforms match. Python-side Volume2D enforces matching
+    // xfmname (so xfms agree); dataset.makeFrom can pair volumes with
+    // matching shape but different transforms — bail out in that case.
+    module.volumeGeomsMatch = function (dataview) {
+        var data = dataview && dataview.data;
         if (!data || data.length < 2) return true;
         var d0 = data[0];
         for (var i = 1; i < data.length; i++) {
@@ -14,6 +19,21 @@ var mriview = (function(module) {
             if (d0.shape[0] !== di.shape[0] || d0.shape[1] !== di.shape[1]) return false;
             if (d0.mosaic[0] !== di.mosaic[0] || d0.mosaic[1] !== di.mosaic[1]) return false;
             if (d0.numslices !== di.numslices) return false;
+        }
+        // For 2D volume dataviews, dataview.xfm is [xfm_dim0, xfm_dim1, ...];
+        // each entry is a flat 16-element array. (For 1D the xfm is itself a
+        // flat 16-element array, no per-dim entries to compare — handled by
+        // the early return above.)
+        var xfm = dataview.xfm;
+        if (Array.isArray(xfm) && xfm.length === data.length && Array.isArray(xfm[0])) {
+            var x0 = xfm[0];
+            for (var j = 1; j < xfm.length; j++) {
+                var xj = xfm[j];
+                if (!Array.isArray(xj) || xj.length !== x0.length) return false;
+                for (var k = 0; k < x0.length; k++) {
+                    if (x0[k] !== xj[k]) return false;
+                }
+            }
         }
         return true;
     };
@@ -771,7 +791,7 @@ var mriview = (function(module) {
                     // dataset.makeFrom (mriview.js:283) can pair arbitrary 1D
                     // volumes; if their geometries diverge, hide the readout
                     // rather than display a wrong-but-plausible value.
-                    if (!module.volumeGeomsMatch(this.active.data)) {
+                    if (!module.volumeGeomsMatch(this.active)) {
                         $('#mouseover_value').css('display', 'none')
                         return
                     }
@@ -965,7 +985,7 @@ var mriview = (function(module) {
             if (coords !== -1) {
                 // Volume branch. See the matching note in the mousemove handler
                 // for why we hide on geometry mismatch.
-                if (!module.volumeGeomsMatch(this.active.data)) {
+                if (!module.volumeGeomsMatch(this.active)) {
                     $('#picked_value').css('display', 'none')
                     return
                 }

--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -1,5 +1,41 @@
 var mriview = (function(module) {
     var grid_shapes = [null, [1,1], [2, 1], [3, 1], [2, 2], [2, 2], [3, 2], [3, 2]];
+
+    // Returns true iff every VolumeData entry in `data` shares the same
+    // shape, mosaic, and numslices as data[0]. The hover/click value
+    // readout for 2D volume views reuses data[0]'s mouse_index across
+    // all dims and is only correct under that condition.
+    module.volumeGeomsMatch = function (data) {
+        if (!data || data.length < 2) return true;
+        var d0 = data[0];
+        for (var i = 1; i < data.length; i++) {
+            var di = data[i];
+            if (!d0.shape || !di.shape || !d0.mosaic || !di.mosaic) return false;
+            if (d0.shape[0] !== di.shape[0] || d0.shape[1] !== di.shape[1]) return false;
+            if (d0.mosaic[0] !== di.mosaic[0] || d0.mosaic[1] !== di.mosaic[1]) return false;
+            if (d0.numslices !== di.numslices) return false;
+        }
+        return true;
+    };
+
+    // Returns true iff every entry in `data` has the per-frame buffers the
+    // hover/click handlers need (verts for vertex data, textures for
+    // volume data). Loading is async — the dataview's `loaded` deferred
+    // can resolve a tick before all child VertexData/VolumeData buffers
+    // are populated, and the setData refire fires inside that window.
+    module.dataBuffersReady = function (data) {
+        if (!data || data.length === 0) return false;
+        for (var i = 0; i < data.length; i++) {
+            var d = data[i];
+            if (d.mosaic !== undefined) {
+                if (!d.textures || d.textures.length === 0) return false;
+            } else {
+                if (!d.verts || d.verts.length === 0) return false;
+            }
+        }
+        return true;
+    };
+
     module.Viewer = function(figure) {
         jsplot.Axes.call(this, figure);
 
@@ -252,6 +288,14 @@ var mriview = (function(module) {
 
     module.Viewer.prototype.setData = function(name) {
 
+        // Hide any previously displayed hover/click values immediately. They
+        // refer to the OLD dataview; we will re-fire them against the NEW
+        // dataview once it has loaded (see this.active.loaded.done() below).
+        // Without this transient hide, a stale number is briefly visible
+        // during the (sometimes slow) load of the new dataset.
+        $('#mouseover_value').css('display', 'none')
+        $('#picked_value').css('display', 'none')
+
         // blur any selected input elements
         let ids = [
             ['#vmin', '#vmin-input'],
@@ -312,7 +356,28 @@ var mriview = (function(module) {
         this.active.loaded.done(function() {
             this.active.set();
             // Register event for dataset switching
-            this.dispatchEvent({type:"setData", name:this.active.name});            
+            this.dispatchEvent({type:"setData", name:this.active.name});
+            // Push the new dataview into each surface (shaders + picker xfm)
+            // before re-firing hover/click. drawView normally does this on
+            // the next render frame, but pick() needs the picker's xfm to
+            // already match the new dataview — otherwise a vertex→volume
+            // switch picks with the prior (vertex-view, NaN) transform.
+            for (var i = 0; i < this.surfs.length; i++) {
+                if (this.surfs[i].apply !== undefined)
+                    this.surfs[i].apply(this.active);
+            }
+            // Re-fire hover and click indicators so the displayed values
+            // reflect the newly-active dataview at the same screen positions
+            // (see _lastHoverEvent / _lastPickEvt cached by the handlers).
+            if (this._lastHoverEvent) {
+                $("#brain").trigger($.Event('mousemove', {
+                    clientX: this._lastHoverEvent.clientX,
+                    clientY: this._lastHoverEvent.clientY,
+                }));
+            }
+            if (this._lastPickEvt) {
+                this.pick({x: this._lastPickEvt.x, y: this._lastPickEvt.y});
+            }
         }.bind(this));
 
         // var surf, scene, grid = grid_shapes[this.active.data.length];
@@ -667,40 +732,64 @@ var mriview = (function(module) {
 
         $("#brain").on('mousemove',
             function (event) {
-                // only implemented for 1d volume datasets or vertex datasets
-                if (this.active.data.length != 1 || this.active.data[0].raw) {
+                // Cache last mouse position so setData() can recompute the
+                // hover indicator for the newly-active dataset at the same
+                // screen coordinate.
+                this._lastHoverEvent = event;
+                // Skip RGB views (no underlying scalars), unsupported lengths,
+                // or dataviews whose buffers haven't finished populating yet
+                // (the setData refire can briefly precede buffer fill).
+                if (this.active.data[0].raw ||
+                    (this.active.data.length !== 1 && this.active.data.length !== 2) ||
+                    !module.dataBuffersReady(this.active.data)) {
                     $('#mouseover_value').css('display', 'none')
                     return
                 }
                 // We need to use a different logic if we have a VolumeData or a VertexData object
-                let value = null;
+                let values = null;
                 if (this.active.vertex) {
                     coords = this.getCoords(event)
                     if (coords !== -1) {
                         hemiIdx = (coords.hemi == 'left') ? 0 : 1
-                        // console.log('hemiIdx: ', hemiIdx)
                         vertex = coords.vertex
-                        // console.log('vertex: ', vertex)
                         // Now we need to map back with the index map
                         // First figure out the subject, then get the index map
+                        // (dim1 and dim2 share subject for 2D views, enforced server-side)
                         subject = this.active.data[0].subject
                         indexMap = subjects[subject].hemis[coords.hemi].indexMap
-                        // console.log("vertex before: " + vertex);
                         vertex = indexMap[vertex]
-                        // console.log("vertex after: " + vertex);
-                        // Now access the data
-                        value = this.active.data[0].verts[0][hemiIdx].array[vertex]
+                        // Now access the data for each channel (1 for 1D, 2 for 2D)
+                        values = this.active.data.map(function (d) {
+                            return d.verts[0][hemiIdx].array[vertex]
+                        })
                     }
                 } else {
-                    // Get index of the mosaic to get the value
+                    // Volume branch. For 2D views we reuse data[0]'s mouse_index
+                    // across all dims; that is safe iff every dim shares the
+                    // same shape/mosaic/numslices. Python-side Volume2D enforces
+                    // matching xfmname → matching geometry. Client-side
+                    // dataset.makeFrom (mriview.js:283) can pair arbitrary 1D
+                    // volumes; if their geometries diverge, hide the readout
+                    // rather than display a wrong-but-plausible value.
+                    if (!module.volumeGeomsMatch(this.active.data)) {
+                        $('#mouseover_value').css('display', 'none')
+                        return
+                    }
                     mouse_index = this.getMouseIndex(event)
                     if (mouse_index !== -1) {
-                        value = this.active.data[0].textures[0].image.data[mouse_index]
+                        values = this.active.data.map(function (d) {
+                            return d.textures[0].image.data[mouse_index]
+                        })
                     }
                 }
-                // console.log("Value on mouseover: " + value);
-                if (value !== null) {
-                    $('#mouseover_value').text(parseFloat(value).toPrecision(3))
+                if (values !== null) {
+                    let formatted = values.map(function (v) {
+                        return parseFloat(v).toPrecision(3)
+                    }).join(', ')
+                    if (values.length > 1) {
+                        formatted = '(' + formatted + ')'
+                    }
+                    $('#mouseover_value').text(formatted)
                     $('#mouseover_value').css('display', 'block')
                 } else {
                     $('#mouseover_value').css('display', 'none')
@@ -839,44 +928,64 @@ var mriview = (function(module) {
     }
 
     module.Viewer.prototype.pick = function(evt) {
+        // Cache last pick position so setData() can refresh the picked
+        // indicator for the newly-active dataset at the same screen point.
+        this._lastPickEvt = {x: evt.x, y: evt.y};
         let coords
         for (var i = 0; i < this.surfs.length; i++) {
             if (this.surfs[i].pick)
                 coords = this.surfs[i].pick(this.renderer, this.camera, evt.x, evt.y);
         }
         // set the picked value display
-        // only implemented for 1d volume datasets or vertex datasets
-        if (this.active.data.length != 1 || this.active.data[0].raw) {
+        // Skip RGB, unsupported lengths, or unloaded buffers (see hover note).
+        if (this.active.data[0].raw ||
+            (this.active.data.length !== 1 && this.active.data.length !== 2) ||
+            !module.dataBuffersReady(this.active.data)) {
             $('#picked_value').css('display', 'none')
             return
         }
 
         // We need to use a different logic if we have a VolumeData or a VertexData object
-        let value = null;
+        let values = null;
         if (this.active.vertex) {
             if (coords !== -1) {
                 hemiIdx = (coords.hemi == 'left') ? 0 : 1
                 vertex = coords.vertex
                 // Now we need to map back with the index map
                 // First figure out the subject, then get the index map
+                // (dim1 and dim2 share subject for 2D views, enforced server-side)
                 subject = this.active.data[0].subject
                 indexMap = subjects[subject].hemis[coords.hemi].indexMap
                 vertex = indexMap[vertex]
-                // Now access the data
-                value = this.active.data[0].verts[0][hemiIdx].array[vertex]
+                // Now access the data for each channel (1 for 1D, 2 for 2D)
+                values = this.active.data.map(function (d) {
+                    return d.verts[0][hemiIdx].array[vertex]
+                })
             }
         } else {
             if (coords !== -1) {
-                // Get index of the mosaic to get the value
+                // Volume branch. See the matching note in the mousemove handler
+                // for why we hide on geometry mismatch.
+                if (!module.volumeGeomsMatch(this.active.data)) {
+                    $('#picked_value').css('display', 'none')
+                    return
+                }
                 let mouse_index = this.xyxToI(coords.voxel.x, coords.voxel.y, coords.voxel.z)
                 if (mouse_index !== -1) {
-                    value = this.active.data[0].textures[0].image.data[mouse_index]
+                    values = this.active.data.map(function (d) {
+                        return d.textures[0].image.data[mouse_index]
+                    })
                 }
             }
         }
-        console.log("Value on click: " + value);
-        if (value !== null) {
-            $('#picked_value').text(parseFloat(value).toPrecision(3))
+        if (values !== null) {
+            let formatted = values.map(function (v) {
+                return parseFloat(v).toPrecision(3)
+            }).join(', ')
+            if (values.length > 1) {
+                formatted = '(' + formatted + ')'
+            }
+            $('#picked_value').text(formatted)
             $('#picked_value').css('display', 'block')
         } else {
             $('#picked_value').css('display', 'none')

--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -736,11 +736,13 @@ var mriview = (function(module) {
                 // hover indicator for the newly-active dataset at the same
                 // screen coordinate.
                 this._lastHoverEvent = event;
-                // Skip RGB views (no underlying scalars), unsupported lengths,
-                // or dataviews whose buffers haven't finished populating yet
-                // (the setData refire can briefly precede buffer fill).
-                if (this.active.data[0].raw ||
-                    (this.active.data.length !== 1 && this.active.data.length !== 2) ||
+                // Length check first so the short-circuit guards us against
+                // an empty data array before we read data[0]. Then skip RGB
+                // (no underlying scalars), then ensure all child buffers
+                // have populated (the setData refire can briefly precede
+                // buffer fill).
+                if ((this.active.data.length !== 1 && this.active.data.length !== 2) ||
+                    this.active.data[0].raw ||
                     !module.dataBuffersReady(this.active.data)) {
                     $('#mouseover_value').css('display', 'none')
                     return
@@ -748,16 +750,14 @@ var mriview = (function(module) {
                 // We need to use a different logic if we have a VolumeData or a VertexData object
                 let values = null;
                 if (this.active.vertex) {
-                    coords = this.getCoords(event)
+                    let coords = this.getCoords(event)
                     if (coords !== -1) {
-                        hemiIdx = (coords.hemi == 'left') ? 0 : 1
-                        vertex = coords.vertex
-                        // Now we need to map back with the index map
-                        // First figure out the subject, then get the index map
-                        // (dim1 and dim2 share subject for 2D views, enforced server-side)
-                        subject = this.active.data[0].subject
-                        indexMap = subjects[subject].hemis[coords.hemi].indexMap
-                        vertex = indexMap[vertex]
+                        let hemiIdx = (coords.hemi == 'left') ? 0 : 1
+                        // Map the picked vertex through the subject's indexMap.
+                        // dim1 and dim2 share subject for 2D views (server-side).
+                        let subject = this.active.data[0].subject
+                        let indexMap = subjects[subject].hemis[coords.hemi].indexMap
+                        let vertex = indexMap[coords.vertex]
                         // Now access the data for each channel (1 for 1D, 2 for 2D)
                         values = this.active.data.map(function (d) {
                             return d.verts[0][hemiIdx].array[vertex]
@@ -775,7 +775,7 @@ var mriview = (function(module) {
                         $('#mouseover_value').css('display', 'none')
                         return
                     }
-                    mouse_index = this.getMouseIndex(event)
+                    let mouse_index = this.getMouseIndex(event)
                     if (mouse_index !== -1) {
                         values = this.active.data.map(function (d) {
                             return d.textures[0].image.data[mouse_index]
@@ -937,9 +937,10 @@ var mriview = (function(module) {
                 coords = this.surfs[i].pick(this.renderer, this.camera, evt.x, evt.y);
         }
         // set the picked value display
-        // Skip RGB, unsupported lengths, or unloaded buffers (see hover note).
-        if (this.active.data[0].raw ||
-            (this.active.data.length !== 1 && this.active.data.length !== 2) ||
+        // Length check first so we don't index data[0] on an empty array.
+        // Skip RGB, then ensure all child buffers have populated.
+        if ((this.active.data.length !== 1 && this.active.data.length !== 2) ||
+            this.active.data[0].raw ||
             !module.dataBuffersReady(this.active.data)) {
             $('#picked_value').css('display', 'none')
             return
@@ -949,14 +950,12 @@ var mriview = (function(module) {
         let values = null;
         if (this.active.vertex) {
             if (coords !== -1) {
-                hemiIdx = (coords.hemi == 'left') ? 0 : 1
-                vertex = coords.vertex
-                // Now we need to map back with the index map
-                // First figure out the subject, then get the index map
-                // (dim1 and dim2 share subject for 2D views, enforced server-side)
-                subject = this.active.data[0].subject
-                indexMap = subjects[subject].hemis[coords.hemi].indexMap
-                vertex = indexMap[vertex]
+                let hemiIdx = (coords.hemi == 'left') ? 0 : 1
+                // Map the picked vertex through the subject's indexMap.
+                // dim1 and dim2 share subject for 2D views (server-side).
+                let subject = this.active.data[0].subject
+                let indexMap = subjects[subject].hemis[coords.hemi].indexMap
+                let vertex = indexMap[coords.vertex]
                 // Now access the data for each channel (1 for 1D, 2 for 2D)
                 values = this.active.data.map(function (d) {
                     return d.verts[0][hemiIdx].array[vertex]


### PR DESCRIPTION
Fixes [#634](https://github.com/gallantlab/pycortex/issues/634).

## Summary

- Hover and click handlers now display both channel values for `Vertex2D` / `Volume2D` as `(v1, v2)`. The bail-out condition `data.length != 1` was hiding both indicators on 2D views even though both channels reach the browser intact (`Dataview2D.uniques` yields dim1 and dim2 as separate brain entries).
- **`Volume2D` picker fix (latent bug surfaced by the readout work):** for 2D views `dataview.xfm` is `[xfm_dim1, xfm_dim2]`, but `PickPosition.apply` was spreading that as two positional args to `Matrix4.set`, leaving the picker matrix full of `NaN`. Voxel coords resolved to `(0,0,0)`, which is why the new readout initially showed `(0, 0)` always. The fix mirrors the `volxfm` length check from `VolumeData.init` and uses dim1's transform (both share `xfmname` server-side).
- **Vertex views explicitly NaN the picker matrix.** A stale volume xfm would otherwise bleed through after switching from a Volume view and draw voxel-axis crosshairs across an inflated brain. Vertex picks aren't voxel picks; suppressing the marker matches the implicit pre-existing behavior (`set.apply(xfm, undefined)` invoked `Matrix4.set()` with no args).
- **Geometry guard for client-side `dataset.makeFrom`.** That path pairs two arbitrary 1D dataviews into an ad-hoc 2D view, only checking "both volume or both vertex" — it can produce a 2D view with divergent `shape`/`mosaic`. The hover/click code reuses `data[0]`'s `mouse_index` for both channels, so divergent geometry would yield a wrong-but-plausible second value. Hide the indicators in that case rather than mislead.
- **Refresh indicators on dataset switch.** Cache the last hover and pick screen coordinates and re-fire after the new dataview loads, with a `dataBuffersReady` guard for the brief window between `dataview.loaded` resolving and child `VertexData`/`VolumeData` buffers populating.

## Files changed

- [`cortex/webgl/resources/js/mriview.js`](cortex/webgl/resources/js/mriview.js) — handlers, `volumeGeomsMatch` / `dataBuffersReady` helpers, `setData` reset+refire.
- [`cortex/webgl/resources/js/facepick.js`](cortex/webgl/resources/js/facepick.js) — `PickPosition.apply` xfm dispatch.
- `.gitignore` — ignore the per-worktree `.claude/` scratch dir.

## Test plan

- [x] Existing `cortex/tests/test_webgl_headless.py::test_datatype_renders` (Volume / Vertex / VolumeRGB / VertexRGB / Volume2D / Vertex2D) — 6/6 pass.
- [x] End-to-end Playwright probe for hover and click on each of: `Vertex` (1D), `Volume` (1D), `Vertex2D`, `Volume2D`, `VertexRGB`, plus a regression case for `dataset.makeFrom` pairing two `Volume`s with divergent `xfmname` (S1 fullhead × retinotopy → 100³ vs 72³ shape) — all 6 pass.
- [x] Interactive: confirmed `Vertex2D` shows `(-0.670, 1.98)` (matches `Vertex` 1D's first channel for same RNG seed); `Volume2D` shows `(-1.00, -1.14)` (matches `Volume` 1D's first channel); `VertexRGB` indicators stay hidden; voxel crosshairs do not appear on vertex views; switching datasets refreshes the picked indicator without showing a stale value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)