### PR TITLE
webgl: bind an OS-assigned ephemeral port for the viewer server

### DIFF
--- a/cortex/webgl/serve.py
+++ b/cortex/webgl/serve.py
@@ -28,6 +28,7 @@ import tornado.web
 import tornado.ioloop
 import tornado.httpserver
 from tornado import websocket
+from tornado.netutil import bind_sockets
 from tornado.web import HTTPError
 
 cwd = os.path.split(os.path.abspath(__file__))[0]
@@ -310,9 +311,32 @@ class WebApp(threading.Thread):
             (r"/wsconnect/", ClientSocket, dict(parent=self)),
             (r"/(.*)", tornado.web.StaticFileHandler, dict(path=cwd)),
         ]
-        self.port = port
+        # Bind the listening socket(s) here, synchronously, in the calling
+        # thread -- rather than picking a random port and calling
+        # ``server.listen(port)`` later on the server thread. This fixes two
+        # long-standing sources of intermittent headless/CI hangs:
+        #   * ``port=0`` asks the OS for a guaranteed-free ephemeral port, so
+        #     we never collide with a lingering server (the old code used
+        #     ``random.randint`` and hoped for the best).
+        #   * a bind failure now raises *here*, visibly, in the caller. The old
+        #     ``listen()`` ran on the server thread, so an
+        #     "Address already in use" died silently and left callers to hang
+        #     for the full timeout waiting to connect to a server that had
+        #     never actually come up.
+        # The socket is bound immediately, so the OS accepts and queues client
+        # connections in the backlog even before the IOLoop starts serving --
+        # eliminating the connect race too.
+        self._sockets = bind_sockets(port if port is not None else 0)
+        # When port==0 the OS assigns the port; read the real value back so
+        # callers can build a correct URL.
+        self.port = self._sockets[0].getsockname()[1]
         self.response: Queue[Union[str, bytes]] = Queue()
         self.connect = threading.Event()
+        # Set by run() once self.server and self.ioloop exist and the server is
+        # about to serve. stop() waits on this so an early stop() (called before
+        # the server thread has finished starting up) neither hits missing
+        # attributes nor gets silently lost.
+        self._ready = threading.Event()
         self.sockets: list[websocket.WebSocketHandler] = []
 
     @property
@@ -333,13 +357,34 @@ class WebApp(threading.Thread):
             self.server = tornado.httpserver.HTTPServer(application, io_loop=ioloop)
         else:
             self.server = tornado.httpserver.HTTPServer(application)
-        self.server.listen(self.port)
+        # The socket(s) were already bound in __init__; just start serving on
+        # them. This cannot raise "Address already in use" on the server thread.
+        self.server.add_sockets(self._sockets)
+        # self.server and self.ioloop are now set; signal that stop() is safe.
+        self._ready.set()
         ioloop.start()
 
     def stop(self):
         print("Stopping server")
-        self.server.stop()
-        self.ioloop.stop()
+        # stop() may race a just-started server: run() sets self.ioloop and
+        # self.server on the server thread, so a stop() that arrives first would
+        # hit missing attributes -- or, worse, do nothing and let run() go on to
+        # serve forever. Wait for the server to finish coming up before stopping
+        # it.
+        if self.is_alive() and self._ready.wait(timeout=5):
+            self.server.stop()  # also closes the sockets it now owns
+            self.ioloop.stop()
+        else:
+            # The server thread never brought the server up (start() was never
+            # called, or it died during startup), so nothing owns the sockets
+            # bound in __init__. Close them here so we do not leak the
+            # listening port. is_alive() short-circuits the wait when start()
+            # was never called.
+            for sock in self._sockets:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
 
     def send(self, **kwargs: Any) -> Union[list[JSON], list[None]]:
         msg = json.dumps(kwargs, cls=NPEncode, ensure_ascii=False)

--- a/cortex/webgl/view.py
+++ b/cortex/webgl/view.py
@@ -5,7 +5,6 @@ import glob
 import json
 import mimetypes
 import os
