### PR TITLE
webgl: fix intermittent headless test hangs

### DIFF
--- a/cortex/export/headless.py
+++ b/cortex/export/headless.py
@@ -342,38 +342,64 @@ def headless_viewer(
     pw_thread = _PlaywrightThread()
 
     handle = None
+    # ------------------------------------------------------------------
+    # 3. Begin waiting for the WebSocket "connect" message on a *daemon*
+    #    thread *before* navigating, so we cannot miss it even if the browser
+    #    connects before page.goto() returns.
+    #
+    #    A daemon thread (rather than a ThreadPoolExecutor) is essential here:
+    #    server.get_client() blocks on a threading.Event with no timeout, so if
+    #    the browser never sends "connect" the getter parks forever. An
+    #    executor's worker is non-daemon and concurrent.futures joins every
+    #    worker at interpreter exit -- a parked getter would then wedge the
+    #    whole process at shutdown (observed as a multi-minute CI hang after
+    #    the tests have already finished). Daemon threads are never joined at
+    #    exit, so a stuck getter can never hold the process hostage.
+    # ------------------------------------------------------------------
+    connect_result: dict[str, Any] = {}
+
+    def _await_client() -> None:
+        try:
+            connect_result["handle"] = server.get_client()
+        except BaseException as exc:  # noqa: BLE001 - reported to main thread
+            connect_result["error"] = exc
+
+    client_thread = threading.Thread(
+        target=_await_client, name="headless-await-client", daemon=True
+    )
+
     try:
-        # ------------------------------------------------------------------
-        # 3. Begin waiting for the WebSocket "connect" message in a thread
-        #    *before* navigating, so we cannot miss it even if the browser
-        #    connects before page.goto() returns.
-        # ------------------------------------------------------------------
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        fut = pool.submit(server.get_client)
+        client_thread.start()
         try:
             # Launch the browser and navigate.  python_interface.js runs on
             # load and sends "connect" over WebSocket, which unblocks
             # server.get_client().
             pw_thread.start(url, timeout=timeout)
 
-            # Retrieve the handle; it should already be ready by this point,
-            # but the timeout guard surfaces hung state clearly.
-            handle = fut.result(timeout=timeout)
+            # Wait (bounded) for the getter to return; the timeout guard
+            # surfaces hung state clearly instead of blocking indefinitely.
+            client_thread.join(timeout=timeout)
+            if "error" in connect_result:
+                raise connect_result["error"]
+            if "handle" not in connect_result:
+                raise TimeoutError(
+                    f"No WebSocket 'connect' received within {timeout:.0f}s"
+                )
+            handle = connect_result["handle"]
         except Exception as e:
-            fut.cancel()
             browser_errors = pw_thread.browser_errors
             detail = (
                 "\nBrowser errors:\n" + "\n".join(browser_errors)
                 if browser_errors
                 else "\nNo browser errors were captured."
             )
-            pool.shutdown(wait=False, cancel_futures=True)
+            # Unblock the (daemon) getter if it is still parked on the connect
+            # event so it exits promptly rather than lingering across sessions.
+            server.connect.set()
             raise RuntimeError(
                 f"Failed to establish WebSocket connection with headless browser at {url} "
                 f"within {timeout:.0f} seconds. {detail}"
             ) from e
-        else:
-            pool.shutdown(wait=False)
 
         assert not isinstance(handle, list)  # type narrowing to JSMixer
         handle.server = server

--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -28,6 +28,7 @@ import tornado.web
 import tornado.ioloop
 import tornado.httpserver
 from tornado import websocket
+from tornado.netutil import bind_sockets
 from tornado.web import HTTPError
 
 cwd = os.path.split(os.path.abspath(__file__))[0]
@@ -310,7 +311,25 @@ class WebApp(threading.Thread):
             (r"/wsconnect/", ClientSocket, dict(parent=self)),
             (r"/(.*)", tornado.web.StaticFileHandler, dict(path=cwd)),
         ]
-        self.port = port
+        # Bind the listening socket(s) here, synchronously, in the calling
+        # thread -- rather than picking a random port and calling
+        # ``server.listen(port)`` later on the server thread. This fixes two
+        # long-standing sources of intermittent headless/CI hangs:
+        #   * ``port=0`` asks the OS for a guaranteed-free ephemeral port, so
+        #     we never collide with a lingering server (the old code used
+        #     ``random.randint`` and hoped for the best).
+        #   * a bind failure now raises *here*, visibly, in the caller. The old
+        #     ``listen()`` ran on the server thread, so an
+        #     "Address already in use" died silently and left callers to hang
+        #     for the full timeout waiting to connect to a server that had
+        #     never actually come up.
+        # The socket is bound immediately, so the OS accepts and queues client
+        # connections in the backlog even before the IOLoop starts serving --
+        # eliminating the connect race too.
+        self._sockets = bind_sockets(port if port is not None else 0)
+        # When port==0 the OS assigns the port; read the real value back so
+        # callers can build a correct URL.
+        self.port = self._sockets[0].getsockname()[1]
         self.response: Queue[Union[str, bytes]] = Queue()
         self.connect = threading.Event()
         self.sockets: list[websocket.WebSocketHandler] = []
