### PR TITLE
ENH item access support for subject/surface/transform names

### DIFF
--- a/cortex/database.py
+++ b/cortex/database.py
@@ -94,9 +94,25 @@ class SurfaceDB:
     def __dir__(self):
         return list(self.types.keys())
 
+    def __getitem__(self, name: str) -> 'Surf':
+        """Return the surface named `name`.
+
+        Item access works for any surface name, including names that are not
+        valid python identifiers (e.g. ``surfaces['flat-orig']``).
+        """
+        try:
+            return self.types[name]
+        except KeyError:
+            raise KeyError("Subject {subj} has no surface '{name}'. Available "
+                           "surfaces: {avail}".format(subj=self.subject, name=name,
+                                                      avail=', '.join(sorted(self.types.keys()))))
+
     def __getattr__(self, attr: str):
-        if attr in self.types:
-            return self.types[attr]
+        if attr.startswith('__') and attr.endswith('__'):
+            raise AttributeError(attr)
+        types = self.__dict__.get('types', {})
+        if attr in types:
+            return types[attr]
         raise AttributeError(attr)
 
 class Surf:
@@ -119,9 +135,26 @@ class XfmDB:
         self.xfms: list[str] = Database(self.filestore).get_paths(subj)['xfms']
 
     def __getitem__(self, name: str) -> 'XfmSet':
+        """Return the transform set named `name`.
+
+        Item access works for any transform name, including names that are not
+        valid python identifiers.
+        """
         if name in self.xfms:
             return XfmSet(self.subject, name, filestore=self.filestore)
-        raise AttributeError
+        raise KeyError("Subject {subj} has no transform '{name}'. Available "
+                       "transforms: {avail}".format(subj=self.subject, name=name,
+                                                    avail=', '.join(sorted(self.xfms))))
+
+    def __dir__(self):
+        return list(self.xfms)
+
+    def __getattr__(self, attr: str) -> 'XfmSet':
+        if attr.startswith('__') and attr.endswith('__'):
+            raise AttributeError(attr)
+        if attr in self.__dict__.get('xfms', []):
+            return XfmSet(self.subject, attr, filestore=self.filestore)
+        raise AttributeError(attr)
     
     def __repr__(self):
         xfms = "\n".join(sorted(self.xfms))
@@ -137,10 +170,24 @@ class XfmSet:
         self.masks = MaskSet(subj, name, filestore=filestore)
         self.db = Database(filestore)
     
+    def __getitem__(self, name: str) -> Transform:
+        """Return the transform of type `name` (e.g. ``'coord'`` or ``'magnet'``)."""
+        if name in self._jsdat:
+            return self.db.get_xfm(self.subject, self.name, name)
+        raise KeyError("Transform {xfm} for subject {subj} has no type '{name}'. "
+                       "Available types: {avail}".format(xfm=self.name, subj=self.subject,
+                                                         name=name,
+                                                         avail=', '.join(sorted(self._jsdat.keys()))))
+
+    def __dir__(self):
+        return list(self._jsdat.keys())
+
     def __getattr__(self, attr: str) -> Transform:
-        if attr in self._jsdat:
+        if attr.startswith('__') and attr.endswith('__'):
+            raise AttributeError(attr)
+        if attr in self.__dict__.get('_jsdat', {}):
             return self.db.get_xfm(self.subject, self.name, attr)
-        raise AttributeError
+        raise AttributeError(attr)
     
     def __repr__(self):
         return "Types: {types}".format(types=", ".join(self._jsdat.keys()))
@@ -182,14 +229,42 @@ class Database:
         subjs = "\n   ".join(sorted(self.subjects.keys()))
         return """Pycortex database\n  Subjects:\n   {subjs}""".format(subjs=subjs)
     
+    def __getitem__(self, subject: str) -> SubjectDB:
+        """Return a handle to `subject`.
+
+        Unlike attribute access (``db.S1``), item access works for any subject
+        name, including names that are not valid python identifiers::
+
+            db['S1-test']
+        """
+        try:
+            subj = self.subjects[subject]
+        except KeyError:
+            raise KeyError("Subject '{subj}' not found in filestore {store}. Available "
+                           "subjects: {avail}".format(subj=subject, store=self.filestore,
+                                                      avail=', '.join(sorted(self.subjects.keys()))))
+        if subj._warning is not None:
+            warnings.warn(subj._warning)
+        return subj
+
+    def __contains__(self, subject: str) -> bool:
+        return subject in self.subjects
+
+    def __iter__(self):
+        return iter(sorted(self.subjects.keys()))
+
     def __getattr__(self, attr: str):
