### PR TITLE
TST harden headless tests against CI timeouts

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -58,7 +58,7 @@ jobs:
       run: playwright install --with-deps --only-shell chromium
 
     - name: Test with pytest
-      timeout-minutes: 20  # in case webviewer tests hang
+      timeout-minutes: 25  # in case webviewer tests hang
       run: pytest --cov=./
 
     - name: Upload coverage to Codecov

--- a/cortex/export/headless.py
+++ b/cortex/export/headless.py
@@ -42,12 +42,50 @@ import concurrent.futures
 import contextlib
 import logging
 import threading
+import time
 from typing import Any, Mapping, Optional
 
 import cortex
 from .. import dataset
 
 logger = logging.getLogger(__name__)
+
+
+def _wait_for_viewer_loaded(handle, timeout: float = 60.0) -> None:
+    """Block until ``window.viewer.loaded`` resolves in the browser.
+
+    The WebSocket "connect" message fires as soon as the page DOM is ready,
+    but the WebGL viewer's CTM mesh download, parse, and initial render
+    typically take a few more seconds. ``viewer.loaded`` is a jQuery
+    Deferred that resolves at the end of ``setData`` (mriview.js), so polling
+    its ``.state()`` is a faithful "the viewer is ready to be driven"
+    signal that replaces brittle fixed sleeps in callers and tests.
+
+    We bypass the JSProxy attribute machinery and call ``send`` directly so
+    each poll is exactly one WebSocket roundtrip (the JSProxy ``__getattr__``
+    path would issue an extra ``query`` call per poll).
+    """
+    deadline = time.monotonic() + timeout
+    poll_interval = 0.1
+    last_err: Optional[str] = None
+    while time.monotonic() < deadline:
+        try:
+            result = handle.send(
+                method="run", params=["window.viewer.loaded.state", []]
+            )
+        except Exception as exc:
+            last_err = repr(exc)
+            result = None
+        if isinstance(result, list) and result and result[0] == "resolved":
+            return
+        if isinstance(result, list) and result and isinstance(result[0], dict):
+            last_err = str(result[0].get("error", result[0]))
+        time.sleep(poll_interval)
+    raise RuntimeError(
+        f"Viewer's .loaded deferred did not resolve within {timeout:.0f}s "
+        f"(last response: {last_err!r}). The CTM mesh may have failed to "
+        "download or parse, or mriview.js failed to initialise."
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -336,6 +374,12 @@ def headless_viewer(
         # Expose a live reference so callers can query browser errors at
         # any point during the session (each call returns a fresh snapshot).
         handle._pw_thread = pw_thread
+
+        # Block until the WebGL viewer has finished initialising (CTM mesh
+        # download + parse + first setData). Replaces ad-hoc time.sleep(10)
+        # calls in tests and callers, and shortens the wait when the
+        # browser is faster than the worst-case timeout.
+        _wait_for_viewer_loaded(handle, timeout=timeout)
 
         yield handle
 

--- a/cortex/export/headless.py
+++ b/cortex/export/headless.py
@@ -76,10 +76,16 @@ def _wait_for_viewer_loaded(handle, timeout: float = 60.0) -> None:
         except Exception as exc:
             last_err = repr(exc)
             result = None
-        if isinstance(result, list) and result and result[0] == "resolved":
+        # WebApp.send always wraps its single per-client response in a list;
+        # unpack the leaf so the "resolved"/"pending"/error-dict check below
+        # is straightforward and last_err carries the actual value seen.
+        val = result[0] if isinstance(result, list) and result else result
+        if val == "resolved":
             return
-        if isinstance(result, list) and result and isinstance(result[0], dict):
-            last_err = str(result[0].get("error", result[0]))
+        if val is not None:
+            last_err = (
+                str(val.get("error", val)) if isinstance(val, dict) else str(val)
+            )
         time.sleep(poll_interval)
     raise RuntimeError(
         f"Viewer's .loaded deferred did not resolve within {timeout:.0f}s "

--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -114,8 +114,12 @@ def save_3d_views(
         cm = contextlib.nullcontext(cortex.webshow(volume, **viewer_params))
 
     with cm as handle:
-        # Wait for the viewer to be loaded
-        time.sleep(sleep)
+        # Wait for the viewer to be loaded. The headless context manager
+        # already blocks on ``viewer.loaded`` before yielding, so we only
+        # need this fixed sleep for the interactive (real-browser) path
+        # where the user is opening the page manually.
+        if not headless:
+            time.sleep(sleep)
 
         # Add interpolation and layers params only if we have a volume
         if isinstance(volume, (cortex.Volume, cortex.Volume2D, cortex.VolumeRGB)):

--- a/cortex/tests/test_webgl_headless.py
+++ b/cortex/tests/test_webgl_headless.py
@@ -83,7 +83,6 @@ def test_datatype_renders(dtype_name, tmp_path):
     """Each data type should render in the headless viewer without errors."""
     vol = make_dataview(dtype_name)
     with cortex.export.headless_viewer(vol, viewer_params={}) as handle:
-        time.sleep(10)
         outfile = str(tmp_path / "test.png")
         handle.getImage(outfile, (512, 384))
         _wait_for_file(outfile)
@@ -111,7 +110,6 @@ class TestAllAngles:
         cls = type(self)
         cls.tmp_dir = tmp_path_factory.mktemp("angles")
         with cortex.export.headless_viewer(vol, viewer_params={}) as handle:
-            time.sleep(10)
             cls.handle = handle
             yield
 
@@ -149,7 +147,6 @@ class TestAllSurfaces:
         cls = type(self)
         cls.tmp_dir = tmp_path_factory.mktemp("surfaces")
         with cortex.export.headless_viewer(vol, viewer_params={}) as handle:
-            time.sleep(10)
             cls.handle = handle
             yield
 
@@ -208,7 +205,6 @@ def test_capture_view_roundtrip():
     """Setting view parameters and capturing them back should match."""
     vol = cortex.Volume(np.random.randn(*volshape), subj, xfmname)
     with cortex.export.headless_viewer(vol, viewer_params={}) as handle:
-        time.sleep(10)
         target_params = {
             "camera.azimuth": 90,
             "camera.altitude": 90,
@@ -243,7 +239,6 @@ def test_overlay_visibility_changes_image(tmp_path):
     with cortex.export.headless_viewer(
         vol, viewer_params=dict(overlays_visible=["rois"])
     ) as handle:
-        time.sleep(10)
         handle._set_view(**view)
         time.sleep(1)
         handle.getImage(f1, (512, 384))
@@ -254,7 +249,6 @@ def test_overlay_visibility_changes_image(tmp_path):
     with cortex.export.headless_viewer(
         vol, viewer_params=dict(overlays_visible=[])
     ) as handle:
-        time.sleep(10)
         handle._set_view(**view)
         time.sleep(1)
         handle.getImage(f2, (512, 384))
@@ -299,7 +293,6 @@ def test_vertex_no_nan_renders_data(tmp_path):
     }
 
     with cortex.export.headless_viewer(vtx, viewer_params={}) as handle:
-        time.sleep(10)
         handle._set_view(**view)
         time.sleep(1)
         outfile = str(tmp_path / "vtx.png")
@@ -336,7 +329,6 @@ def test_vertex_with_nan_renders_partial(tmp_path):
     def render(data, name):
         vtx = cortex.Vertex(data, subj, vmin=0, vmax=1, cmap="Reds")
         with cortex.export.headless_viewer(vtx, viewer_params={}) as handle:
-            time.sleep(10)
             handle._set_view(**view)
             time.sleep(1)
             outfile = str(tmp_path / f"{name}.png")
@@ -400,7 +392,6 @@ def test_vertexrgb_alpha_zero_renders_curvature_only(tmp_path):
         **unfold_view_params["inflated"],
     }
     with cortex.export.headless_viewer(vrgb, viewer_params={}) as handle:
-        time.sleep(10)
         handle._set_view(**view)
         time.sleep(1)
         outfile = str(tmp_path / "alpha_zero.png")
@@ -462,7 +453,6 @@ def test_volumergb_alpha_half_renders_correct_blend(tmp_path):
         **unfold_view_params["inflated"],
     }
     with cortex.export.headless_viewer(vrgb, viewer_params={}) as handle:
-        time.sleep(10)
         handle._set_view(**view)
         time.sleep(1)
         outfile = str(tmp_path / "volumergb_alpha_half.png")
@@ -544,7 +534,10 @@ def test_vertex2d_alpha_half_renders_correct_blend(tmp_path):
     # (some pixels with R clearly > G or B, or vice-versa). We then run the
     # premultiplication discriminator on that frame.
     with cortex.export.headless_viewer(vtx2d, viewer_params={}) as handle:
-        time.sleep(15)
+        # viewer.loaded already resolved by the context manager; a short
+        # extra pause covers the gap before the cmap <img> decodes. The
+        # retry loop below is the real guard for slow decodes.
+        time.sleep(2)
         rgb = None
         outfile = None
         for attempt in range(6):
@@ -617,7 +610,6 @@ def test_addData_no_crash():
     vol1 = cortex.Volume(np.random.randn(*volshape), subj, xfmname)
     vol2 = cortex.Volume(np.random.randn(*volshape), subj, xfmname)
     with cortex.export.headless_viewer(vol1, viewer_params={}) as handle:
-        time.sleep(10)
         handle.addData(second=vol2)
         time.sleep(2)
         pageerrors = [e for e in handle._pw_thread.browser_errors if "[pageerror]" in e]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ test = [
     "nbformat>=5.10.4",
     "pytest",
     "pytest-cov",
+    "pytest-timeout",
 ]
 
 [project.optional-dependencies]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,8 @@ testpaths =
 addopts =
     -r a
     -v
+# Per-test timeout (in seconds) so a single hung headless browser session
+# does not consume the entire CI budget. Individual tests can override with
+# @pytest.mark.timeout(N). Requires the optional ``pytest-timeout``
+# plugin; if not installed, this key is silently ignored.
+timeout = 240


### PR DESCRIPTION
The 20-minute job wall in run_tests.yml was getting close to the
ceiling (19m58s on a recent run) because every headless test waited a
fixed 10s for the WebGL viewer to be "loaded" before driving it.
Across ~26 browser sessions in the matrix, that adds up.

Replace the ad-hoc sleeps with an adaptive wait inside
``headless_viewer``: poll ``window.viewer.loaded.state()`` (a jQuery
Deferred whose resolution marks "CTM mesh downloaded + parsed +
setData done") and only yield the handle once it reports
"resolved". Tests that previously did ``time.sleep(10)`` right
after entering the context manager can drop the sleep entirely;
``save_views.save_3d_views`` skips its own fixed sleep on the
headless path for the same reason.

Add ``pytest-timeout`` with a 240s default so a single hung browser
session fails its own test instead of draining the whole job, and
bump the CI ``timeout-minutes`` to 25 to give some headroom for
matrix stragglers.

https://claude.ai/code/session_01SwRcFj8xoAY3Fv2TG9DXNs