### PR TITLE
ENH add types in quickflat and vertex mappers

### DIFF
--- a/cortex/mapper/__init__.py
+++ b/cortex/mapper/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations # needed for `type`?
+
 import os
 
 import numpy as np
@@ -7,11 +9,11 @@ from .mapper import Mapper, _savecache
 from .utils import nanproject, vol2surf
 
 
-def get_mapper(subject, xfmname, type='nearest', recache=False, **kwargs):
+def get_mapper(subject: str, xfmname: str, maptype: str='nearest', recache: bool=False, **kwargs) -> Mapper:
     from ..database import db
     from . import point, patch, line
 
-    mapcls = dict(
+    mapcls: dict[str, type[Mapper]] = dict(
         nearest=point.PointNN,
         trilinear=point.PointTrilin,
         gaussian=point.PointGauss,
@@ -22,7 +24,7 @@ def get_mapper(subject, xfmname, type='nearest', recache=False, **kwargs):
         line_nearest=line.LineNN,
         line_trilinear=line.LineTrilin,
         line_lanczos=line.LineLanczos)
-    Map = mapcls[type]
+    Map = mapcls[maptype]
     ptype = Map.__name__.lower()
     kwds ='_'.join(['%s%s'%(k,str(v)) for k, v in list(kwargs.items())])
     if len(kwds) > 0:

--- a/cortex/mapper/line.py
+++ b/cortex/mapper/line.py
@@ -26,7 +26,7 @@ class LineMapper(Mapper):
         #vidx = np.nonzero(valid)[0]
         mapper = sparse.csr_matrix((len(pia), np.prod(shape)))
         for t in np.linspace(0, 1, npts+2)[1:-1]:
-            i, j, data = cls.sampler(pia*t + wm*(1-t), shape)
+            i, j, data = cls.sampler(pia*t + wm*(1-t), shape, **kwargs)
             mapper = mapper + sparse.csr_matrix((data / npts, (i, j)), shape=mapper.shape)
         return mapper
 

--- a/cortex/mapper/mapper.py
+++ b/cortex/mapper/mapper.py
@@ -1,14 +1,27 @@
+import abc
+from typing import Union, overload
+
 import numpy as np
+import numpy.typing as npt
 from scipy import sparse
 
 from .. import dataset
 
+import sys
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
 import warnings
+
 warnings.simplefilter('ignore', sparse.SparseEfficiencyWarning)
 
-class Mapper:
+MapperShape = Union[npt.NDArray[np.integer], tuple[int, int, int]]
+
+class Mapper(abc.ABC):
     '''Maps data from epi volume onto surface using various projections'''
-    def __init__(self, left, right, shape, subject, xfmname):
+    def __init__(self, left: sparse.csr_matrix, right: sparse.csr_matrix, shape: MapperShape, subject: str, xfmname: str):
         self.idxmap = None
         self.masks = [left, right]
         self.nverts = left.shape[0] + right.shape[0]
@@ -17,7 +30,7 @@ class Mapper:
         self.xfmname = xfmname
 
     @classmethod
-    def from_cache(cls, cachefile, subject, xfmname):
+    def from_cache(cls, cachefile: str, subject: str, xfmname: str) -> Self:
         npz = np.load(cachefile)
         left = (npz['left_data'], npz['left_indices'], npz['left_indptr'])
         right = (npz['right_data'], npz['right_indices'], npz['right_indptr'])
@@ -26,12 +39,12 @@ class Mapper:
         return cls(lsparse, rsparse, npz['shape'], subject, xfmname)
 
     @property
-    def mask(self):
+    def mask(self) -> npt.NDArray[np.bool_]:
         mask = np.array(self.masks[0].sum(0) + self.masks[1].sum(0))
         return (mask.squeeze() != 0).reshape(self.shape)
 
     @property
-    def hemimasks(self):
+    def hemimasks(self) -> list[npt.NDArray[np.bool_]]:
         func = lambda m: (np.array(m.sum(0)).squeeze() != 0).reshape(self.shape)
         return [func(x) for x in self.masks]
 
@@ -39,7 +52,13 @@ class Mapper:
         ptype = self.__class__.__name__
         return '<%s mapper with %d vertices>'%(ptype, self.nverts)
 
-    def __call__(self, data):
+    @overload
+    def __call__(self, data: Union[dataset.Volume, tuple]) -> dataset.Vertex: ...
+
+    @overload
+    def __call__(self, data: dataset.Vertex) -> tuple[npt.NDArray, npt.NDArray]: ...
+
+    def __call__(self, data: Union[dataset.Vertex, dataset.Volume, tuple]) -> Union[tuple[npt.NDArray, npt.NDArray], dataset.Vertex]:
         if isinstance(data, tuple):
             data = dataset.Volume(*data)
 
@@ -61,9 +80,9 @@ class Mapper:
         volume.shape = len(volume), -1
         volume = volume.T
 
-        mapped = []
+        mapped: list[npt.NDArray] = []
         for mask in self.masks:
-            mapped.append(np.array(mask * volume).T)
+            mapped.append(np.array(mask * volume).T) # change to @ matmul
 
         if self.idxmap is not None:
             mapped[0] = mapped[0][:, self.idxmap[0]]
@@ -71,7 +90,13 @@ class Mapper:
 
         return dataset.Vertex(np.hstack(mapped).squeeze(), data.subject)
 
-    def backwards(self, vertexdata):
+    @overload
+    def backwards(self, vertexdata: dataset.Vertex) -> dataset.Volume: ...
+
+    @overload
+    def backwards(self, vertexdata: npt.NDArray) -> npt.NDArray: ...
+
+    def backwards(self, vertexdata: Union[dataset.Vertex, npt.NDArray]) -> Union[dataset.Volume, npt.NDArray]:
         '''Projects vertex data back into volume space.
 
         Parameters
@@ -81,8 +106,7 @@ class Mapper:
             If Vertex object is provided, a Volume object is returned
             If an array is provided, an array is returned
         '''
-        Vert2Vol = isinstance(vertexdata, dataset.Vertex)
-        if Vert2Vol:
+        if isinstance(vertexdata, dataset.Vertex):
             to_map = vertexdata.data
         else:
             to_map = vertexdata
@@ -91,8 +115,8 @@ class Mapper:
         # dot the vertex data with the stacked mappers
         partial_vertex = bothmappers.T.dot(to_map)
         # solve the inverse mapping problem
-        voxeldata = self._get_backmapper().solve(partial_vertex).reshape(self.shape)
-        if Vert2Vol:
+        voxeldata: npt.NDArray = self._get_backmapper().solve(partial_vertex).reshape(self.shape)
+        if isinstance(vertexdata, dataset.Vertex):
             # construct a volume object with the new data
             return dataset.Volume(voxeldata, self.subject, self.xfmname)
         else:
@@ -112,10 +136,10 @@ class Mapper:
         return self._backmapper
 
     @classmethod
-    def _cache(cls, filename, subject, xfmname, **kwargs):
+    def _cache(cls, filename: str, subject: str, xfmname: str, **kwargs) -> Self:
         print('Caching mapper...')
         from ..database import db
-        masks = []
+        masks: list[sparse.csr_matrix] = []
         xfm = db.get_xfm(subject, xfmname, xfmtype='coord')
         fid = db.get_surf(subject, 'fiducial', merge=False, nudge=False)
 
@@ -130,7 +154,19 @@ class Mapper:
         _savecache(filename, masks[0], masks[1], xfm.shape)
         return cls(masks[0], masks[1], xfm.shape, subject, xfmname)
 
-def _savecache(filename, left, right, shape):
+    @classmethod
+    @abc.abstractmethod
+    def _getmask(cls, coords: npt.NDArray[np.floating], polys: npt.NDArray[np.integer], shape: tuple[int, int, int], **kwargs) -> sparse.csr_matrix:
+        '''Generates a sparse matrix mapping from volume to surface vertices'''
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def sampler(coords: npt.NDArray[np.floating], shape: tuple[int, int, int], **kwargs) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp], npt.NDArray[np.floating]]:
+        '''Generates a sparse matrix mapping from volume to surface vertices'''
+        pass
+
+def _savecache(filename: str, left: sparse.csr_matrix, right: sparse.csr_matrix, shape: MapperShape) -> None:
     np.savez(filename,
              left_data=left.data,
              left_indices=left.indices,

--- a/cortex/mapper/patch.py
+++ b/cortex/mapper/patch.py
@@ -6,6 +6,8 @@ from . import samplers
 from .. import polyutils
 
 class PatchMapper(Mapper):
+    patchsize: int
+
     @classmethod
     def _getmask(cls, pts, polys, shape, npts=64, mp=True, **kwargs):
         rand = np.random.rand(2, npts)

--- a/cortex/mapper/point.py
+++ b/cortex/mapper/point.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.typing as npt
 from scipy import sparse
 
 from . import Mapper
@@ -6,7 +7,7 @@ from . import samplers
 
 class PointMapper(Mapper):
     @classmethod
-    def _getmask(cls, coords, polys, shape, **kwargs):
+    def _getmask(cls, coords: npt.NDArray[np.floating], polys: npt.NDArray[np.integer], shape: tuple[int, int, int], **kwargs) -> sparse.csr_matrix:
         valid = np.unique(polys)
         mcoords = np.nan * np.ones_like(coords)
         mcoords[valid] = coords[valid]

--- a/cortex/mapper/samplers.py
+++ b/cortex/mapper/samplers.py
@@ -1,11 +1,15 @@
 import numpy as np
+import numpy.typing as npt
 
 def collapse(j, data):
     """Collapses samples into a single row"""
     uniques = np.unique(j)
     return uniques, np.array([data[j == u].sum() for u in uniques])
 
-def nearest(coords, shape, **kwargs):
+def nearest(coords: npt.NDArray[np.floating], shape: tuple[int, int, int], **kwargs) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp], npt.NDArray[np.float64]]:
+    if len(kwargs) > 0:
+        raise ValueError('nearest sampler does not take any kwargs')
+
     valid = ~(np.isnan(coords).all(1))
     valid = np.logical_and(valid, np.logical_and(coords[:,0] > -.5, coords[:,0] < shape[2]+.5))
     valid = np.logical_and(valid, np.logical_and(coords[:,1] > -.5, coords[:,1] < shape[1]+.5))
