### PR TITLE
NF: refactor webgl lighting

### DIFF
--- a/cortex/defaults.cfg
+++ b/cortex/defaults.cfg
@@ -126,6 +126,11 @@ voxline_color = #FFFFFF
 voxline_width = 0.01
 # Overwrites emissive, specular, and diffuse to have uniform lighting
 uniform_illumination = false
+# Replace the default three-light setup with a single grazing light from the
+# upper left, following the top-left lighting convention used for shaded-relief
+# topographic maps. Makes sulci read as valleys and gyri as ridges, which helps
+# when bumpy_flatmap is enabled. Dimmer overall than the default lighting.
+topleft_lighting = false
 specularity = 1.0
 overlayscale = 1
 anim_speed = 2

--- a/cortex/defaults.cfg
+++ b/cortex/defaults.cfg
@@ -124,13 +124,23 @@ filter = url(#dropshadow)
 voxlines = false
 voxline_color = #FFFFFF
 voxline_width = 0.01
-# Overwrites emissive, specular, and diffuse to have uniform lighting
-uniform_illumination = false
-# Replace the default three-light setup with a single grazing light from the
-# upper left, following the top-left lighting convention used for shaded-relief
+# How uniform (flat, shadowless) the illumination is, from 0 (fully directional
+# lighting) to 1 (emissive only, no diffuse or specular). Booleans are still
+# accepted for backwards compatibility. This is the value unfolding starts from:
+# unfolding towards a flatmap drives illumination to fully uniform on its own,
+# unless bumpy_flatmap is on.
+uniform_illumination = 0
+# Crossfade from the default headlight (0) to a single light from the upper
+# left (1), following the top-left lighting convention used for shaded-relief
 # topographic maps. Makes sulci read as valleys and gyri as ridges, which helps
-# when bumpy_flatmap is enabled. Dimmer overall than the default lighting.
-topleft_lighting = false
+# when bumpy_flatmap is enabled. Booleans are still accepted for backwards
+# compatibility. Dimmer overall than the default lighting. This is the value
+# unfolding starts from: unfolding a bumpy flatmap towards flat drives top-left
+# lighting to 1 on its own.
+topleft_lighting = 0
+# Specular reflection level. This is the value unfolding starts from: it is
+# driven to zero along with the illumination as the surface flattens, unless
+# bumpy_flatmap is on.
 specularity = 1.0
 overlayscale = 1
 anim_speed = 2

--- a/cortex/export/save_views.py
+++ b/cortex/export/save_views.py
@@ -18,7 +18,9 @@ ViewParams = TypedDict(
         "surface.{subject}.unfold": float,
         "surface.{subject}.pivot": float,
         "surface.{subject}.shift": float,
-        "surface.{subject}.specularity": float,
+        "surface.{subject}.lighting.specularity": float,
+        "surface.{subject}.lighting.uniform_illumination": float,
+        "surface.{subject}.lighting.topleft_lighting": float,
     },
     total=False,
 )
