### PR TITLE
DOC fix build warnings

### DIFF
--- a/docs/api_reference_flat.rst
+++ b/docs/api_reference_flat.rst
@@ -26,19 +26,19 @@ quickflat
 .. autosummary::
     :toctree:generated/
 
-    add_curvature
-    add_data
-    add_rois
-    add_sulci
-    add_hatch
-    add_colorbar
-    add_custom
-    add_cutout
     make_figure
     make_png
     make_svg
-    get_flatmask
-    get_flatcache
+    composite.add_curvature
+    composite.add_data
+    composite.add_rois
+    composite.add_sulci
+    composite.add_hatch
+    composite.add_colorbar
+    composite.add_custom
+    composite.add_cutout
+    utils.get_flatmask
+    utils.get_flatcache
 
 
 webgl

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -204,7 +204,7 @@ Where, ``'subject'`` is the subject identifier and ``'name'`` is a unique name f
 ``overlays.svg``
 ----------------
 
-Overlays are stored as SVG_'s. This is where surface ROIs are defined. Since these surface ROIs are invariant to transform, only one ROI map is needed for each subject. These SVGs are automatically created for a subject if you call ``cortex.add_roi``. ROI overlays are created and edited in Inkscape_. For more information, see :module:`svgroi.py`.
+Overlays are stored as SVG_'s. This is where surface ROIs are defined. Since these surface ROIs are invariant to transform, only one ROI map is needed for each subject. These SVGs are automatically created for a subject if you call ``cortex.add_roi``. ROI overlays are created and edited in Inkscape_. For more information, see ``svgroi.py``.
 
 
 ``rois.svg``

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -118,7 +118,7 @@ Reference volumes are typically in Nifti_ format (*.nii), but can be any format 
 
 
 Accessing transforms
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 Similar to the surfaces, transforms can be access through two methods: direct command access, and the tab interface.
 
 Command access looks like this::
@@ -150,7 +150,7 @@ Tab complete looks like this::
 
 
 Adding new transforms
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~
 Transforms from anatomical space to functional space are notoriously tricky. Automated algorithms generally give results optimized for various global energy metrics, but do not attempt to target the alignments for your ROIs. It is highly recommended that you use the included aligner to make your affine transforms. To add a transform, either directly create a transform json in ``{$FILESTORE}/transforms/``, or use this command::
 
     import cortex
@@ -159,7 +159,8 @@ Transforms from anatomical space to functional space are notoriously tricky. Aut
 .. _database-masks:
 
 Masks
-^^^^^
+~~~~~
+
 One of the fundamental reasons for carefully aligning surfaces is to allow the creation and use of cortical masks. This limits the number of voxels you need to model. Traditionally, these masks are created by selecting the set of nearest neighbor voxels for each vertex on the transformed surface. Unfortunately, pycortex's advanced per-pixel mapping precludes the use of this simple mask, since faces could potentially intersect with voxel corners which are not in this simple mask. Thus, the default masks in pycortex use a distance metric to compute mask membership.
 
 Masks were added into pycortex in May 2013, due to previous issues with masked data and the addition of the per-pixel mapping. Masked datasets are further discussed in the datasets page.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ User Guide
    segmentation_guide
    database
    align
-   dataset
+   .. dataset
    rois
    userguide/webgl
    roidraw

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ User Guide
    segmentation_guide
    database
    align
-   .. dataset
+   dataset
    rois
    roidraw
    transforms

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ User Guide
    align
    dataset
    rois
+   userguide/webgl
    roidraw
    transforms
    colormaps

--- a/docs/transforms.rst
+++ b/docs/transforms.rst
@@ -2,13 +2,13 @@ Transform formats
 =================
 Functional data, usually collected by an epi sequence, typically does not have the same scan parameters as the anatomical MPRAGE scan used to generate the surfaces. Additionally, fMRI sequences which are usually optimized for T2* have drastically different and larger distortions than a typical T1 anatomical sequence. While automatic algorithms exist to align these two scan types, they will sometimes fail spectacularly, especially if a partial volume slice prescription is necessary.
 
