### PR TITLE
webgl: fix overlay/label async texture-bake races (complete)

### DIFF
--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -738,6 +738,11 @@ var mriview = (function(module) {
         var surf = new surftype(this.active, opts);
         surf.addEventListener("mix", this._mix);
         surf.addEventListener("allowTilt", this._allowTilt);
+        // The SVG overlay (ROIs/sulci/labels) re-bakes its texture asynchronously, then dispatches
+        // "update" on the surface once the new texture is committed. Redraw when that lands --
+        // otherwise a toggle (or a freshly-loaded label texture) is not visible until the next
+        // interaction, because the menu's immediate schedule() races and beats the async bake.
+        surf.addEventListener("update", this.schedule.bind(this));
 
         this.surfs.push(surf);
         this.root.add(surf.object);

--- a/cortex/webgl/resources/js/svgoverlay.js
+++ b/cortex/webgl/resources/js/svgoverlay.js
@@ -79,6 +79,14 @@ var svgoverlay = (function(module) {
             this.layers[name] = this[name];
             this.labels.left.add(this[name].labels.meshes.left);
             this.labels.right.add(this[name].labels.meshes.right);
+            // A label's glyph texture bakes asynchronously (Labels.set_tex). When it finishes,
+            // ask the surface to redraw so the freshly-loaded labels are actually drawn -- without
+            // this they stay blank/black until the next interaction. Routed through the surface's
+            // own "update" (-> Viewer.schedule) rather than the overlay-texture path, so it does
+            // not clobber uniforms.overlay.value.
+            this[name].labels.addEventListener("update", function() {
+                this.surf.dispatchEvent({type:"update"});
+            }.bind(this));
             this.layers[name].addEventListener("update", this.update.bind(this));
 
             var labels = this.layers[name].labels;
@@ -114,11 +122,17 @@ var svgoverlay = (function(module) {
         this.svg.setAttribute("height", this.height);
     }, 
     module.SVGOverlay.prototype.update = function() {
-	console.log("Updating overlay!");
+        // Re-bake the SVG overlay into a GPU texture asynchronously (toDataURL -> Image.onload).
+        // Rapid layer toggles (ROIs / sulci / labels) can kick off several bakes that finish out
+        // of order, leaving a stale texture on the surface that disagrees with the switch state.
+        // Tag each bake with a generation id and commit only the most recent one.
+        var gen = (this._updateGen = (this._updateGen || 0) + 1);
         this.svg.toDataURL("image/png", {renderer:"native", callback:function(dataurl) {
             var img = new Image();
             //img.src = dataurl;
 	    img.onload = function () {
+		if (gen !== this._updateGen)
+		    return;  // superseded by a newer toggle -- discard this stale bake
 		var tex = new THREE.Texture(img);
 		tex.needsUpdate = true;
 		//tex.anisotropy = 16;
@@ -340,6 +354,7 @@ var svgoverlay = (function(module) {
             this.hide();
         this.update();
     }
+    THREE.EventDispatcher.prototype.apply(module.Labels.prototype);
 
     module.Labels.prototype._make_object = function() {
         this.geometry = {left:new THREE.BufferGeometry(), right:new THREE.BufferGeometry()};
@@ -471,16 +486,23 @@ var svgoverlay = (function(module) {
         // }
 
         var set_tex = function(dataurl) {
+            // Build the glyph texture only AFTER the image has loaded. Creating the THREE.Texture
+            // from a not-yet-loaded image uploaded an empty texture to the GPU (the persistent
+            // black label squares); waiting for onload gives the shader real glyph data. Then
+            // dispatch "update" so the surface redraws now that the texture is ready.
             var img = new Image();
+            img.onload = function() {
+                var tex = new THREE.Texture(img);
+                tex.needsUpdate = true;
+                tex.premultiplyAlpha = true;
+                tex.flipY = false;
+                //delete old texture
+                if (this.shader.uniforms.text.value && this.shader.uniforms.text.value.dispose)
+                    this.shader.uniforms.text.value.dispose();
+                this.shader.uniforms.text.value = tex;
+                this.dispatchEvent({type:"update"});
+            }.bind(this);
             img.src = dataurl;
-            var tex = new THREE.Texture(img);
-            tex.needsUpdate = true;
-            tex.premultiplyAlpha = true;
-            tex.flipY = false;
-            //delete old texture
-            if (this.shader.uniforms.text.value && this.shader.uniforms.text.value.dispose)
-                this.shader.uniforms.text.value.dispose();
-            this.shader.uniforms.text.value = tex;
         }.bind(this);
 
         // $.when(defs).done(function() {


### PR DESCRIPTION
## Problem

On the WebGL `make_static` viewers, the ROI / sulci / label overlay controls misbehave: a toggle often doesn't take effect until you next move the brain, and rapid toggling can leave the overlay disagreeing with the checkbox state. This is the long-standing overlay-toggle bug.

Two earlier fixes (#643 generation guard, #644 redraw-on-bake) were merged and then **both reverted** (#645, #646) — because #644 alone forced a redraw *before* asynchronously-loaded **label** textures were ready, producing persistent **black-square labels** on load (seen on chen-2024). This PR is the complete fix that also handles the label path.

## Root cause — three intertwined async bugs

1. **Out-of-order overlay bakes.** `SVGOverlay.update()` re-bakes the overlay into a GPU texture asynchronously (`toDataURL → Image.onload → dispatch "update"`) with no sequencing guard, so the last bake to *resolve* (not the last *requested*) wins.
2. **No redraw on commit.** `addSurf` never wired the surface's own `"update"` to `Viewer.schedule()`, so a committed overlay texture isn't drawn until the next interaction.
3. **Label texture built from an unloaded image.** `Labels.set_tex` created the glyph `THREE.Texture` from an `Image` whose `src` had just been set (not yet loaded) → an empty GPU upload (the black squares) → and never scheduled a redraw when it finally loaded. This is exactly what made #644 regress.

## Fix

- **(1)** Generation-id guard in `SVGOverlay.update()`; stale bakes are discarded. Stray `console.log("Updating overlay!")` removed.
- **(2)** `surf.addEventListener("update", this.schedule.bind(this))` in `addSurf`.
- **(3)** `Labels.set_tex` now builds the glyph texture inside `img.onload`, then dispatches `"update"`. `Labels` is made an `EventDispatcher`, and each layer's label `"update"` is routed via **`this.surf.dispatchEvent({type:"update"})`** → `Viewer.schedule()`.

Routing the label redraw through the **surface's own `"update"`** (the redraw channel) rather than the overlay-texture channel means `uniforms.overlay.value` is never touched — so no `mriview_surface.js` change is needed and there's no clobber/re-bake loop.

`node --check` passes on both files.

## Verification

Browser-verified against a real make_static viewer (`viewer-stories-group`, a target named in #643): patched the inline JS in `viewer.html` and confirmed — single toggles take effect immediately, rapid toggling always settles on the checkbox state, labels render as text (no black squares) and appear on first enable, and the console no longer logs on every overlay update. Recommend a quick re-check in-browser before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)