### PR TITLE
FIX explicit vmin/vmax of 0 discarded by Dataview2D.to_json

### DIFF
--- a/cortex/dataset/view2D.py
+++ b/cortex/dataset/view2D.py
@@ -57,8 +57,10 @@ class Dataview2D(Dataview):
         d1js = self.dim1.to_json()
         d2js = self.dim2.to_json()
         sdict.update(dict(
-            vmin = [[self.vmin or d1js['vmin'][0], self.vmin2 or d2js['vmin'][0]]],
-            vmax = [[self.vmax or d1js['vmax'][0], self.vmax2 or d2js['vmax'][0]]],
+            vmin = [[d1js['vmin'][0] if self.vmin is None else self.vmin,
+                     d2js['vmin'][0] if self.vmin2 is None else self.vmin2]],
+            vmax = [[d1js['vmax'][0] if self.vmax is None else self.vmax,
+                     d2js['vmax'][0] if self.vmax2 is None else self.vmax2]],
             ))
 
         if "xfm" in d1js:

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -154,6 +154,36 @@ def test_2D():
     twod.to_json()
 
 
+def test_2D_to_json_keeps_explicit_zero_limits():
+    """to_json must keep an explicitly requested limit of 0 for all four bounds.
+
+    0 is falsy, so a fallback written with ``or`` silently replaces it with the
+    data range taken from the underlying dim.
+    """
+    d1 = cortex.Volume.random(subj, xfmname)
+    d2 = cortex.Volume.random(subj, xfmname)
+
+    # Control: nonzero limits are already passed through untouched.
+    control = cortex.Volume2D(d1, d2, vmin=1, vmax=3, vmin2=2, vmax2=4)
+    assert control.to_json()["vmin"] == [[1, 2]]
+    assert control.to_json()["vmax"] == [[3, 4]]
+
+    view = cortex.Volume2D(d1, d2, vmin=0, vmax=0, vmin2=0, vmax2=0)
+    assert view.to_json()["vmin"] == [[0, 0]]
+    assert view.to_json()["vmax"] == [[0, 0]]
+
+    v1 = cortex.Vertex.random(subj)
+    v2 = cortex.Vertex.random(subj)
+
+    control = cortex.Vertex2D(v1, v2, vmin=1, vmax=3, vmin2=2, vmax2=4)
+    assert control.to_json()["vmin"] == [[1, 2]]
+    assert control.to_json()["vmax"] == [[3, 4]]
+
+    view = cortex.Vertex2D(v1, v2, vmin=0, vmax=0, vmin2=0, vmax2=0)
+    assert view.to_json()["vmin"] == [[0, 0]]
+    assert view.to_json()["vmax"] == [[0, 0]]
+
+
 def test_braindata_hash():
     d = cortex.Volume.random(subj, xfmname)
     hash(d)


### PR DESCRIPTION
`Dataview2D.to_json` uses `or` to fall back to the dim's own range, so a limit of exactly 0 is treated as unset and replaced by the 1st or 99th percentile of the data. All four of `vmin`, `vmax`, `vmin2` and `vmax2` are affected, on both `Volume2D` and `Vertex2D`.

```python
import numpy as np, cortex

shape = cortex.db.get_xfm("S1", "fullhead").shape
data = np.linspace(0.0, 1.0, int(np.prod(shape))).reshape(shape)
d1 = cortex.Volume(data, "S1", "fullhead")
d2 = cortex.Volume(data, "S1", "fullhead")

view = cortex.Volume2D(d1, d2, vmin=0, vmax=3, vmin2=0, vmax2=4)
print(view.vmin, view.vmax, view.vmin2, view.vmax2)
print(view.to_json()["vmin"], view.to_json()["vmax"])
```

On `main`:

```
0 3 0 4
[[np.float64(0.01), np.float64(0.01)]] [[3, 4]]
```

`0.01` is the 1st percentile of the data. The nonzero bounds in the same call come through untouched, so it is specifically the limits equal to 0 that get dropped. The object itself holds what was asked for; only the JSON handed to the webgl viewer loses it, so the viewer draws a range nobody requested.

0 is a normal limit to want. It is what you get from `vmin=arr.min()` on non-negative data, and it is the convention the alpha example in `examples/datasets/plot_data_with_alpha.py` tells people to use.

## Why this looks like an oversight

The same file makes this same pick correctly in ten other places, all with an `is None` test: lines 27-28 in `Dataview2D.__init__`, 171-174 in `Volume2D.__init__`, and 267-270 in `Vertex2D.__init__`. `Dataview2D._to_raw` passes `self.vmin` straight to `Normalize`, which is why `quickshow` already renders the requested range while the webgl viewer does not. The two render paths disagree today. `Dataview.to_json` in `views.py` handles the 1D case with `is None` too.

#332 reported the same family of problem, a limit the caller asked for not reaching the render, and e15f35f ("FIX vmin2 and vmax2 not used in Vertex2D") worked in `__init__` and left `to_json` alone. I have not checked whether that commit was intended as the fix for that issue; it does not say so.

## The change

The two statements in `to_json`, rewritten to test `is None`. Nothing else.

I kept the fallback rather than dropping it. `Volume2D` and `Vertex2D` both resolve `None` in their constructors, so `d1js['vmin'][0]` is unreachable through them, but `Dataview2D` can be constructed directly and leaves `vmin` as `None`. Dropping it would change behaviour beyond this bug. Happy to simplify if you would rather.

## Backward compatibility

Anyone who currently passes a limit of 0 sees their webgl colour scale change, including saved `make_static` viewers regenerated after this. That seems like the point rather than a regression: percentile scaling is what you already get by passing nothing, `quickshow` has always honoured 0 for the same object, and the viewer has interactive vmin/vmax sliders. Worth saying out loud though.

## Testing

New regression test next to the existing `test_2D`, covering all four bounds on both `Volume2D` and `Vertex2D`, with a nonzero control alongside the zero case so it records which half already worked.

```
pytest cortex/tests/test_dataset.py::test_2D_to_json_keeps_explicit_zero_limits
```

Fails on `main`, passes with the change. Verified by reverting `view2D.py` alone with the test in place, confirming it goes red, then restoring.

Full `pytest cortex/tests/` is unchanged apart from the new pass: 6 failed, 57 passed, 55 skipped, against 6 failed, 56 passed on base. I ran it on Windows, where five HDF tests fail on file locking and one needs Inkscape, before and after, unrelated to this.

## One thing worth knowing about the test

It passes `Volume`/`Vertex` objects as the dims and gives the limits to `Volume2D` itself, rather than the shorter raw-array form. That is deliberate: with raw arrays, `__init__` builds each dim with the matching limits, so `d1js['vmin'][0]` is 0 as well and `0 or 0` happens to give the right answer. The raw-array path hides the bug on all four bounds, which is why a test written that way would pass on `main` and prove nothing.