@@ -16,7 +20,10 @@ def nearest(coords, shape, **kwargs):
     #return np.nonzero(valid)[0], j, (rcoords > 0).all(1) #np.ones((valid.sum(),))
     return np.nonzero(valid)[0], j, np.ones((valid.sum(),))
     
-def trilinear(coords, shape, **kwargs):
+def trilinear(coords: npt.NDArray[np.floating], shape: tuple[int, int, int], **kwargs) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp], npt.NDArray[np.floating]]:
+    if len(kwargs) > 0:
+        raise ValueError('trilinear sampler does not take any kwargs')
+
     #trilinear interpolation equation from http://paulbourke.net/miscellaneous/interpolation/
     valid = ~(np.isnan(coords).all(1))
     (x, y, z), floor = np.modf(coords[valid].T)

--- a/cortex/quickflat/composite.py
+++ b/cortex/quickflat/composite.py
@@ -1,18 +1,26 @@
 import copy
+from typing import Optional, Union
+
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+from matplotlib.figure import Figure
+from matplotlib.image import AxesImage
 import numpy as np
+import numpy.typing as npt
+
+from .utils import _get_height, _get_extents, _convert_svg_kwargs, _get_images, _parse_defaults
+from .utils import make_flatmap_image, _make_hatch_image, _get_fig_and_ax, get_flatmask, get_flatcache
 from .. import dataset
 from ..database import db
 from ..options import config
