### PR TITLE
FIX DataView.loaded race causing blank canvas in multi-data viewers (#637)

### DIFF
--- a/cortex/webgl/resources/js/dataset.js
+++ b/cortex/webgl/resources/js/dataset.js
@@ -481,7 +481,15 @@ var dataset = (function(module) {
                     this.loaded.notify(available);
                 }.bind(this));
             }.bind(this)).done(function(){
-                this.loaded.resolve();
+                // Wait for subjects[this.subject].loaded before resolving so
+                // anyone awaiting VertexData.loaded actually sees populated
+                // this.verts / this.nanmasks: the progress-queued callbacks
+                // above push to those arrays from inside the same
+                // subjects.loaded.done chain, and jQuery dispatches done
+                // callbacks in registration order.
+                subjects[this.subject].loaded.done(function() {
+                    this.loaded.resolve();
+                }.bind(this));
             }.bind(this))
         }.bind(this));
     }

--- a/cortex/webgl/resources/js/dataset.js
+++ b/cortex/webgl/resources/js/dataset.js
@@ -109,34 +109,37 @@ var dataset = (function(module) {
 
         this._dispatch = this.dispatchEvent.bind(this);
 
-        //Aggregate all Volume/VertexData deferreds to determine when to resolve
+        // Aggregate all child Volume/VertexData deferreds to determine when
+        // to resolve. Each child is tracked separately by registering on its
+        // own .loaded — using $.when().progress and looping over data.length
+        // would mark every child ready on a single child's notify, since
+        // $.when's combined progress event doesn't say which source fired.
+        // That ordering bug caused setData → active.set() to dispatch
+        // verts/textures for a sibling that hadn't pushed yet.
         var allready = [];
         for (var i = 0; i < this.data.length; i++) {
             allready.push(false);
         }
-
-        var deferred = this.data.length == 1 ?
-            $.when(this.data[0].loaded) :
-            $.when(this.data[0].loaded, this.data[1].loaded);
-        deferred
-        .progress(function(available) {
-            for (var i = 0; i < this.data.length; i++) {
-                //TODO: fix this load order
-                if (available > this.delay && !allready[i]) {
-                    allready[i] = true;
-
-                    //Resolve this deferred if ALL the BrainData objects are loaded (for multiviews)
-                    var test = true;
-                    for (var j = 0; j < allready.length; j++)
-                        test = test && allready[j];
-                    if (test)
-                        this.loaded.resolve();
-                }
-            }
-        }.bind(this))
-        .done(function() {
+        var checkResolve = function() {
+            for (var j = 0; j < allready.length; j++)
+                if (!allready[j]) return;
             this.loaded.resolve();
-        }.bind(this));
+        }.bind(this);
+        var markReady = function(idx) {
+            if (!allready[idx]) {
+                allready[idx] = true;
+                checkResolve();
+            }
+        };
+        for (var i = 0; i < this.data.length; i++) {
+            (function(idx) {
+                this.data[idx].loaded
+                    .progress(function(available) {
+                        if (available > this.delay) markReady(idx);
+                    }.bind(this))
+                    .done(function() { markReady(idx); });
+            }.bind(this))(i);
+        }
 
         this.ui = new jsplot.Menu();
 
@@ -481,15 +484,7 @@ var dataset = (function(module) {
                     this.loaded.notify(available);
                 }.bind(this));
             }.bind(this)).done(function(){
-                // Wait for subjects[this.subject].loaded before resolving so
-                // anyone awaiting VertexData.loaded actually sees populated
-                // this.verts / this.nanmasks: the progress-queued callbacks
-                // above push to those arrays from inside the same
-                // subjects.loaded.done chain, and jQuery dispatches done
-                // callbacks in registration order.
-                subjects[this.subject].loaded.done(function() {
-                    this.loaded.resolve();
-                }.bind(this));
+                this.loaded.resolve();
             }.bind(this))
         }.bind(this));
     }

--- a/cortex/webgl/resources/js/dataset.js
+++ b/cortex/webgl/resources/js/dataset.js
@@ -140,6 +140,9 @@ var dataset = (function(module) {
                     .done(function() { markReady(idx); });
             }.bind(this))(i);
         }
+        // Handle the empty-data edge case so this.loaded still resolves
+        // (matches the pre-refactor $.when() semantics for no arguments).
+        checkResolve();
 
         this.ui = new jsplot.Menu();
 


### PR DESCRIPTION
Fixes #637.

## Summary

After [#635](https://github.com/gallantlab/pycortex/pull/635) (`28129b3e`), `cortex.webgl.make_static` viewers
intermittently render a blank canvas on initial load when the `.npy`
textures finish downloading before the CTM mesh has been parsed.
DevTools shows:

```
TypeError: can't access property 0, event.value is undefined
  at SurfDelegate.setAttribute (mriview_surface.js:740)
  at VertexData.set            (dataset.js:496)
  at DataView.setFrame         (dataset.js:274)
  at Viewer.setData            (mriview.js:377)
```

## Root cause

In the `DataView` constructor, the loaded aggregation looped over every
child every time `$.when()`'s combined progress fired:

```js
deferred.progress(function (available) {
    for (var i = 0; i < this.data.length; i++) {
        if (available > this.delay && !allready[i]) {
            allready[i] = true;          // <-- marks EVERY i
            ...
            if (test) this.loaded.resolve();
        }
    }
})
```

`$.when`'s combined progress callback doesn't say which source fired, so
the first child's notify flips **every** `allready[i]` to true and the
test passes. `DataView.loaded` resolves as soon as the first child's
verts push lands — the sibling `VertexData`'s `verts` is still `[]`.
`setData`'s `this.active.set()` (added in #635 to make picker xfm correct
on dataset switch) then iterates `data[i].set()` for both children, and
`data[1].set()` dispatches `{ value: this.verts[0] } === { value:
undefined }`, crashing `SurfDelegate.setAttribute` on `event.value[0]`.

The race already existed but was harmless before #635, when `setData`
never called `this.active.set()` on the initial load.

## Fix

Register on **each** child's `.loaded` deferred individually, so
`allready[idx]` is only set when `data[idx]` actually notifies (or
resolves, for the 1D path). `DataView.loaded` only resolves once every
child has notified — by which time every child has pushed verts inside
its `subjects[subject].loaded.done` callback, so `active.set()` finds
populated buffers.

## What didn't work

The first commit on this PR wrapped `VertexData.loaded.resolve()` in
`subjects[subject].loaded.done(...)` thinking the race was inside
`VertexData`. That was a no-op for the multi-D arrays that make_static
actually emits: `NParray.update` only `notify`s `array.loaded` for
shape `(1, nverts)`, never `resolve`s it, so the outer `.done` handler
at `dataset.js:484` doesn't fire and adding another wait inside it
changes nothing. That commit is reverted in the follow-up.

## Test plan

- [x] `pytest cortex/tests/test_webgl_headless.py -k "not visual_comparison and not addData"` — 13 tests pass with zero page errors (all 6 dtypes, NaN-mask regressions, RGB alpha regressions, capture roundtrip, overlay visibility)
- [x] Manual (mvdoc): `make_static` viewer over `python -m http.server`, hard-reload 10+ times in Firefox/Chrome — every reload should render with no `event.value is undefined` console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)