### PR TITLE
FIX bumpy flatmap smoothing skipped on the left hemisphere

### DIFF
--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -148,6 +148,18 @@ var mriview = (function(module) {
                 left :{positions:[], normals:[]}, 
                 right:{positions:[], normals:[]},
             };
+
+            // Smoothing parameters for the bumpy flatmap. These must be declared
+            // outside the per-hemisphere loop below: they used to live inside it,
+            // and `var` hoisting meant they were still undefined on the first
+            // iteration, so the left hemisphere was left unsmoothed while the
+            // right one picked up the values assigned during the left pass.
+            var areasmoothfactor = 0.1;
+            var areasmoothiter = 5;
+
+            var distsmoothfactor = 0.1;
+            var distsmoothiter = 20;
+
             for (var name in names) {
                 var hemi = geometries[names[name]];
                 posdata[name].map = hemi.indexMap;
@@ -172,11 +184,11 @@ var mriview = (function(module) {
                 }
                 //Setup flatmap mix
 		var wmareas = module.computeAreas(hemi.attributes.wm, hemi.attributes.index, hemi.offsets);
-                wmareas = module.iterativelySmoothVertexData(hemi.attributes.wm, hemi.attributes.index, hemi.offsets, wmareas, smoothfactor, smoothiter);
+                wmareas = module.iterativelySmoothVertexData(hemi.attributes.wm, hemi.attributes.index, hemi.offsets, wmareas, areasmoothfactor, areasmoothiter);
                 hemi.wmareas = wmareas;
 
 		var pialareas = module.computeAreas(hemi.attributes.position, hemi.attributes.index, hemi.offsets);
-                pialareas = module.iterativelySmoothVertexData(hemi.attributes.position, hemi.attributes.index, hemi.offsets, pialareas, smoothfactor, smoothiter);
+                pialareas = module.iterativelySmoothVertexData(hemi.attributes.position, hemi.attributes.index, hemi.offsets, pialareas, areasmoothfactor, areasmoothiter);
                 hemi.pialareas = pialareas;
 
 		var pialarea_attr = new THREE.BufferAttribute(pialareas, 1);
@@ -196,10 +208,6 @@ var mriview = (function(module) {
                     posdata[name].positions.push(hemi.attributes['mixSurfs'+json.names.length]);
                     posdata[name].normals.push(hemi.attributes['mixNorms'+json.names.length]);
 
-
-                    var smoothfactor = 0.1;
-                    var smoothiter = 50;
-
                     // var flatareas = module.computeAreas(hemi.attributes.mixSurfs1, hemi.culled.index, hemi.culled.offsets);
                     // var flatareascale = flatscale ** 2;
                     // flatareas = flatareas.map(function (a) { return a / flatareascale;});
@@ -207,7 +215,7 @@ var mriview = (function(module) {
                     // hemi.flatareas = flatareas;
 
                     var dists = module.computeDist(hemi.attributes.position, hemi.attributes.wm);
-                    dists = module.iterativelySmoothVertexData(hemi.attributes.position, hemi.attributes.index, hemi.offsets, dists, smoothfactor, smoothiter);
+                    dists = module.iterativelySmoothVertexData(hemi.attributes.position, hemi.attributes.index, hemi.offsets, dists, distsmoothfactor, distsmoothiter);
 
                     var vertexvolumes = module.computeVertexPrismVolume(wmareas, pialareas, dists);
                     hemi.vertexvolumes = vertexvolumes;


### PR DESCRIPTION
Splits the bug fix out of #310 (which has been sitting since 2019 and no longer merges cleanly).

## The bug

In `mriview_surface.js`, `smoothfactor` and `smoothiter` are declared with `var` inside the `if (this.flatlims !== undefined)` block, but used ~25 lines earlier in the same per-hemisphere loop to smooth `wmareas` and `pialareas`.

`var` hoists the *declaration* to function scope but not the *assignment*, so on the first iteration of the loop they are still `undefined`. `iterativelySmoothVertexData` then runs:

```js
for ( var i = 0; i < undefined; i ++ ) { ... }
```

`0 < undefined` is `false`, so the loop body never executes and the areas come back completely unsmoothed. By the second iteration the values assigned during the first pass are visible, so:

- **left hemisphere** — areas unsmoothed
- **right hemisphere** — areas smoothed with factor 0.1, 50 iterations

which is why the two hemispheres have visibly different bump relief. I confirmed the bug is still present on current `main`.

## The fix

Declare the parameters above the loop, split them into separate constants for the area and distance passes, and reduce the iteration counts (areas 50 → 5, dists 50 → 20) for a somewhat less smoothed result.

The commit adds a comment explaining why the declarations have to live outside the loop, so the bug does not get quietly reintroduced by re-nesting them.

## Note for reviewers

The iteration-count reduction is a deliberate *appearance* change riding along with the correctness fix — it is part of what @alexhuth was going for in #310 ("I also reduced the amount of smoothing somewhat"), but it is separable if you would rather land the hoist alone first. These are also hardcoded constants; they could reasonably be exposed in `[webgl_viewopts]` next to `bumpy_flatmap`.

## Testing

`node --check` passes. Not verified visually — no render was produced.

The lighting half of #310 is split into a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