-from .utils import _get_height, _get_extents, _convert_svg_kwargs, _get_images, _parse_defaults
-from .utils import make_flatmap_image, _make_hatch_image, _get_fig_and_ax, get_flatmask, get_flatcache
 
 
 """ --- Individual compositing functions --- """
 
 
-def add_curvature(fig, dataview, extents=None, height=None, threshold=True, contrast=None,
-                  brightness=None, smooth=None, cmap='gray', recache=False, curvature_lims=0.5,
-                  legacy_mode=False):
+def add_curvature(fig: Axes, dataview: dataset.Dataview, extents: Optional[tuple[float, float, float, float]]=None, height: Optional[int]=None, threshold: Optional[bool]=True, contrast: Optional[float]=None,
+                  brightness: Optional[float]=None, smooth: Optional[float]=None, cmap: str='gray', recache: bool=False, curvature_lims: float=0.5,
+                  legacy_mode: bool=False) -> AxesImage:
     """Add curvature layer to figure
 
     Parameters
@@ -21,11 +29,12 @@ def add_curvature(fig, dataview, extents=None, height=None, threshold=True, cont
         figure into which to plot image of curvature
     dataview : cortex.Dataview object
         dataview containing data to be plotted, subject (surface identifier), and transform.
-    extents : array-like
+    extents : array-like TODO: fix
         4 values for [Left, Right, Top, Bottom] extents of image plotted. None defaults to 
         extents of images already present in figure.
     height : scalar
         Height of image. None defaults to height of images already present in figure. 
+        TODO: what units?
     threshold : boolean
         Whether to apply a threshold to the curvature values to create a binary curvature image
         (one shade for positive curvature, one shade for negative). `None` defaults to value 
@@ -66,7 +75,7 @@ def add_curvature(fig, dataview, extents=None, height=None, threshold=True, cont
     if default_smoothing.lower()=='none':
         default_smoothing = None
     else:
-        default_smoothing = np.float_(default_smoothing)
+        default_smoothing = np.float64(default_smoothing)
     if smooth is None:
         # (Might still be None!)
         smooth = default_smoothing
@@ -120,15 +129,15 @@ def add_curvature(fig, dataview, extents=None, height=None, threshold=True, cont
                       zorder=0)
     return cvimg
 
-def add_data(fig, braindata, height=1024, thick=32, depth=0.5, pixelwise=True,
-             sampler='nearest', recache=False, nanmean=False):
+def add_data(fig: Figure, braindata: Union[dataset.Volume, dataset.Vertex, dataset.Dataview], height: int=1024, thick: int=32, depth: float=0.5, pixelwise: bool=True,
+             sampler: str='nearest', recache: bool=False, nanmean: bool=False) -> tuple[AxesImage, npt.NDArray]:
     """Add data to quickflat plot
 
     Parameters
     ----------
     fig : figure or ax
         Figure into which to plot image of curvature
-    braindata : one of: {cortex.Volume, cortex.Vertex, cortex.Dataview)
+    braindata : one of: {cortex.Volume, cortex.Vertex, cortex.Dataview}
         Object containing containing data to be plotted, subject (surface identifier),
         and transform.
     height : scalar