@@ -333,7 +352,9 @@ class WebApp(threading.Thread):
             self.server = tornado.httpserver.HTTPServer(application, io_loop=ioloop)
         else:
             self.server = tornado.httpserver.HTTPServer(application)
-        self.server.listen(self.port)
+        # The socket(s) were already bound in __init__; just start serving on
+        # them. This cannot raise "Address already in use" on the server thread.
+        self.server.add_sockets(self._sockets)
         ioloop.start()
 
     def stop(self):

--- a/cortex/webgl/view.py
+++ b/cortex/webgl/view.py
@@ -930,7 +930,10 @@ def show(
             return JSMixer(self.srvsend, "window.viewer")
 
     if port is None:
-        port = random.randint(1024, 65536)
+        # Let the OS assign a guaranteed-free ephemeral port (WebApp binds
+        # port 0 and reads the real port back). This avoids the random-port
+        # collisions that made headless/CI runs intermittently hang.
+        port = 0
 
     server = WebApp([(r'/ctm/(.*)', CTMHandler),
                      (r'/data/(.*)', DataHandler),


### PR DESCRIPTION
## Summary

The headless WebGL tests hung randomly and then failed in CI (e.g. [run 29051424261](https://github.com/gallantlab/pycortex/actions/runs/29051424261/job/86232825486): one `RuntimeError: Failed to establish WebSocket connection ... within 60 seconds`, then the whole job hit the 25-minute `timeout-minutes` guard ~15 min after pytest had already printed its summary). The job log also showed an unhandled thread exception `OSError: [Errno 98] Address already in use` at `serve.py`.

Two distinct root causes, both in the headless viewer's connection setup:

### 1. Random-port collision with a silent bind failure (the visible test failure)
`WebApp` chose its port with `random.randint(1024, 65536)` and bound it **asynchronously** on the server thread via `server.listen(port)`. When the random port was already taken, `listen()` raised `OSError: [Errno 98] Address already in use` on that thread and died silently, while `server.start()` had already returned. The caller then pointed headless Chromium at a port whose server never came up, so `server.get_client()` blocked for the full 60 s timeout and the test failed.

**Fix:** bind the listening socket **synchronously** in `WebApp.__init__` via `bind_sockets(0)`, letting the OS hand out a guaranteed-free ephemeral port (read back into `self.port`). Bind failures now raise **in the caller**, visibly, instead of dying on the server thread; the pre-bound socket also removes the connect race (the OS backlogs connections before the IOLoop starts). `show()` now requests port 0 instead of a random port. As a side benefit, many simultaneous viewers are now collision-free — each holds its own kernel-reserved ephemeral port for its lifetime.

### 2. Exit-time deadlock after the tests finished (the 25-minute job timeout)
`headless_viewer` awaited the WebSocket `"connect"` on a `ThreadPoolExecutor` worker running `get_client()`, which blocks on a no-timeout `threading.Event`. `cancel_futures=True` can't cancel an already-running future, so on a failed connection the worker parked forever — and `concurrent.futures` joins every worker at interpreter exit, wedging pytest until CI killed it.

**Fix:** await the client on a **daemon** thread (never joined at exit) with a bounded `join`, and set the connect event during teardown so the getter unblocks promptly.

## Testing

Exercised the real `WebApp` directly (standalone, since a full `cortex` import needs `h5py`/Chromium not present in the dev sandbox):
- `port=0` binds a real ephemeral port synchronously and the server serves HTTP on it.
- An explicit in-use port now raises `OSError` (errno 98) **synchronously in the caller** — no silent thread death.
- 30 viewers constructed concurrently from threads got 30 distinct ports — zero collisions.

CI on this PR is the end-to-end check for the headless suite.

## Notes

A small follow-up — hardening `WebApp.stop()` against an early `start()`/`stop()` race (it read `self.server`/`self.ioloop` before the server thread set them) — is prepared but not included here: the branch ruleset requires status checks to update the branch, which only run via this PR, so the extra commit couldn't be pushed on top. It can be added to this branch through the allowed path once checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFExgXD5GN7kzoKZnnytkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFExgXD5GN7kzoKZnnytkH)_