### PR TITLE
WebGL viewer: make opacity slider and `o` toggle work for Vertex data

### DIFF
--- a/cortex/tests/test_webgl_headless.py
+++ b/cortex/tests/test_webgl_headless.py
@@ -614,6 +614,20 @@ def test_vertex_opacity_slider_fades_data(tmp_path):
     viewer session and checks that the red pixels disappear at 0 and come
     back at 1.
     """
+    image_size = (512, 384)
+    n_pixels = image_size[0] * image_size[1]
+    # At this lateral/inflated view the brain fills ~30% of the frame and,
+    # with a saturated colormap at full opacity, ~27% of the frame is
+    # red-dominant (measured). Require a third of that so small view or
+    # lighting changes don't cause flakiness, while staying far above what a
+    # curvature-only render produces (0%).
+    min_visible_data_fraction = 0.10
+    # At opacity 0 the data layer must be gone: allow up to 1% of the visible
+    # count for anti-aliased edges (measured: 0).
+    max_hidden_to_visible_ratio = 0.01
+    # Toggling back to opacity 1 must reproduce the original render.
+    restore_tolerance = 0.05
+
     data = np.full(nverts, 5.0)
     vtx = cortex.Vertex(data, subj, vmin=0, vmax=1, cmap="Reds")
 
@@ -626,7 +640,7 @@ def test_vertex_opacity_slider_fades_data(tmp_path):
     def render(handle, name):
         outfile = str(tmp_path / f"{name}.png")
         time.sleep(1)
-        handle.getImage(outfile, (512, 384))
+        handle.getImage(outfile, image_size)
         _wait_for_file(outfile)
         return _count_red_pixels(outfile)
 
@@ -644,17 +658,20 @@ def test_vertex_opacity_slider_fades_data(tmp_path):
         handle._set_view(**{"surface.{subject}.opacity": 1.0})
         n_restored = render(handle, "opacity_1_again")
 
-    assert n_full > 1000, (
-        f"Vertex data at opacity 1 should render visibly (got {n_full} "
-        "red-dominant pixels)"
+    assert n_full >= min_visible_data_fraction * n_pixels, (
+        f"Vertex data at opacity 1 should cover at least "
+        f"{min_visible_data_fraction:.0%} of the frame; got {n_full} of "
+        f"{n_pixels} pixels ({n_full / n_pixels:.1%})"
     )
-    assert n_zero < 50, (
-        f"Vertex data at opacity 0 still renders {n_zero} red-dominant pixels; "
+    assert n_zero <= max_hidden_to_visible_ratio * n_full, (
+        f"Vertex data at opacity 0 still renders {n_zero} red-dominant pixels "
+        f"({n_zero / n_full:.1%} of the {n_full} visible at opacity 1); "
         "the surface_vertex shader is ignoring dataAlpha (#684)."
     )
-    assert n_restored > 1000, (
-        f"Vertex data should be visible again at opacity 1 (got {n_restored} "
-        "red-dominant pixels)"
+    assert abs(n_restored - n_full) <= restore_tolerance * n_full, (
+        f"Restoring opacity 1 should reproduce the original render within "
+        f"{restore_tolerance:.0%}; got {n_restored} vs {n_full} red-dominant "
+        "pixels"
     )
 
 

--- a/cortex/tests/test_webgl_headless.py
+++ b/cortex/tests/test_webgl_headless.py
@@ -598,6 +598,67 @@ def test_vertex2d_alpha_half_renders_correct_blend(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Group 8b: opacity slider for vertex data (#684)
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_opacity_slider_fades_data(tmp_path):
+    """The ``opacity`` control must fade Vertex data into the curvature.
+
+    Regression test for #684: the ``surface_vertex`` fragment shader declared
+    the ``dataAlpha`` uniform (driven by the dat.GUI opacity slider and the
+    ``o`` shortcut) but never used it, so opacity changes were a no-op for
+    Vertex / Vertex2D / VertexRGB data while working for Volume data.
+
+    Renders a constant, saturated-red Vertex at opacity 1 → 0 → 1 within one
+    viewer session and checks that the red pixels disappear at 0 and come
+    back at 1.
+    """
+    data = np.full(nverts, 5.0)
+    vtx = cortex.Vertex(data, subj, vmin=0, vmax=1, cmap="Reds")
+
+    view = {
+        **default_view_params,
+        **angle_view_params["lateral_pivot"],
+        **unfold_view_params["inflated"],
+    }
+
+    def render(handle, name):
+        outfile = str(tmp_path / f"{name}.png")
+        time.sleep(1)
+        handle.getImage(outfile, (512, 384))
+        _wait_for_file(outfile)
+        return _count_red_pixels(outfile)
+
+    # No ROI/sulci overlays or labels: their anti-aliased colored edges would
+    # otherwise add stray red-dominant pixels.
+    with cortex.export.headless_viewer(
+        vtx, viewer_params=dict(overlays_visible=[], labels_visible=[])
+    ) as handle:
+        handle._set_view(**view)
+        n_full = render(handle, "opacity_1")
+
+        handle._set_view(**{"surface.{subject}.opacity": 0.0})
+        n_zero = render(handle, "opacity_0")
+
+        handle._set_view(**{"surface.{subject}.opacity": 1.0})
+        n_restored = render(handle, "opacity_1_again")
+
+    assert n_full > 1000, (
+        f"Vertex data at opacity 1 should render visibly (got {n_full} "
+        "red-dominant pixels)"
+    )
+    assert n_zero < 50, (
+        f"Vertex data at opacity 0 still renders {n_zero} red-dominant pixels; "
+        "the surface_vertex shader is ignoring dataAlpha (#684)."
+    )
+    assert n_restored > 1000, (
+        f"Vertex data should be visible again at opacity 1 (got {n_restored} "
+        "red-dominant pixels)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Group 9: addData dataset switching
 # ---------------------------------------------------------------------------
 

--- a/cortex/webgl/resources/js/mriview_surface.js
+++ b/cortex/webgl/resources/js/mriview_surface.js
@@ -626,8 +626,17 @@ var mriview = (function(module) {
         viewer.schedule();
     };
     module.Surface.prototype.toggleOpacity = function() {
-        let newValue = 1 - Math.round(this.uniforms.dataAlpha.value)
-        surface = Object.keys(viewer.ui._desc.surface).filter((key) => key[0] != '_')[0]
+        // Toggle between hidden (0) and the last visible opacity, so a slider
+        // value like 0.7 survives an off/on round trip instead of rounding to 1.
+        var current = this.uniforms.dataAlpha.value;
+        var newValue;
+        if (current > 0) {
+            this._savedOpacity = current;
+            newValue = 0;
+        } else {
+            newValue = this._savedOpacity || 1;
+        }
+        var surface = Object.keys(viewer.ui._desc.surface).filter((key) => key[0] != '_')[0]
         viewer.ui.set('surface.' + surface + '.opacity', newValue)
         viewer.schedule();
     };

--- a/cortex/webgl/resources/js/shaderlib.js
+++ b/cortex/webgl/resources/js/shaderlib.js
@@ -846,9 +846,14 @@ var Shaderlib = (function() {
             //     "vec4 vColor = texture2D(colormap, vValue);",
             // "#endif",
 
+                // Data layer scaled by the opacity slider. vColor is a
+                // varying (read-only here), so scale into a local. Scaling
+                // all four channels keeps the premultiplied-alpha convention
+                // used by surface_pixel, so opacity 0 shows curvature only.
+                "vec4 dColor = vColor * dataAlpha;",
 
                 "gl_FragColor = cColor;",
-                "gl_FragColor = vColor + (1.-vColor.a)*gl_FragColor;",
+                "gl_FragColor = dColor + (1.-dColor.a)*gl_FragColor;",
                 //"gl_FragColor = vec4(1., 0., 0., 1.);",
                 // "gl_FragColor = hColor + (1.-hColor.a)*gl_FragColor;",
             "#ifdef ROI_RENDER",


### PR DESCRIPTION
Closes #684

## Problem

With a `Vertex` (or `Vertex2D` / `VertexRGB`) dataset, the **opacity** slider in the surface folder and the `o` shortcut did nothing, while both work for `Volume` data.

Both controls drive the `dataAlpha` uniform. The volume shaders apply it (`vColor *= dataAlpha;` in `Shaders.main` and `Shaders.surface_pixel`), but the `surface_vertex` fragment shader only *declared* `dataAlpha` (via `standard_frag_vars`) and never read it, so the uniform changed and the pixels didn't.

The `o` shortcut itself already existed (`Surface.toggleOpacity`, listed in the `h` help overlay and in `docs/userguide/webgl.rst`) — it just looked broken for vertex data because it only flips `dataAlpha`.

## Changes

- **`shaderlib.js`** — in `surface_vertex`, scale the interpolated data colour by `dataAlpha` before compositing over the curvature (`vec4 dColor = vColor * dataAlpha;`). `vColor` is a varying, hence the local. Scaling all four channels keeps the premultiplied-alpha convention of the volume path (and of #631), so opacity 0 yields pure curvature.
- **`mriview_surface.js`** — `toggleOpacity` now remembers the last visible opacity instead of rounding it (0.7 → 0 → 0.7 rather than 0.7 → 0 → 1), and no longer leaks an implicit global `surface`.
- **`test_webgl_headless.py`** — new `test_vertex_opacity_slider_fades_data`: renders a saturated-red `Vertex` at opacity 1 → 0 → 1 in one viewer session and counts red-dominant pixels. Fails on `main` (53,760 red pixels at opacity 0), passes with the fix.

## Verification

- Full `cortex/tests/test_webgl_headless.py`: 43 passed, 1 skipped (pre-existing manual visual test).
- Rendered `Vertex`, `VertexRGB` and `Volume` at opacity 1 / 0.5 / 0 — `Vertex` now fades into the curvature exactly like `Volume`; `Volume` output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8oA4mUvTLd7sbs9iFaqM8
