### PR TITLE
webgl: redraw when the SVG overlay finishes its async texture bake

### DIFF
--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -738,6 +738,10 @@ var mriview = (function(module) {
         var surf = new surftype(this.active, opts);
         surf.addEventListener("mix", this._mix);
         surf.addEventListener("allowTilt", this._allowTilt);
+        // The SVG overlay (ROIs/sulci/labels) re-bakes its texture asynchronously, then
+        // dispatches "update" on the surface once the new texture is swapped in. Redraw when
+        // that lands, otherwise a toggle isn't visible until the next interaction.
+        surf.addEventListener("update", this.schedule.bind(this));
 
         this.surfs.push(surf);
         this.root.add(surf.object);


### PR DESCRIPTION
## Problem

Follow-up to #643. Even with the out-of-order race fixed, a single ROI/sulci/label toggle often still doesn't appear until you next move the brain.

`SVGOverlay.update()` re-bakes the overlay texture **asynchronously**; on completion the surface swaps it into `uniforms.overlay.value` and dispatches `"update"` on itself (`mriview_surface.js:295`). But `addSurf` only wires the surface's `mix`/`allowTilt` and the *dataview's* `update` — **never the surface's own `"update"` to `schedule()`**. So the texture swap lands with no redraw. The menu calls `schedule()` immediately on toggle, which races and usually beats the async bake, drawing the **old** texture; the corrected texture then sits unused until the next interaction.

## Fix

```js
surf.addEventListener("update", this.schedule.bind(this));
```

in `addSurf`, so the overlay redraws the moment its rebaked texture is committed. Together with #643's generation guard, a single toggle now deterministically settles on the current switch state. One line; `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)