@@ -267,8 +276,8 @@ def add_sulci(fig, dataview, extents=None, height=None, with_labels=True, sulci_
     return img
 
 
-def add_hatch(fig, hatch_data, extents=None, height=None, hatch_space=4,
-              hatch_color=(0, 0, 0), sampler='nearest', recache=False):
+def add_hatch(fig: Axes, hatch_data: dataset.Dataview, extents: Optional[tuple[float, float, float, float]]=None, height: Optional[int]=None, hatch_space: int=4,
+              hatch_color: tuple[int, int, int]=(0, 0, 0), sampler: str='nearest', recache: bool=False) -> AxesImage:
     """Add hatching to figure at locations specified in hatch_data
 
     Parameters
@@ -323,8 +332,8 @@ def add_hatch(fig, hatch_data, extents=None, height=None, hatch_space=4,
     return img
 
 
-def add_colorbar(fig, cimg, colorbar_ticks=None, colorbar_location=(0.4, 0.07, 0.2, 0.04), 
-                 orientation='horizontal'):
+def add_colorbar(fig: Figure, cimg: AxesImage, colorbar_ticks: Optional[npt.ArrayLike]=None, colorbar_location: tuple[float, float, float, float]=(0.4, 0.07, 0.2, 0.04),
+                 orientation: str='horizontal') -> Axes:
     """Add a colorbar to a flatmap plot
 
     Parameters
@@ -348,8 +357,8 @@ def add_colorbar(fig, cimg, colorbar_ticks=None, colorbar_location=(0.4, 0.07, 0
     return cbar
 
 
-def add_colorbar_2d(fig, cmap_name, colorbar_ticks,
-                    colorbar_location=(0.425, 0.02, 0.15, 0.15), fontsize=12):
+def add_colorbar_2d(fig: Figure, cmap_name: str, colorbar_ticks: tuple[float, float, float, float],
+                    colorbar_location: tuple[float, float, float, float]=(0.425, 0.02, 0.15, 0.15), fontsize: int=12) -> AxesImage:
     """Add a 2D colorbar to a flatmap plot
 
     Parameters
@@ -358,13 +367,14 @@ def add_colorbar_2d(fig, cmap_name, colorbar_ticks,
     cimg : matplotlib.image.AxesImage object
         Image for which to create colorbar. For reference, matplotlib.image.AxesImage 
         is the output of imshow()
-    colorbar_ticks : array-like
-        values for colorbar ticks
+    colorbar_ticks : tuple[float, float, float, float]
+        Values for colorbar *extents*, in order [xmin, xmax, ymin, ymax]. The colorbar will be plotted with these values as the limits of the colorbar axes, and the ticks will be placed at the values specified in the first two and last two entries of this tuple.
     colorbar_location : array-like
         Four-long list, tuple, or array that specifies location for colorbar axes 
         [left, top, width, height] (?)
     orientation : string
         'vertical' or 'horizontal'
+        TODO: unused
     """
     # a bit sketchy - lazy imports
     import matplotlib.pyplot as plt
@@ -375,9 +385,9 @@ def add_colorbar_2d(fig, cmap_name, colorbar_ticks,
     fig.add_axes(colorbar_location)
     cbar = plt.imshow(cim, extent=colorbar_ticks, interpolation='bilinear')
     cbar.axes.set_xticks(colorbar_ticks[:2])
-    cbar.axes.set_xticklabels(colorbar_ticks[:2], fontdict=dict(size=fontsize))
+    cbar.axes.set_xticklabels([str(t) for t in colorbar_ticks[:2]], fontdict=dict(size=fontsize))
     cbar.axes.set_yticks(colorbar_ticks[2:])
-    cbar.axes.set_yticklabels(colorbar_ticks[2:], fontdict=dict(size=fontsize))
+    cbar.axes.set_yticklabels([str(t) for t in colorbar_ticks[2:]], fontdict=dict(size=fontsize))
 
     return cbar
 
@@ -445,10 +455,10 @@ def add_custom(fig, dataview, svgfile, layer, extents=None, height=None, with_la
                     zorder=6)
     return img
 
-def add_connected_vertices(fig, dataview, exclude_border_width=None,
-                           height=None, extents=None, recache=False,
-                           color=(1.0, 0.5, 0.1, 0.6), linewidth=0.75,
-                           alpha=1.0, **kwargs):
+def add_connected_vertices(fig: Axes, dataview: dataset.Volume, exclude_border_width: Optional[int]=None,
+                           height: Optional[int]=None, extents: Optional[tuple[float, float, float, float]]=None, recache: bool=False,
+                           color: tuple[float, float, float, float]=(1.0, 0.5, 0.1, 0.6), linewidth: float=0.75,
+                           alpha: float=1.0, **kwargs) -> LineCollection:
     """Plot lines btw distant vertices that are within the same voxel
 
     Parameters
@@ -462,10 +472,10 @@ def add_connected_vertices(fig, dataview, exclude_border_width=None,
     exclude_border_width : scalar or None
         if not None, width from edge of flatmap for which crossover lines are
         not computed.
-    height : scalar
+    height : scalar or None
         Height of image. if None, defaults to height of images already present
         in figure.
-    extents : array-like
+    extents : array-like or None
         4 values for [Left, Right, Bottom, Top] extents of image plotted. If
         None, defaults to extents of images already present in figure.
     color : rgba tuple
@@ -532,7 +542,7 @@ def add_connected_vertices(fig, dataview, exclude_border_width=None,
     # (This is the most time consuming step, as it draws many lines)
     # print('plotting lines...')
     fig, ax = _get_fig_and_ax(fig)
-    lc = LineCollection(pix_array_scaled,
+    lc = LineCollection(list(pix_array_scaled),
                         transform=fig.transFigure,
                         figure=fig,
                         colors=color,

--- a/cortex/quickflat/utils.py
+++ b/cortex/quickflat/utils.py
@@ -4,22 +4,25 @@ import os
 import string
 import warnings
 from functools import reduce
+from typing import Literal, Optional, Union, cast
 
 import numpy as np
+import numpy.typing as npt
+from scipy import sparse # TODO: remove if loading is slow
 
 from .. import dataset, utils
 from ..database import db
 from ..options import config
 
 
-def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **kwargs):
+def make_flatmap_image(braindata: Union[dataset.Volume, dataset.Vertex, dataset.Dataview], height: int=1024, recache: bool=False, nanmean: bool=False, **kwargs) -> tuple[npt.NDArray[np.uint8], npt.NDArray[np.floating]]:
     """Generate flatmap image from volumetric brain data
 
     This 
 
     Parameters
     ----------
-    braindata : one of: {cortex.Volume, cortex.Vertex, cortex.Dataview)
+    braindata : one of: {cortex.Volume, cortex.Vertex, cortex.Dataview}
         Object containing containing data to be plotted, subject (surface identifier), 
         and transform.
     height : scalar 
@@ -34,9 +37,10 @@ def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **k
 
     Returns
     -------
-    image : 
-
-    extents :
+    image : numpy.ndarray[np.uint8]
+        The generated flatmap image.
+    extents : numpy.ndarray[np.floating]
+        The extents of the generated flatmap image.
 
     """
     mask, extents = get_flatmask(braindata.subject, height=height, recache=recache)
@@ -100,7 +104,7 @@ def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **k
             averaged_data = pixmap.dot(np.nan_to_num(data.ravel()))
             ignored = np.isnan(data.ravel())
             if isinstance(data, np.ma.MaskedArray):
-                ignored = ignored.filled()  # masked voxels are also ignored
+                ignored = cast(np.ma.MaskedArray, ignored).filled()  # masked voxels are also ignored
 
         if ignored is not None:
             weights_not_ignored = pixmap.dot((~ignored).astype(data.dtype))
@@ -117,7 +121,7 @@ def make_flatmap_image(braindata, height=1024, recache=False, nanmean=False, **k
 
         return img, extents
 
-def get_flatmask(subject, height=1024, recache=False):
+def get_flatmask(subject: str, height: int=1024, recache: bool=False) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.floating]]:
     """
     Parameters
     ----------
@@ -141,8 +145,8 @@ def get_flatmask(subject, height=1024, recache=False):
 
     return mask, extents
 
-def get_flatcache(subject, xfmname, pixelwise=True, thick=32, sampler='nearest',
-                  recache=False, height=1024, depth=0.5):
+def get_flatcache(subject: str, xfmname: Optional[str], pixelwise: bool=True, thick: int=32, sampler: str='nearest',
+                  recache: bool=False, height: int=1024, depth: float=0.5):
     """
     
     Parameters
@@ -189,7 +193,7 @@ def get_flatcache(subject, xfmname, pixelwise=True, thick=32, sampler='nearest',
     if not pixelwise and xfmname is not None:
         from scipy import sparse
         mapper = utils.get_mapper(subject, xfmname, sampler)
-        pixmap = pixmap * sparse.vstack(mapper.masks)
+        pixmap = cast(sparse.csr_matrix, pixmap * sparse.vstack(mapper.masks))
 
     return pixmap
 
@@ -254,23 +258,26 @@ def _convert_svg_kwargs(kwargs):
                for k,v in kwargs.items() if v is not None}
     return out
 
-def _parse_defaults(section):
-    defaults = dict(config.items(section))
-    for k in defaults.keys():
+def _parse_defaults(section: str) -> dict[str, Union[float, list[float], None, str]]:
+    raw = dict(config.items(section))
+    defaults: dict[str, Union[float, list[float], None, str]] = dict(raw)
+    for k, v in raw.items():
         # Convert numbers to floating point numbers
-        if defaults[k][0] in string.digits + '.':
-            if ',' in defaults[k]:
-                defaults[k] = [float(x) for x in defaults[k].split(',')]
+        if v[0] in string.digits + '.':
+            if ',' in v:
+                defaults[k] = [float(x) for x in v.split(',')]
             else:
-                defaults[k] = float(defaults[k])
+                defaults[k] = float(v)
         # Convert 'None' to None
-        if defaults[k] == 'None':
+        if v == 'None':
             defaults[k] = None
         # Special case formatting
         if k=='stroke' or k=='fill':
-            defaults[k] = _color2hex(defaults[k])
-        elif k=='stroke-dasharray' and isinstance(defaults[k], (list,tuple)):
-            defaults[k] = '{}, {}'.format(*defaults[k])
+            defaults[k] = _color2hex(v)
+        elif k=='stroke-dasharray':
+            dasharray = defaults[k]
+            if isinstance(dasharray, (list, tuple)):
+                defaults[k] = '{}, {}'.format(*dasharray)
     return defaults
 
 def _get_fig_and_ax(fig):
@@ -353,7 +360,7 @@ def _make_hatch_image(hatch_data, height, sampler='nearest', hatch_space=4, reca
 
     return hatchim
 
-def _make_flatmask(subject, height=1024):
+def _make_flatmask(subject: str, height: int=1024) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.floating]]:
     from PIL import Image, ImageDraw
 
     from .. import polyutils
@@ -368,11 +375,11 @@ def _make_flatmask(subject, height=1024):
     draw = ImageDraw.Draw(im)
     draw.polygon(lpts[:,:2].ravel().tolist(), fill=255)
     draw.polygon(rpts[:,:2].ravel().tolist(), fill=255)
-    extents = np.hstack([pts.min(0), pts.max(0)])[[0,3,1,4]]
+    extents: npt.NDArray[np.floating] = np.hstack([pts.min(0), pts.max(0)])[[0,3,1,4]]
 
     return np.array(im).T > 0, extents
 
-def _make_vertex_cache(subject, height=1024):
+def _make_vertex_cache(subject: str, height: int=1024) -> sparse.csr_matrix:
     from scipy import sparse
     from scipy.spatial import cKDTree
     flat, polys = db.get_surf(subject, "flat", merge=True, nudge=True)
@@ -388,10 +395,11 @@ def _make_vertex_cache(subject, height=1024):
 
     kdt = cKDTree(flat[valid,:2])
     dist, vert = kdt.query(grid.T[mask.ravel()])
+    vert = np.asarray(vert)
     dataij = (np.ones((len(vert),)), np.array([np.arange(len(vert)), valid[vert]]))
     return sparse.csr_matrix(dataij, shape=(mask.sum(), len(flat)))
 
-def _make_pixel_cache(subject, xfmname, height=1024, thick=32, depth=0.5, sampler='nearest'):
+def _make_pixel_cache(subject: str, xfmname: str, height: int=1024, thick: int=32, depth: float=0.5, sampler: str='nearest') -> sparse.csr_matrix:
     from scipy import sparse
     from scipy.spatial import Delaunay
     flat, polys = db.get_surf(subject, "flat", merge=True, nudge=True)
@@ -441,7 +449,7 @@ def _make_pixel_cache(subject, xfmname, height=1024, thick=32, depth=0.5, sample
 
         valid = np.logical_and(valid_p, valid_w)
         vidx = np.nonzero(valid)[0]
-        mapper = sparse.csr_matrix((mask.sum(), np.prod(xfm.shape)))
+        mapper: sparse.csr_matrix = sparse.csr_matrix((mask.sum(), np.prod(xfm.shape)))
         if thick == 1:
             i, j, data = sampclass(piacoords[valid]*depth + wmcoords[valid]*(1-depth), xfm.shape)
             mapper = mapper + sparse.csr_matrix((data / float(thick), (vidx[i], j)),

--- a/cortex/quickflat/view.py
+++ b/cortex/quickflat/view.py
@@ -4,7 +4,7 @@ import tempfile
 import binascii
 import numpy as np
 import numpy.typing as npt
-from typing import Optional, Union, IO
+from typing import Optional, Union, IO, Sequence
 
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -41,7 +41,7 @@ def make_figure(braindata: dataset.Dataview, recache: bool=False, pixelwise: boo
                 linewidth: Optional[int]=None, linecolor: Optional[ColorType]=None, roifill: Optional[ColorType]=None, shadow: Optional[int]=None,
                 labelsize: Optional[str]=None, labelcolor: Optional[ColorType]=None, cutout: Optional[str]=None, curvature_brightness: Optional[float]=None,
                 curvature_contrast: Optional[float]=None, curvature_threshold: Optional[bool]=None, fig: Optional[Union[Figure, Axes]]=None, extra_hatch: Optional[tuple[dataset.Dataview, tuple[float, float, float]]]=None,
-                colorbar_ticks: Optional[npt.ArrayLike]=None, colorbar_location: Union[tuple[float, float, float, float], str]='center', roi_list: Optional[list[str]]=None, sulci_list: Optional[list[str]]=None,
+                colorbar_ticks: Optional[npt.ArrayLike]=None, colorbar_location: Union[tuple[float, float, float, float], str]='center', roi_list: Optional[Sequence[str]]=None, sulci_list: Optional[Sequence[str]]=None,
                 nanmean: bool=False) -> Figure:
     """Show a Volume or Vertex on a flatmap with matplotlib.
 
@@ -305,8 +305,8 @@ def make_png(fname: Union[str, os.PathLike, IO], braindata: dataset.Dataview, re
     fig.clf()
     plt.close(fig)
 
-def make_svg(fname, braindata, with_labels=False, with_curvature=True, layers=['rois'],
-             height=1024, overlay_file=None, with_dropout=False, **kwargs):
+def make_svg(fname, braindata: dataset.Dataview, with_labels: bool=False, with_curvature: bool=True, layers: Sequence[str]=['rois'],
+             height: int=1024, overlay_file: Optional[str]=None, with_dropout: bool=False, **kwargs):
     """Save an svg file of the desired flatmap.
 
     This function creates an SVG file with vector graphic ROIs overlaid on a single png image.

--- a/cortex/tests/test_quickflat.py
+++ b/cortex/tests/test_quickflat.py
@@ -2,12 +2,24 @@ import cortex
 import numpy as np
 import tempfile
 import pytest
+from matplotlib.figure import Figure
+from matplotlib.axes import Axes
 
 from cortex import dataset
+import cortex.quickflat.utils # for ty
 from cortex.testing_utils import has_installed
 from cortex.webgl.data import Package
 
 no_inkscape = not has_installed('inkscape')
+
+def random_volume(with_nan=False, **kwargs):
+    orig_vol = cortex.Volume.random("S1", "fullhead", **kwargs)
+    data = orig_vol.data.copy()
+    if with_nan:
+        # set 50% of the values in the dataset to NaN
+        data[np.random.rand(*data.shape) > 0.5] = np.nan
+    # TODO: make sure kwargs are passed through correctly (e.g. vmin/vmax, etc.)
+    return orig_vol.copy(data=data)
 
 
 @pytest.mark.skipif(no_inkscape, reason='Inkscape required')
@@ -118,4 +130,263 @@ def test_make_flatmap_image_vertexrgb_alpha_unchanged():
     assert bright_red_pixels.size > 0, (
         "VertexRGB.vertices appears to be premultiplied -- the matplotlib "
         "path will double-attenuate. The fix should live in webgl/data.py."
+    )
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_quickflat_curvature():
+    vol = random_volume(with_nan=True, cmap="hot", vmin=0, vmax=1)
+    cortex.quickflat.make_figure(vol, with_curvature=True)
+
+
+# Tests for remaining make_figure arguments
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_recache():
+    """Test recache parameter"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    fig = cortex.quickflat.make_figure(view, recache=False)
+    
+    # recache=True takes longer but should still work
+    fig = cortex.quickflat.make_figure(view, recache=True)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_pixelwise_and_thick():
+    """Test pixelwise and thick parameters"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    # Test pixelwise=True with different thick values
+    for thick in [1, 4, 8, 16, 32]:
+        fig = cortex.quickflat.make_figure(view, pixelwise=True, thick=thick)
+    
+    # Test pixelwise=False
+    fig = cortex.quickflat.make_figure(view, pixelwise=False)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_sampler():
+    """Test sampler parameter with different sampling methods"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    for sampler in ['nearest', 'trilinear']:
+        fig = cortex.quickflat.make_figure(view, sampler=sampler)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_height_and_dpi():
+    """Test height and dpi parameters"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    # Test smaller height for faster rendering
+    height, dpi = 512, 100
+    fig = cortex.quickflat.make_figure(view, height=height, dpi=dpi)
+    # Check the resulting figure size in inches (height in pixels / dpi)
+    expected_height_inch = height / dpi
+    assert np.isclose(fig.get_figheight(), expected_height_inch, atol=0.1)
+    
+    # Test larger height
+    height, dpi = 1024, 150
+    fig = cortex.quickflat.make_figure(view, height=height, dpi=dpi)
+    expected_height_inch = height / dpi
+    assert np.isclose(fig.get_figheight(), expected_height_inch, atol=0.1)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_depth():
+    """Test depth parameter for sampling different cortical depths"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    # Test different depth values (0 = gray/white matter, 1 = pial surface)
+    for depth in [0.0, 0.5, 1.0]:
+        fig = cortex.quickflat.make_figure(view, depth=depth)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_display_flags():
+    """Test boolean display flags: with_rois, with_sulci, with_labels, with_colorbar"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    # Test with_rois
+    fig = cortex.quickflat.make_figure(view, with_rois=True)
+    fig = cortex.quickflat.make_figure(view, with_rois=False)
+    
+    # Test with_sulci
+    fig = cortex.quickflat.make_figure(view, with_sulci=False)
+    fig = cortex.quickflat.make_figure(view, with_sulci=True)
+    
+    # Test with_labels
+    fig = cortex.quickflat.make_figure(view, with_labels=False)
+    fig = cortex.quickflat.make_figure(view, with_labels=True)
+    
+    # Test with_colorbar
+    fig = cortex.quickflat.make_figure(view, with_colorbar=False)
+    fig = cortex.quickflat.make_figure(view, with_colorbar=True)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_with_dropout():
+    """Test with_dropout parameter with bool and float values"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    # Test with_dropout with boolean values
+    fig = cortex.quickflat.make_figure(view, with_dropout=False)
+    fig = cortex.quickflat.make_figure(view, with_dropout=True)
+    
+    # Test with_dropout with float value
+    fig = cortex.quickflat.make_figure(view, with_dropout=10.0)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_with_connected_vertices():
+    """Test with_connected_vertices parameter"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    fig = cortex.quickflat.make_figure(view, with_connected_vertices=False)
+    
+    # Note: with_connected_vertices=True is more computationally expensive
+    fig = cortex.quickflat.make_figure(view, with_connected_vertices=True)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_roi_styling_parameters():
+    """Test ROI styling parameters: linewidth, linecolor, roifill, shadow, labelsize, labelcolor"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    # TODO: need with_rois, etc.?
+    
+    # Test linewidth
+    fig = cortex.quickflat.make_figure(view, linewidth=2)
+    
+    # Test linecolor (RGB/RGBA tuple)
+    fig = cortex.quickflat.make_figure(view, linecolor=(1.0, 0.0, 0.0))
+    
+    # Test roifill (RGB/RGBA tuple)
+    fig = cortex.quickflat.make_figure(view, roifill=(1.0, 0.0, 0.0, 0.5))
+    
+    # Test shadow
+    #fig = cortex.quickflat.make_figure(view, shadow=1) # TODO: why does this fail?
+    
+    # Test labelsize
+    fig = cortex.quickflat.make_figure(view, labelsize="10pt")
+    
+    # Test labelcolor
+    fig = cortex.quickflat.make_figure(view, labelcolor=(0.0, 0.0, 0.0))
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_curvature_parameters():
+    """Test curvature styling parameters: curvature_brightness, curvature_contrast, curvature_threshold"""
+    vol = random_volume(with_nan=True, cmap="hot", vmin=0, vmax=1) 
+
+    
+    # Test brightness and contrast together
+    fig = cortex.quickflat.make_figure(vol, with_curvature=True,
+                                       curvature_brightness=0.7, 
+                                       curvature_contrast=0.5)
+    
+    # Test threshold
+    fig = cortex.quickflat.make_figure(vol, with_curvature=True, 
+                                       curvature_threshold=True)
+    
+    fig = cortex.quickflat.make_figure(vol, with_curvature=True,
+                                       curvature_threshold=False)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_colorbar_ticks():
+    """Test colorbar_ticks parameter"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot", vmin=0, vmax=1)
+    
+    # Custom ticks
+    ticks = np.array([0.0, 0.5, 1.0])
+    fig = cortex.quickflat.make_figure(view, with_colorbar=True, 
+                                       colorbar_ticks=ticks)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_fig_parameter():
+    """Test fig parameter with Figure and Axes objects"""
+    from matplotlib import pyplot as plt
+    
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    # Test passing a Figure object
+    fig_obj = plt.figure()
+    result = cortex.quickflat.make_figure(view, fig=fig_obj)
+    assert isinstance(result, Figure)
+    plt.close(fig_obj)
+    
+    # Test passing an Axes object
+    fig_obj = plt.figure()
+    ax_obj = fig_obj.add_subplot(111)
+    result = cortex.quickflat.make_figure(view, fig=ax_obj)
+    assert isinstance(result, Figure)
+    plt.close(fig_obj)
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_extra_hatch():
+    """Test extra_hatch parameter with additional hatching layer"""
+    mask = cortex.db.get_mask("S1", "fullhead", type="thick")
+    data = np.ones(mask.sum())
+    vol = cortex.Volume(data, "S1", "fullhead", vmin=0, vmax=1)
+    
+    # Create a hatch layer with same shape
+    hatch_data = cortex.Volume(np.random.rand(mask.sum()), "S1", "fullhead", vmin=0, vmax=1)
+    hatch_color = (1.0, 0.0, 0.0)  # Red
+    
+    fig = cortex.quickflat.make_figure(vol, extra_hatch=(hatch_data, hatch_color))
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_roi_list_and_sulci_list():
+    """Test roi_list and sulci_list parameters to filter displayed regions"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot")
+    
+    # Test roi_list - get available ROIs first
+    # Note: This depends on the database having ROIs available
+    try:
+        fig = cortex.quickflat.make_figure(view, with_rois=True, roi_list=['V1'])
+    except (ValueError, KeyError):
+        # Database might not have specific ROI names for this subject
+        pass
+    
+    # Test sulci_list
+    try:
+        fig = cortex.quickflat.make_figure(view, with_sulci=True, sulci_list=None)
+    except (ValueError, KeyError):
+        # Database might not have specific sulci names
+        pass
+
+
+@pytest.mark.skipif(no_inkscape, reason='Inkscape required')
+def test_combined_parameters():
+    """Test make_figure with multiple parameters combined"""
+    view = cortex.Volume.random("S1", "fullhead", cmap="hot", vmin=0, vmax=1)
+    
+    # Comprehensive combination test
+    fig = cortex.quickflat.make_figure(
+        view,
+        recache=False,
+        pixelwise=True,
+        thick=16,
+        sampler='nearest',
+        height=512,
+        dpi=100,
+        depth=0.5,
+        with_rois=True,
+        with_sulci=False,
+        with_labels=True,
+        with_colorbar=True,
+        with_dropout=False,
+        with_curvature=True,
+        with_connected_vertices=False,
+        linewidth=1,
+        linecolor=(0.0, 0.0, 0.0),
+        labelsize="12pt",
+        curvature_brightness=0.6,
+        curvature_contrast=0.4,
+        curvature_threshold=True,
+        colorbar_location='center',
+        nanmean=False
     )

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -337,7 +337,7 @@ def get_cortical_mask(subject, xfmname, type='nearest'):
         dist, idx = get_vox_dist(subject, xfmname)
         return dist < dict(thick=8, thin=2)[type]
     else:
-        return get_mapper(subject, xfmname, type=type).mask
+        return get_mapper(subject, xfmname, maptype=type).mask
 
 
 def get_vox_dist(subject, xfmname, surface="fiducial", max_dist=np.inf):
@@ -395,7 +395,7 @@ def get_hemi_masks(subject, xfmname, type='nearest'):
     -------
 
     '''
-    return get_mapper(subject, xfmname, type=type).hemimasks
+    return get_mapper(subject, xfmname, maptype=type).hemimasks
 
 def add_roi(data, name="new_roi", open_inkscape=True, add_path=True,
             overlay_file=None, **kwargs):
@@ -590,7 +590,7 @@ def get_roi_mask(subject, xfmname, roi=None, projection='nearest'):
     """
     warnings.warn('Deprecated! Use get_roi_masks')
 
-    mapper = get_mapper(subject, xfmname, type=projection)
+    mapper = get_mapper(subject, xfmname, maptype=projection)
     rois = get_roi_verts(subject, roi=roi, mask=True)
     output = dict()
     for name, verts in list(rois.items()):
@@ -790,7 +790,7 @@ def get_roi_masks(subject, xfmname, roi_list=None, gm_sampler='cortical', split_
     if (use_cortex_mask or split_lr) or (not return_dict):
         vox_dst, vox_idx = get_vox_dist(subject, xfmname)
     if use_mapper:
-        mapper = get_mapper(subject, xfmname, type=mapper_dict[gm_sampler])
+        mapper = get_mapper(subject, xfmname, maptype=mapper_dict[gm_sampler])
     elif use_cortex_mask:
         if isinstance(gm_sampler, str):
             cortex_mask = db.get_mask(subject, xfmname, type=gm_sampler)


### PR DESCRIPTION
**NOTE**: this is WIP. It has broken mapper changes.

---

This PR adds type support for the non-SVG functions in `cortex.quickflat` and standardizes the Mapper API.

It also improves test coverage for the many arguments of `quickflat.make_figure`. 


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>