### PR TITLE
Revert #644 (overlay redraw) — incomplete, regresses ROI labels

### DIFF
--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -738,10 +738,6 @@ var mriview = (function(module) {
         var surf = new surftype(this.active, opts);
         surf.addEventListener("mix", this._mix);
         surf.addEventListener("allowTilt", this._allowTilt);
-        // The SVG overlay (ROIs/sulci/labels) re-bakes its texture asynchronously, then
-        // dispatches "update" on the surface once the new texture is swapped in. Redraw when
-        // that lands, otherwise a toggle isn't visible until the next interaction.
-        surf.addEventListener("update", this.schedule.bind(this));
 
         this.surfs.push(surf);
         this.root.add(surf.object);


### PR DESCRIPTION
Reverts #644. The `surf "update" -> schedule()` redraw fixes the overlay not redrawing on toggle, but it's **incomplete**: ROI label `text` textures are generated asynchronously in `Labels.update` (`svg.toDataURL -> set_tex`) and `set_tex` doesn't schedule a redraw. #644 forces a redraw the instant the overlay rebakes — usually *before* the label texture has loaded — so the label shader samples an empty texture and renders **black squares** that persist (nothing redraws again). Observed on the static `make_static` viewers (e.g. chen-2024) on load.

The generation guard (#643) is correct and stays. A complete fix must also redraw when each label texture finishes loading (touches the `Labels` class) and needs in-browser verification before landing — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)