-import random
 import shutil
 import sys
 import threading
@@ -323,8 +322,8 @@ def show(
         If True, uses the webbrowser library to open the viewer in the default
         local browser. Default True
     port : int or None, optional
-        The port that will be used by the server. If None, a random port will be
-        selected from the range 1024-65536. Default None
+        The port that will be used by the server. If None, a free ephemeral
+        port is assigned by the operating system. Default None
     pickerfun : function or None, optional
         Should be a function that takes three arguments, a 3-D voxel vector, a
         vertex index, and the hemisphere ("left" or "right"). Is called whenever
@@ -930,7 +929,10 @@ def show(
             return JSMixer(self.srvsend, "window.viewer")
 
     if port is None:
-        port = random.randint(1024, 65536)
+        # Let the OS assign a guaranteed-free ephemeral port (WebApp binds
+        # port 0 and reads the real port back). This avoids the random-port
+        # collisions that made headless/CI runs intermittently hang.
+        port = 0
 
     server = WebApp([(r'/ctm/(.*)', CTMHandler),
                      (r'/data/(.*)', DataHandler),


### PR DESCRIPTION
## Summary

Split out of #659 — this is the **port half**. The other half (the interpreter-exit deadlock in `headless_viewer`) is in a separate PR; the two are independent and can land in either order.

`WebApp` chose its port with `random.randint(1024, 65536)` and bound it **asynchronously** on the server thread via `server.listen(port)`. When the random port was already taken, `listen()` raised `OSError: [Errno 98] Address already in use` on that thread and died silently, while `server.start()` had already returned. The caller then pointed its client at a port whose server never came up, so `server.get_client()` blocked for the full timeout. This is the unhandled thread exception that showed up in [run 29051424261](https://github.com/gallantlab/pycortex/actions/runs/29051424261/job/86232825486) alongside the `RuntimeError: Failed to establish WebSocket connection ... within 60 seconds`.

**Fix:** bind the listening socket **synchronously** in `WebApp.__init__` via `bind_sockets(0)`, letting the OS hand out a guaranteed-free ephemeral port (read back into `self.port`). Bind failures now raise **in the caller**, visibly, instead of dying on the server thread; the pre-bound socket also removes the connect race (the OS backlogs connections before the IOLoop starts). `show()` now requests port 0. As a side benefit, many simultaneous viewers are collision-free — each holds its own kernel-reserved ephemeral port for its lifetime.

### `stop()` safety, required by the above

Binding in `__init__` means `stop()` has to be safe against a server that hasn't finished starting: it reads `self.server` / `self.ioloop`, which `run()` sets on the server thread, so an early `stop()` could hit an `AttributeError`, be lost entirely, or leak the bound sockets if the server never started. (This is the point [gemini-code-assist flagged on #658](https://github.com/gallantlab/pycortex/pull/658).)

`run()` now sets a readiness `Event` once those attributes exist; `stop()` waits on it (bounded, short-circuited by `is_alive()`) before stopping the server + loop, and closes the bound sockets itself if the server never came up. This is kept in the same PR because it exists solely to make the `__init__`-time bind safe — landing the bind without it would knowingly reintroduce the leak.

Also drops the now-unused `import random` in `view.py` and corrects the `port` docstring, which still promised a random port from 1024–65536.

## Testing

Exercised the real `WebApp` directly (standalone, since a full `cortex` import needs `h5py`/Chromium not present in the dev sandbox):
- `port=0` binds a real ephemeral port synchronously and the server serves HTTP on it.
- An explicit in-use port raises `OSError` (errno 98) **synchronously in the caller** — no silent thread death.
- 30 viewers constructed concurrently from threads got 30 distinct ports — zero collisions.
- Every `stop()` path — normal serve→stop, never-started→stop (closes the socket, no leak, returns immediately), and 30× concurrent start+immediate-stop — is clean with no errors.

`ruff check` on the touched files reports the same 18 pre-existing findings as `main` — no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
