### PR TITLE
MNT ignore docs build outputs written into the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,13 @@ docs/_build
 docs/auto_examples
 docs/generated
 docs/colormaps.rst
+docs/sg_execution_times.rst
+
+# Outputs the example gallery writes into the source tree when docs are built
+examples/quickflat/flatmap_comparison.gif
+examples/quickflat/my_flatmap.png
+examples/quickflat/my_flatmap.svg
+examples/quickstart/S1_retinotopy.hdf
 
 # Python virtual environment
 .venv


### PR DESCRIPTION
Building the docs runs the example gallery, which writes its outputs next to the example sources instead of into `docs/_build` — so `my_flatmap.png/svg`, `flatmap_comparison.gif`, `S1_retinotopy.hdf`, and sphinx-gallery's `sg_execution_times.rst` all showed up as untracked after every local `make html`.

Verified with `git check-ignore` that all five are now ignored and that `git status` is clean after a docs build. No tracked files are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)