+        # Never look up dunder attributes in the filestore: doing so would
+        # recurse through `subjects` while the object is being constructed,
+        # copied, or pickled.
+        if attr.startswith('__') and attr.endswith('__'):
+            raise AttributeError(attr)
         if attr in self.subjects:
-            _warning = self.subjects[attr]._warning
-            if _warning is not None:
-                warnings.warn(_warning)
-            return self.subjects[attr]
-        else:
-            raise AttributeError
+            return self[attr]
+        raise AttributeError(
+            "'{attr}' is not an attribute of the pycortex database, and no such subject "
+            "exists in the filestore. Note that subject names that are not valid python "
+            "identifiers (e.g. 'S1-test') must be accessed as db['{attr}'].".format(attr=attr))
     
     def __dir__(self):
         return ["save_xfm","get_xfm", "get_surf", "get_anat", "get_surfinfo", "subjects", # "get_paths", # Add?

--- a/cortex/database.py
+++ b/cortex/database.py
@@ -105,7 +105,7 @@ class SurfaceDB:
         except KeyError:
             raise KeyError("Subject {subj} has no surface '{name}'. Available "
                            "surfaces: {avail}".format(subj=self.subject, name=name,
-                                                      avail=', '.join(sorted(self.types.keys()))))
+                                                      avail=', '.join(sorted(self.types.keys())))) from None
 
     def __getattr__(self, attr: str):
         if attr.startswith('__') and attr.endswith('__'):
@@ -242,7 +242,7 @@ class Database:
         except KeyError:
             raise KeyError("Subject '{subj}' not found in filestore {store}. Available "
                            "subjects: {avail}".format(subj=subject, store=self.filestore,
-                                                      avail=', '.join(sorted(self.subjects.keys()))))
+                                                      avail=', '.join(sorted(self.subjects.keys())))) from None
         if subj._warning is not None:
             warnings.warn(subj._warning)
         return subj

--- a/cortex/tests/test_database.py
+++ b/cortex/tests/test_database.py
@@ -1,0 +1,104 @@
+"""Tests for the database access interfaces (attribute and item access)."""
+import json
+import os
+
+import numpy as np
+import pytest
+
+from cortex.database import Database
+
+SUBJECT = "S1-test"
+
+
+@pytest.fixture
+def filestore(tmp_path):
+    """A minimal filestore containing a subject whose name is not an identifier."""
+    subj = tmp_path / SUBJECT
+    for dirname in ["transforms", "anatomicals", "cache", "surfaces", "surface-info", "views"]:
+        (subj / dirname).mkdir(parents=True)
+    for hemi in ["lh", "rh"]:
+        (subj / "surfaces" / f"flat-orig_{hemi}.gii").write_text("")
+    xfmdir = subj / "transforms" / "full-head"
+    xfmdir.mkdir()
+    (xfmdir / "matrices.xfm").write_text(json.dumps({
+        "subject": SUBJECT,
+        "coord": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+    }))
+    return str(tmp_path)
+
+
+@pytest.fixture
+def db(filestore):
+    return Database(filestore)
+
+
+def test_getitem_subject(db):
+    # Subject names that are not valid python identifiers are reachable by item access.
+    assert db[SUBJECT].subject == SUBJECT
+
+
+def test_getattr_still_works(filestore):
+    os.makedirs(os.path.join(filestore, "S1", "surfaces"))
+    os.makedirs(os.path.join(filestore, "S1", "transforms"))
+    db = Database(filestore)
+    assert db.S1.subject == "S1"
+
+
+def test_getitem_missing_subject_lists_available(db):
+    with pytest.raises(KeyError) as excinfo:
+        db["nosuchsubject"]
+    assert SUBJECT in str(excinfo.value)
+
+
+def test_getattr_missing_subject_points_at_item_access(db):
+    with pytest.raises(AttributeError) as excinfo:
+        db.nosuchsubject
+    assert "db['nosuchsubject']" in str(excinfo.value)
+
+
+def test_contains_and_iter(db):
+    assert SUBJECT in db
+    assert "nosuchsubject" not in db
+    assert list(db) == [SUBJECT]
+
+
+def test_dunder_lookup_does_not_hit_filestore(db):
+    # Dunders must not be resolved against the filestore, or copy/pickle recurse.
+    with pytest.raises(AttributeError):
+        db.__deepcopy__
+    assert db._subjects is None
+
+
+def test_surfaces_getitem(db):
+    surfaces = db[SUBJECT].surfaces
+    # 'flat-orig' is not a valid identifier, but item access finds it.
+    assert surfaces["flat-orig"].surftype == "flat-orig"
+    with pytest.raises(KeyError) as excinfo:
+        surfaces["nosuchsurface"]
+    assert "flat-orig" in str(excinfo.value)
+
+
+def test_transforms_getitem_and_getattr(db):
+    transforms = db[SUBJECT].transforms
+    assert transforms["full-head"].name == "full-head"
+    with pytest.raises(KeyError) as excinfo:
+        transforms["nosuchxfm"]
+    assert "full-head" in str(excinfo.value)
+    with pytest.raises(AttributeError):
+        transforms.nosuchxfm
+
+
+def test_xfmset_getitem(db):
+    xfmset = db[SUBJECT].transforms["full-head"]
+    assert np.allclose(np.asarray(xfmset["coord"].xfm), np.eye(4))
+    with pytest.raises(KeyError) as excinfo:
+        xfmset["magnet"]
+    assert "coord" in str(excinfo.value)
+
+
+def test_warning_is_raised_on_item_access(db, filestore):
+    with open(os.path.join(filestore, SUBJECT, "warning.txt"), "w") as fp:
+        fp.write("this subject is a test")
+    db.reload_subjects()
+    with pytest.warns(UserWarning, match="this subject is a test"):
+        db[SUBJECT]

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -93,9 +93,9 @@ Finally, selecting one surface type will give you two new functions: get, and sh
     In [6]: left, right = cortex.db.S1.surfaces.inflated.get()
     In [7]: cortex.db.S1.surfaces.fiducial.show()
 
