### PR TITLE
replace np.in1d with np.isin

### DIFF
--- a/cortex/rois.py
+++ b/cortex/rois.py
@@ -117,8 +117,8 @@ class ROIpack(object):
                 # Find polys
                 allbpolys = np.unique(surf.connected[inbound+exbound].indices)
                 selbpolys = surf.polys[allbpolys]
-                inpolys = np.in1d(selbpolys, inbound).reshape(selbpolys.shape)
-                expolys = np.in1d(selbpolys, exbound).reshape(selbpolys.shape)
+                inpolys = np.isin(selbpolys, inbound).reshape(selbpolys.shape)
+                expolys = np.isin(selbpolys, exbound).reshape(selbpolys.shape)
                 badpolys = np.logical_or(inpolys.all(1), expolys.all(1))
                 boundpolys = np.logical_and(np.logical_or(inpolys, expolys).all(1), ~badpolys)
 

--- a/cortex/rois.py
+++ b/cortex/rois.py
@@ -117,8 +117,8 @@ class ROIpack(object):
                 # Find polys
                 allbpolys = np.unique(surf.connected[inbound+exbound].indices)
                 selbpolys = surf.polys[allbpolys]
-                inpolys = np.isin(selbpolys, inbound).reshape(selbpolys.shape)
-                expolys = np.isin(selbpolys, exbound).reshape(selbpolys.shape)
+                inpolys = np.isin(selbpolys, inbound)
+                expolys = np.isin(selbpolys, exbound)
                 badpolys = np.logical_or(inpolys.all(1), expolys.all(1))
                 boundpolys = np.logical_and(np.logical_or(inpolys, expolys).all(1), ~badpolys)
 

--- a/cortex/segment.py
+++ b/cortex/segment.py
@@ -384,7 +384,7 @@ def flatten_slim(
     )
     # Cull pts that are not in manifold
     pi = np.arange(len(pts))
-    pii = np.in1d(pi, polys.flatten())
+    pii = np.isin(pi, polys.flatten())
     idx = np.nonzero(pii)[0]
     pts_new = pts[idx]
     # Match indices in polys to new index for pts

--- a/cortex/surfinfo.py
+++ b/cortex/surfinfo.py
@@ -186,7 +186,7 @@ def flat_border(outfile, subject):
     mwallset = set.union(*(set(g[v]) for v in fog.nodes())) & set(allbounds)
     #cutset = (set(g.nodes()) - mwallset) & set(allbounds)
 
-    mwallbounds = [np.in1d(b, mwallset) for b in bounds]
+    mwallbounds = [np.isin(b, mwallset) for b in bounds]
     changes = [np.nonzero(np.diff(b.astype(float))!=0)[0]+1 for b in mwallbounds]
     
     #splitbounds = [np.split(b, c) for b,c in zip(bounds, changes)]

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -811,12 +811,12 @@ def get_roi_masks(subject, xfmname, roi_list=None, gm_sampler='cortical', split_
             vert_in_scan = np.hstack([np.array((m>0).sum(1)).flatten() for m in mapper.masks])
             vert_in_scan = vert_in_scan[roi_verts[roi]]
         elif use_cortex_mask:
-            vox_in_roi = np.in1d(vox_idx.flatten(), roi_verts[roi]).reshape(vox_idx.shape)
+            vox_in_roi = np.isin(vox_idx.flatten(), roi_verts[roi]).reshape(vox_idx.shape)
             roi_voxels[roi] = vox_in_roi & cortex_mask
             # This is not accurate... because vox_idx only contains the indices of the *nearest*
             # vertex to each voxel, it excludes many vertices. I can't think of a way to compute
             # this accurately for non-mapper gm_samplers for now... ML 2017.07.14
-            vert_in_scan = np.in1d(roi_verts[roi], vox_idx[cortex_mask])
+            vert_in_scan = np.isin(roi_verts[roi], vox_idx[cortex_mask])
         # Compute ROI coverage
         pct_coverage[roi] = vert_in_scan.mean() * 100
         if use_mapper:

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -811,7 +811,7 @@ def get_roi_masks(subject, xfmname, roi_list=None, gm_sampler='cortical', split_
             vert_in_scan = np.hstack([np.array((m>0).sum(1)).flatten() for m in mapper.masks])
             vert_in_scan = vert_in_scan[roi_verts[roi]]
         elif use_cortex_mask:
-            vox_in_roi = np.isin(vox_idx.flatten(), roi_verts[roi]).reshape(vox_idx.shape)
+            vox_in_roi = np.isin(vox_idx, roi_verts[roi])
             roi_voxels[roi] = vox_in_roi & cortex_mask
             # This is not accurate... because vox_idx only contains the indices of the *nearest*
             # vertex to each voxel, it excludes many vertices. I can't think of a way to compute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute, according to PEP518
 # specification.
-requires = ["setuptools>=64", "setuptools-scm>=8", "build", "numpy", "cython", "wheel"]
+requires = ["setuptools>=64", "setuptools-scm>=8", "build", "numpy>=1.13.0", "cython", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 future
-numpy
+numpy>=1.13.0
 scipy
 tornado>=4.3
 shapely


### PR DESCRIPTION
`in1d` was deprecated in numpy 2.0 in favor of `isin` and removed in numpy 2.4.0.

Also updated `requirements.txt` and `pypoject.toml` to specify `numpy>=1.13.0`, when `isin` was first introduced.