@@ -227,7 +229,7 @@ default_view_params: ViewParams = {
     "surface.{subject}.unfold": 0,
     "surface.{subject}.pivot": 0,
     "surface.{subject}.shift": 0,
-    "surface.{subject}.specularity": 0,
+    "surface.{subject}.lighting.specularity": 0,
 }
 
 angle_view_params: dict[str, ViewParams] = {

--- a/cortex/webgl/resources/js/axes3d.js
+++ b/cortex/webgl/resources/js/axes3d.js
@@ -2,6 +2,17 @@ var jsplot = (function (module) {
 
     var retina_scale = window.devicePixelRatio || 1;
 
+    //Fractional view options (top-left lighting, uniform illumination) used to
+    //be plain booleans, so accept both spellings.
+    module.parseFraction = function(val) {
+        if (val === undefined || val == 'false')
+            return 0;
+        if (val == 'true')
+            return 1;
+        var parsed = parseFloat(val);
+        return isNaN(parsed) ? 0 : Math.min(Math.max(parsed, 0), 1);
+    };
+
     module.Axes3D = function(figure) {
         if (this.canvas === undefined) {
             module.Axes.call(this, figure);
@@ -23,32 +34,40 @@ var jsplot = (function (module) {
         // Lights are children of the camera, so their positions are in camera
         // space: +x is right, +y is up, +z is towards the viewer. Directional
         // lights only care about the direction, which three.js normalizes.
-        var topleft_lighting = (typeof viewopts !== 'undefined' &&
-                                viewopts.topleft_lighting == 'true');
-        if (topleft_lighting) {
-            // Single grazing light from the upper left, following the top-left
-            // lighting convention used for shaded-relief topographic maps. This
-            // makes sulci read as valleys and gyri as ridges, which is the point
-            // of the bumpy flatmap. Note that a single near-tangential light is
-            // dimmer overall than the default three-light setup.
-            this.lights = [
-                new THREE.DirectionalLight(0xffffff, 1.0)
-            ];
-            this.lights[0].position.set( -100, 200, 10 ); //.normalize();
-        } else {
-            //These lights approximately match what's done by vtk
-            this.lights = [
-                new THREE.DirectionalLight(0xffffff, .47), 
-                new THREE.DirectionalLight(0xffffff, .29), 
-                new THREE.DirectionalLight(0xffffff, .24)
-            ];
-            this.lights[0].position.set( 1, -1, -1 ).normalize();
-            this.lights[1].position.set( -1, -.25, .75 ).normalize();
-            this.lights[2].position.set( 1, -.25, .75 ).normalize();
-        }
+        // Both lighting solutions live in the scene at once and are crossfaded
+        // by intensity: the number of lights is baked into the compiled
+        // shaders, so they can never be added or removed.
+        this.lights = [
+            //The default: a headlight straight down the view axis. This used to
+            //be written as three vtk-like lights at (1,-1,-1), (-1,-.25,.75)
+            //and (1,-.25,.75) with intensities .47/.29/.24, but because their
+            //directions were swamped by the camera's world position (see the
+            //note about light targets below) all three collapsed onto the view
+            //axis: a single intensity-1 headlight is what pycortex has always
+            //actually rendered, so say so.
+            new THREE.DirectionalLight(0xffffff, 1.),
+            //Light from the upper left, following the top-left lighting
+            //convention used for shaded-relief topographic maps: azimuth 315
+            //degrees, altitude 45 degrees above the view axis. This makes sulci
+            //read as valleys and gyri as ridges, which is the point of the
+            //bumpy flatmap. An off-axis light leaves part of the surface in
+            //shadow, so it is dimmer overall than the headlight.
+            new THREE.DirectionalLight(0xffffff, 0.)
+        ];
+        this.lights[0].position.set( 0, 0, 1 );
+        this.lights[1].position.set( -1, 1, Math.SQRT2 ).normalize();
         for (var i = 0; i < this.lights.length; i++) {
+            //three.js takes a directional light's direction to be the vector
+            //from its target to its world position. The lights ride along with
+            //the camera, so aim them at the camera itself; otherwise the
+            //direction is dominated by the camera's own world position, which
+            //leaves every light pointing straight down the view axis and makes
+            //the lighting drift as the camera zooms.
+            this.lights[i].target = this.camera;
             this.camera.add( this.lights[i] );
         }
+        this.setTopLeftLighting(typeof viewopts === 'undefined' ? 0 :
+                                module.parseFraction(viewopts.topleft_lighting));
 
         this.views = [];
 
@@ -108,6 +127,20 @@ var jsplot = (function (module) {
 
         this.dispatchEvent({ type:"resize", width:w, height:h});
         this.schedule();
+    };
+    //Crossfades between the headlight (0) and the top-left light (1). The two
+    //intensities always sum to 1, though the image still darkens somewhat
+    //towards 1 because an off-axis light leaves part of the surface in shadow.
+    module.Axes3D.prototype.setTopLeftLighting = function(val) {
+        if (val === undefined)
+            return this._topleft_lighting;
+
+        this._topleft_lighting = val;
+        this.lights[0].intensity = 1 - val;
+        this.lights[1].intensity = val;
+        //guard against the initial call, which happens before _schedule exists
+        if (this._schedule !== undefined)
+            this.schedule();
     };
     module.Axes3D.prototype.schedule = function() {
         if (!this._scheduled) {

--- a/cortex/webgl/resources/js/axes3d.js
+++ b/cortex/webgl/resources/js/axes3d.js
@@ -20,18 +20,35 @@ var jsplot = (function (module) {
         this.controls.addEventListener("pick", this.pick.bind(this));
         this.controls.addEventListener("change", this.schedule.bind(this));
         
-        //These lights approximately match what's done by vtk
-        this.lights = [
-            new THREE.DirectionalLight(0xffffff, .47), 
-            new THREE.DirectionalLight(0xffffff, .29), 
-            new THREE.DirectionalLight(0xffffff, .24)
-        ];
-        this.lights[0].position.set( 1, -1, -1 ).normalize();
-        this.lights[1].position.set( -1, -.25, .75 ).normalize();
-        this.lights[2].position.set( 1, -.25, .75 ).normalize();
-        this.camera.add( this.lights[0] );
-        this.camera.add( this.lights[1] );
-        this.camera.add( this.lights[2] );
+        // Lights are children of the camera, so their positions are in camera
+        // space: +x is right, +y is up, +z is towards the viewer. Directional
+        // lights only care about the direction, which three.js normalizes.
+        var topleft_lighting = (typeof viewopts !== 'undefined' &&
+                                viewopts.topleft_lighting == 'true');
+        if (topleft_lighting) {
+            // Single grazing light from the upper left, following the top-left
+            // lighting convention used for shaded-relief topographic maps. This
+            // makes sulci read as valleys and gyri as ridges, which is the point
+            // of the bumpy flatmap. Note that a single near-tangential light is
+            // dimmer overall than the default three-light setup.
+            this.lights = [
+                new THREE.DirectionalLight(0xffffff, 1.0)
+            ];
+            this.lights[0].position.set( -100, 200, 10 ).normalize();
+        } else {
+            //These lights approximately match what's done by vtk
+            this.lights = [
+                new THREE.DirectionalLight(0xffffff, .47), 
+                new THREE.DirectionalLight(0xffffff, .29), 
+                new THREE.DirectionalLight(0xffffff, .24)
+            ];
+            this.lights[0].position.set( 1, -1, -1 ).normalize();
+            this.lights[1].position.set( -1, -.25, .75 ).normalize();
+            this.lights[2].position.set( 1, -.25, .75 ).normalize();
+        }
+        for (var i = 0; i < this.lights.length; i++) {
+            this.camera.add( this.lights[i] );
+        }
 
         this.views = [];
 

--- a/cortex/webgl/resources/js/axes3d.js
+++ b/cortex/webgl/resources/js/axes3d.js
@@ -34,7 +34,7 @@ var jsplot = (function (module) {
             this.lights = [
                 new THREE.DirectionalLight(0xffffff, 1.0)
             ];
-            this.lights[0].position.set( -100, 200, 10 ).normalize();
+            this.lights[0].position.set( -100, 200, 10 ); //.normalize();
         } else {
             //These lights approximately match what's done by vtk
             this.lights = [

--- a/cortex/webgl/resources/js/mriview.js
+++ b/cortex/webgl/resources/js/mriview.js
@@ -69,6 +69,12 @@ var mriview = (function(module) {
             this.controls.allowTilt = evt.value;
         }.bind(this);
 
+        //the lights are children of the camera, so the surface has to ask the
+        //viewer to switch lighting modes for it
+        this._lighting = function(evt){
+            this.setTopLeftLighting(evt.topleft);
+        }.bind(this);
+
         //Initialize all the html
         $(this.object).html($("#mriview_html").html())
 
@@ -744,6 +750,7 @@ var mriview = (function(module) {
         var surf = new surftype(this.active, opts);
         surf.addEventListener("mix", this._mix);
         surf.addEventListener("allowTilt", this._allowTilt);
+        surf.addEventListener("lighting", this._lighting);
         // The SVG overlay (ROIs/sulci/labels) re-bakes its texture asynchronously, then dispatches
         // "update" on the surface once the new texture is committed. Redraw when that lands --
         // otherwise a toggle (or a freshly-loaded label texture) is not visible until the next
@@ -940,6 +947,7 @@ var mriview = (function(module) {
                 this.removeEventListener("resize", this.surfs[i]._resize);
                 this.surfs[i].removeEventListener("mix", this._mix);
                 this.surfs[i].removeEventListener("allowTilt", this._allowTilt);
+                this.surfs[i].removeEventListener("lighting", this._lighting);
 
                 this.root.remove(this.surfs[i].object);
             } else

--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -1,6 +1,15 @@
 var mriview = (function(module) {
     var flatscale = 0.3;
 
+    //Base lighting terms used when illumination is fully directional. Uniform
+    //illumination fades diffuse and specular out and emissive in.
+    var base_diffuse = .8, base_emissive = .2, base_specular = .005;
+
+    //Fades a user setting the rest of the way towards 1 as `amount` goes to 1
+    function fadeToFull(base, amount) {
+        return base + (1 - base) * amount;
+    }
+
     function makeAxes(length, color) {
         function v(x,y,z){ 
             return new THREE.Vector3(x,y,z); 
@@ -32,7 +41,18 @@ var mriview = (function(module) {
         this._dither = false;
         this._pivot = 0;
         this._shift = 0;
-        this._specular = parseFloat(viewopts.specularity);
+        //The lighting controls hold the values that are actually in effect, and
+        //unfolding drives them (like pivot does), so keep the configured values
+        //around as the settings to drive them back towards.
+        this._lighting_defaults = {
+            specularity: parseFloat(viewopts.specularity),
+            uniform_illumination: jsplot.parseFraction(viewopts.uniform_illumination),
+            topleft_lighting: jsplot.parseFraction(viewopts.topleft_lighting),
+        };
+        this._specular = this._lighting_defaults.specularity;
+        this._uniform_illumination = this._lighting_defaults.uniform_illumination;
+        this._topleft_lighting = this._lighting_defaults.topleft_lighting;
+        this._flat = 0;
         this._leftvis = true;
         this._rightvis = true;
         this.shaders = {};
@@ -76,12 +96,8 @@ var mriview = (function(module) {
             }
         ]);
 
-        // Update uniform values based on the uniform illumination option
-        if (viewopts.uniform_illumination == 'true') {
-            this.uniforms.diffuse.value.set(0, 0, 0); // Set diffuse to 0
-            this.uniforms.specular.value.set(0, 0, 0); // Set specular to 0
-            this.uniforms.emissive.value.set(1, 1, 1); // Set emissive to 1
-        }
+        //Fold the illumination options into the lighting uniforms
+        this._autoLighting();
 
         this.ui = (new jsplot.Menu()).add({
             unfold: {action:[this, "setMix", 0., 1.]},
@@ -91,7 +107,7 @@ var mriview = (function(module) {
             "pial surface": {action: this.to_pial_surface.bind(this), key: 'p', help: "Pial surface"},
             "fiducial surface": {action: this.to_fiducial_surface.bind(this), key: 'u', help: "Fiducial surface"},
             "WM surface": {action: this.to_white_matter_surface.bind(this), key: 'y', help: "White matter surface"},
-            bumpy_flatmap: {action:[this.uniforms.bumpyflat, "value"]},
+            bumpy_flatmap: {action:[this, "setBumpyFlat"]},
             allow_tilt: {action:[this, "setAllowTilt"]},
             equivolume: {action:[this, "setEquivolume"]},
             changeDepth: {action: this.changeDepth.bind(this), wheel: true, modKeys: ['altKey'], hidden: true, help:'Change depth'},
@@ -103,14 +119,17 @@ var mriview = (function(module) {
             leftToggle: {action: this.toggleLeftVis.bind(this), key: 'L', modKeys: ['shiftKey'], hidden: true, help:'Toggle left hemisphere'},
             right: {action:[this, "setRightVis"]},
             rightToggle: {action: this.toggleRightVis.bind(this), key: 'R', modKeys: ['shiftKey'], hidden: true, help:'Toggle right hemisphere'},
-	        specularity: {action:[this, "setSpecular", 0, 1]},
             layers: {action:[this, "setLayers", {1:1, 4:4, 8:8, 16:16, 32:32}]},
             toggleMultipleLayers: {action: this.toggleMultipleLayers.bind(this), key: 'm', hidden: true, help: "Toggle multiple layers"},
             dither: {action:[this, "setDither"]},
             sampler: {action:[this, "setSampler", ["nearest", "trilinear"]]},
-            uniform_illumination: {action:[this, "setUniformIllumination"]},
         });
-        
+
+        this.ui.addFolder("lighting", true).add({
+            topleft_lighting: {action:[this, "setTopLeftLighting", 0, 1]},
+            uniform_illumination: {action:[this, "setUniformIllumination", 0, 1]},
+            specularity: {action:[this, "setSpecular", 0, 1]},
+        });
 
         this.ui.addFolder("curvature", true).add({
             brightness: {action:[this.uniforms.brightness, "value", 0, 1]},
@@ -506,8 +525,10 @@ var mriview = (function(module) {
         }
         _last_clipped = clipped;
 
-        // this.uniforms.specularStrength.value = this._specular * (1-clipped);
-        this.uniforms.specularStrength.value = this._specular;
+        //Lighting follows the flatmap: see _autoLighting
+        this._flat = clipped;
+        this._autoLighting();
+
         this.setPivot( 180 * clipped);
 
         this.pivots.left.back.rotation.x = clipped * -Math.PI/2;
@@ -596,8 +617,55 @@ var mriview = (function(module) {
             return this._specular;
 
         this._specular = val;
-	this.uniforms.specularStrength.value = this._specular;// * (1-_last_clipped);
-    
+        this.uniforms.specularStrength.value = val;
+    };
+    module.Surface.prototype.setUniformIllumination = function(val) {
+        if (val === undefined)
+            return this._uniform_illumination;
+
+        this._uniform_illumination = val;
+        var diffuse = base_diffuse * (1 - val);
+        var emissive = base_emissive + (1 - base_emissive) * val;
+        var specular = base_specular * (1 - val);
+        this.uniforms.diffuse.value.set(diffuse, diffuse, diffuse);
+        this.uniforms.emissive.value.set(emissive, emissive, emissive);
+        this.uniforms.specular.value.set(specular, specular, specular);
+    };
+    module.Surface.prototype.setTopLeftLighting = function(val) {
+        if (val === undefined)
+            return this._topleft_lighting;
+
+        this._topleft_lighting = val;
+        //The lights themselves hang off the viewer's camera, not the surface
+        this.dispatchEvent({type:'lighting', topleft:val});
+    };
+    module.Surface.prototype.setBumpyFlat = function(val) {
+        if (val === undefined)
+            return this.uniforms.bumpyflat.value;
+
+        this.uniforms.bumpyflat.value = val;
+        //the bumpy flatmap decides which way the lighting is driven
+        this._autoLighting();
+    };
+    //Drives the lighting controls from the current flatness, the way unfolding
+    //drives the pivot. A fully flat, smooth flatmap is a flat sheet:
+    //directional lighting can only add a spurious gradient across it, so
+    //illumination goes fully uniform and the specular highlight fades out as
+    //the surface flattens. A bumpy flatmap does have relief to shade, so it
+    //goes to a fully top-left light instead, which is the direction that reads
+    //as shaded relief. Everything is written through the setters the menu
+    //wraps, so the sliders follow along and stay editable.
+    module.Surface.prototype._autoLighting = function() {
+        var d = this._lighting_defaults;
+        var flat = this.uniforms.bumpyflat.value ? 0 : this._flat;
+        var bumpyflat = this.uniforms.bumpyflat.value ? this._flat : 0;
+
+        var uniform = fadeToFull(d.uniform_illumination, flat);
+        this.setUniformIllumination(uniform);
+        //the specular highlight is part of the directional lighting, so it goes
+        //away as the illumination becomes uniform
+        this.setSpecular(d.specularity * (1 - uniform));
+        this.setTopLeftLighting(fadeToFull(d.topleft_lighting, bumpyflat));
     };
     module.Surface.prototype.setLeftVis = function(val) {
         if (val === undefined)
@@ -878,21 +946,6 @@ var mriview = (function(module) {
         this.mesh = new THREE.Mesh(this.sheets, null);
         this.object.add(this.mesh);
     }
-
-    module.Surface.prototype.setUniformIllumination = function(val) {
-        if (val === undefined)
-            return this.uniforms.emissive.value.x == 1; // Check current state
-        
-        if (val) {
-            this.uniforms.diffuse.value.set(0, 0, 0);
-            this.uniforms.specular.value.set(0, 0, 0);
-            this.uniforms.emissive.value.set(1, 1, 1);
-        } else {
-            this.uniforms.diffuse.value.set(.8, .8, .8);
-            this.uniforms.specular.value.set(.005, .005, .005);
-            this.uniforms.emissive.value.set(.2, .2, .2);
-        }
-    };
 
     return module;
 }(mriview || {}));

--- a/cortex/webgl/resources/js/shaderlib.js
+++ b/cortex/webgl/resources/js/shaderlib.js
@@ -697,6 +697,8 @@ var Shaderlib = (function() {
                 header += "#define ROI_RENDER\n";
             if (opts.extratex)
                 header += "#define EXTRATEX\n";
+            if (opts.hasflat)
+                header += "#define HASFLAT\n"
             if (opts.equivolume)
                 header += "#define EQUIVOLUME\n"
 
@@ -708,6 +710,8 @@ var Shaderlib = (function() {
             "uniform float framemix;",
             // "uniform float thickmix;",
             utils.thickmixer,
+            "uniform int bumpyflat;",
+            "float f_bumpyflat = float(bumpyflat);",
 
             "varying vec4 vColor;",
     "#ifdef RGBCOLORS",
@@ -724,6 +728,11 @@ var Shaderlib = (function() {
             "attribute vec4 wm;",
             "attribute vec3 wmnorm;",
             "attribute vec4 auxdat;",
+
+            "#ifdef HASFLAT",
+                "attribute vec3 flatBumpNorms;",
+                "attribute float flatheight;",
+            "#endif",
             // "attribute float dropout;",
             
             "varying vec3 vViewPosition;",
@@ -778,10 +787,19 @@ var Shaderlib = (function() {
                 "mixfunc(mpos, mnorm, pos, norm);",
 
             "#ifdef CORTSHEET",
-                "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., use_thickmix);",
+                "#ifdef HASFLAT",
+                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * mix(1., 0., use_thickmix) * flatheight * f_bumpyflat;",
+                "#else",
+                    "pos += clamp(surfmix*"+(morphs-1)+"., 0., 1.) * normalize(norm) * .62 * distance(position, wm.xyz) * mix(1., 0., use_thickmix);",
+                "#endif",
             "#endif",
 
-                "vNormal = normalMatrix * norm;",
+                "#ifdef HASFLAT",
+                    "vNormal = normalMatrix * mix(norm, flatBumpNorms, (1.0 - use_thickmix) * clamp(surfmix*"+(morphs-1)+". - 1.0, 0., 1.) * f_bumpyflat);",
+                "#else",
+                    "vNormal = normalMatrix * norm;",
+                "#endif",
+
                 "gl_Position = projectionMatrix * modelViewMatrix * vec4( pos, 1.0 );",
 
             "}"
@@ -873,6 +891,11 @@ var Shaderlib = (function() {
                 wmarea: { type: 'f', value:null },
                 pialarea: { type: 'f', value:null },
             };
+
+            if (opts.hasflat) {
+                attributes.flatBumpNorms = { type: 'v3', value:null };
+                attributes.flatheight = { type: 'f', value:null };
+            }
 
             for (var i = 0; i < 4; i++)
                 attributes['data'+i] = {type:opts.rgb ? 'v4':'f', value:null};

--- a/cortex/webgl/view.py
+++ b/cortex/webgl/view.py
@@ -582,7 +582,20 @@ def show(
             _curvature_props = ['surface.{subject}.curvature.brightness',
                                 'surface.{subject}.curvature.contrast',
                                 'surface.{subject}.curvature.smoothness']
-            return _camera_props + _surface_props + _curvature_props
+            _lighting_props = ['surface.{subject}.lighting.topleft_lighting',
+                               'surface.{subject}.lighting.uniform_illumination',
+                               'surface.{subject}.lighting.specularity']
+            return _camera_props + _surface_props + _curvature_props + _lighting_props
+
+        # Lighting controls used to sit directly in the surface menu; they now
+        # live in its lighting sub-folder. Keep the old names working, both for
+        # user code and for views saved to the database before the move.
+        _legacy_props = {
+            'surface.{subject}.specularity':
+                'surface.{subject}.lighting.specularity',
+            'surface.{subject}.uniform_illumination':
+                'surface.{subject}.lighting.uniform_illumination',
+        }
 
         def _set_view(self, **kwargs):
             """Low-level command: sets view parameters in the current viewer
@@ -598,6 +611,9 @@ def show(
             # Better to only self.view_props once; it interacts with javascript, 
             # don't want to do that too often, it leads to glitches.
             vw_props = copy.copy(self.view_props)
+            for old_key, new_key in self._legacy_props.items():
+                if old_key in kwargs and new_key not in kwargs:
+                    kwargs[new_key] = kwargs.pop(old_key)
             for subject in subject_list:
                 if 'surface.{subject}.unfold' in kwargs:
                     unfold = kwargs.pop('surface.{subject}.unfold')

--- a/docs/userguide/webgl.rst
+++ b/docs/userguide/webgl.rst
@@ -87,17 +87,39 @@ flatten  flatten cortical surface
 Surface Controls
 ****************
 
-=========== ============================
-name        description
-=========== ============================
-unfold      level of unfolding
-pivot       angle between hemispheres
-shift 		distance between hemispheres
-depth 		cortical depth
-left 		toggle left hemisphere
-right       toggle right hemisphere
-specularity specular reflection level
-=========== ============================
+======== ============================
+name     description
+======== ============================
+unfold   level of unfolding
+pivot    angle between hemispheres
+shift    distance between hemispheres
+depth    cortical depth
+left     toggle left hemisphere
+right    toggle right hemisphere
+======== ============================
+
+
+Lighting Controls
+*****************
+
+These live in the ``lighting`` sub-menu of the surface controls.
+
+==================== ==========================================================
+name                 description
+==================== ==========================================================
+topleft_lighting     crossfade from the default headlight (0) to a light from
+                     the upper left (1)
+uniform_illumination how flat and shadowless the illumination is, 0 to 1
+specularity          specular reflection level
+==================== ==========================================================
+
+Unfolding towards a flatmap drives illumination to fully uniform and
+specularity to zero, since a flat sheet has no shape for directional lighting to
+reveal. Turning on ``bumpy_flatmap`` gives the flatmap real relief again:
+unfolding then drives top-left lighting to 1 instead, which is the direction
+that reads as shaded relief. Like ``pivot``, the sliders move to show the values
+in effect and can still be dragged afterwards; the next change to ``unfold`` or
+``bumpy_flatmap`` drives them back from the configured defaults.
 
 
 Overlay Controls


### PR DESCRIPTION
Splits the lighting change out of #310 (which has been sitting since 2019 and no longer merges cleanly), and makes it opt-in.

## What it does

Rationalize the lighting system. Now lighting options are controlled through a new "lighting" submenu under the surface GUI. This menu contains three options: topleft_lighting, uniform_illumination (moved here), and specularity (moved here):
* `topleft_lighting` fades between two light setups: the standard VTK-inspired 3-light setup (at zero) and a single light from above and to the left of the camera (at one), following the [top-left lighting convention](https://en.wikipedia.org/wiki/Terrain_cartography#Shaded_relief) used for shaded-relief topographic maps. This makes sulci read as valleys and gyri as ridges, which is what makes bumpy flatmaps legible — see @alexhuth's before/after screenshots in #310. There is a switch for this in the config file, but it should probably be ignored and removed.
* `uniform_illumination` fades between the standard lighting model (at zero) and uniform emissive shading for the surface (at one).
* `specularity` smoothly adjusts the amount of specular reflection. There is a switch in the config that sets the default specularity to on or off.

Each of these controls will automatically change as the surface morphs into its flattened mode, depending on whether `bumpy_flatmap` is turned on or not.

If `bumpy_flatmap` is turned off:
* `topleft_lighting` will always stay off
* `uniform_illumination` will go to 1.0 as the surface flattens, and then back to 0.0 as it folds up again
* `specularity` will go to 0.0 as the surface flattens, then back to its default value (0 or 1) as it folds up

If `bumpy_flatmap` is turned on:
* `topleft_lighting` will go to 1.0 as the surface flattens (giving nice hillshading), and back to 0.0 as it folds up
* `uniform_illumination` will always stay at 0.0
* `specularity` will always stay at the default value