-pycortex includes a tool based on mayavi_ to do manual **affine** alignments. Please see the :module:`align` module for more information. Alternatively, if an automatic algorithm works well enough, you can also commit your own transform to the database. Transforms in pycortex always go from **fiducial to functional** space. They have four variables associated:
+pycortex includes a tool based on mayavi_ to do manual **affine** alignments. Please see the :mod:`cortex.align` module for more information. Alternatively, if an automatic algorithm works well enough, you can also commit your own transform to the database. Transforms in pycortex always go from **fiducial to functional** space. They have four variables associated:
 
     * **Subject** : name of the subject, must match the surfaces used to create the transform
     * **Name** : A unique identifier for this transform
     * **type** : The type of transform -- from fiducial to functional **magnet** space, or fiducial to **coord** innate space
     * **epifile** : the filename of the functional data that the fiducial is aligned to
 
-Transforms always store the epifile in order to allow visual validation of alignment using the :module:`align` module.
+Transforms always store the epifile in order to allow visual validation of alignment using the :mod:`cortex.align` module.
 
 .. _mayavi: http://docs.enthought.com/mayavi/mayavi/

--- a/examples/datasets/plot_data_with_alpha.py
+++ b/examples/datasets/plot_data_with_alpha.py
@@ -1,7 +1,7 @@
 """
-==========================
+===========================
 Plot Data with Alpha Values
-==========================
+===========================
 
 It is often useful to plot a primary map (the "data" you are interested in)
 masked or attenuated by a secondary map (a "confidence" or "weight"

--- a/examples/fsaverage/upsample_to_fsaverage.py
+++ b/examples/fsaverage/upsample_to_fsaverage.py
@@ -1,7 +1,7 @@
 """
-===================
+=========================================================================================
 Upsample data from a lower resolution fsaverage template to fsaverage for visualization
-===================
+=========================================================================================
 
 This example shows how data in a lower resolution fsaverage template 
 (e.g., fsaverage5 or fsaverage6) can be upsampled to the high resolution fsaverage 

--- a/examples/import_surface/import_fmriprep.py
+++ b/examples/import_surface/import_fmriprep.py
@@ -1,7 +1,7 @@
 """
-==================
+======================
 Import fmriprep output
-==================
+======================
 
 Recently, many people have start to use fmriprep as a complete preprocessing workflow of anatomical and functional data. Pycortex has a convenience function to import
 the output of this workflow.

--- a/examples/quickflat/plot_thickness_nanmean.py
+++ b/examples/quickflat/plot_thickness_nanmean.py
@@ -1,7 +1,7 @@
 """
-===================================
+=======================================================
 Ignore NaN (not-a-number) values in thickness mapping
-===================================
+=======================================================
 
 By default, pycortex quickshow averages across the thickness of the cortex
 for each pixel in the resulting flatmap. If any of these layers contain a value

--- a/examples/utils/plot_get_roi_vertices.py
+++ b/examples/utils/plot_get_roi_vertices.py
@@ -4,7 +4,7 @@ Get Vertices for an ROI
 =======================
 
 In this example we show how to get the vertices that are inside an ROI that was
-defined in the SVG ROI file (see :doc:`/rois.rst`).
+defined in the SVG ROI file (see :doc:`/rois`).
 
 """
 import cortex


### PR DESCRIPTION
**Summary**
- Update `quickflat` autosummary entries for moved functions (`composite.*`/`utils.*`)
- Fix broken `:doc:` role in the ROI vertices example
- Fix heading levels in `database.rst`
- Add [webviewer user guide](https://github.com/gallantlab/pycortex/blob/main/docs/userguide/webgl.rst) to the toctree (was orphaned)
- Fix invalid `:module:` roles, add missing `docs/_static/` dir
- Fix short title overlines in 4 example docstrings

**Test plan**
- [x] `make html` builds clean; total warning count on this branch dropped from 265 (confirmed via containerized `act` run of `build_docs.yml`) to 230, remaining warnings are pre-existing and unrelated to this PR
- [x] `composite.*`/`utils.*` autosummary entries generate and link correctly
- [x] "Masks" heading renders under "Database" at the correct level
- [x] `userguide/webgl.rst` no longer flagged as excluded from any toctree
- [x] No `:module:` role errors remain; `:mod:`cortex.align`` resolves to a real link
- [x] No "Title overline too short" warnings remain