-Subject names that are not valid python identifiers
+Subject names that are not valid Python identifiers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Attribute access only works for names that happen to be valid python
+Attribute access only works for names that happen to be valid Python
 identifiers, so a subject called ``S1-test`` cannot be reached as
 ``cortex.db.S1-test``. Every level of the tab interface also supports item
 access, which works for any name::

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -93,6 +93,20 @@ Finally, selecting one surface type will give you two new functions: get, and sh
     In [6]: left, right = cortex.db.S1.surfaces.inflated.get()
     In [7]: cortex.db.S1.surfaces.fiducial.show()
 
+Subject names that are not valid python identifiers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Attribute access only works for names that happen to be valid python
+identifiers, so a subject called ``S1-test`` cannot be reached as
+``cortex.db.S1-test``. Every level of the tab interface also supports item
+access, which works for any name::
+
+    In [8]: cortex.db['S1-test']
+    In [9]: cortex.db['S1-test'].surfaces['flat'].get()
+    In [10]: cortex.db['S1-test'].transforms['fullhead']['coord'].xfm
+
+You can also test for a subject with ``'S1-test' in cortex.db`` and iterate
+over the subject names with ``for subject in cortex.db``.
+
 
 Adding new surfaces
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
This PR adds `__getitem__` support throughout the database access hierarchy, enabling users to access subjects, surfaces, and transforms by name using bracket notation (e.g., `db['S1-test']`). This is essential for names that are not valid Python identifiers and cannot be accessed via attribute notation.

## Key Changes

- **Database class**: Added `__getitem__`, `__contains__`, and `__iter__` methods to support item access for subjects. Improved `__getattr__` to provide helpful error messages directing users to use item access for non-identifier names.

- **SubjectDB.surfaces (Surfaces class)**: Added `__getitem__` method with informative KeyError messages listing available surfaces. Updated `__getattr__` to avoid recursion issues with dunder attributes.

- **SubjectDB.transforms (Transforms class)**: Added `__getitem__` method, `__dir__` method, and improved `__getattr__` to support both item and attribute access patterns.

- **XfmSet class**: Added `__getitem__` method for accessing transform types (e.g., 'coord', 'magnet'), `__dir__` method, and improved `__getattr__` with better error handling.

- **Error handling**: All `__getitem__` implementations now raise `KeyError` (not `AttributeError`) with helpful messages listing available options. Dunder attributes are explicitly excluded from filestore lookups to prevent recursion during object construction, copying, or pickling.

- **Documentation**: Updated `docs/database.rst` with examples and explanation of item access for non-identifier names, including usage of `in` operator and iteration.

- **Tests**: Added comprehensive test suite (`cortex/tests/test_database.py`) covering item access, attribute access, error messages, dunder attribute handling, and warning behavior.

## Notable Implementation Details

- Dunder attributes (`__*__`) are explicitly checked and raise `AttributeError` before attempting filestore lookups, preventing infinite recursion during object operations.
- Error messages consistently list available options to help users discover valid names.
- The implementation maintains backward compatibility with existing attribute-based access while adding the new item-based access pattern.

https://claude.ai/code/session_01XvzkAD2Fu6irNYq4uKyfRT