### PR TITLE
ENH {Vertex,Volume}.random uses low-frequency noise

### DIFF
--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -192,7 +192,7 @@ class VolumeData(BrainData):
     @classmethod
     def random(cls, subject: str, xfmname: str,
                random_type: Literal['low_frequency', 'uniform']='low_frequency',
-               falloff_exponent: float=-2.0,
+               falloff_exponent: float=-1.25,
                **kwargs) -> Self:
         """
         Create a random-valued VolumeData for the given subject and xfmname.
@@ -419,7 +419,7 @@ class VertexData(BrainData):
 
     @classmethod
     def random(cls, subject: str, random_type: Literal['low_frequency', 'uniform']='low_frequency',
-               smooth_factor: float=20,
+               smooth_factor: float=40,
                **kwargs) -> Self:
         """
         Create a random-valued VertexData for the given subject.
@@ -728,7 +728,7 @@ def _hdf_write(h5: Union[h5py.File, h5py.Group], data: npt.NDArray, name: str="d
 
 # Make low frequency 3d data
 def _low_freq_noise(size: Union[int, tuple[int, int, int]],
-                     falloff_exponent: float=-2) -> npt.NDArray[np.float64]:
+                     falloff_exponent: float=-1.25) -> npt.NDArray[np.float64]:
     """Make low-frequency noise
     
     Parameters

--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -14,7 +14,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..database import db
-
+from .. import polyutils
 
 class BrainData:
     """
@@ -190,7 +190,7 @@ class VolumeData(BrainData):
         return cls(np.ones(shape)*value, subject, xfmname, **kwargs)
 
     @classmethod
-    def random(cls, subject: str, xfmname: str, **kwargs) -> Self:
+    def random(cls, subject: str, xfmname: str, random_type='low_frequency', **kwargs) -> Self:
         """
         Create a random-valued VolumeData for the given subject and xfmname.
         Random values are from gaussian distribution with mean 0, s.d. 1.
@@ -202,6 +202,11 @@ class VolumeData(BrainData):
             Subject identifier. Must exist in the pycortex database.
         xfmname : str
             Transform name. Must exist in the pycortex database.
+        random_type : str, optional
+            type of random data to use. Default: uniform. One of
+            ('low_frequency', 'uniform')
+            'low_frequency' yields blobby, brain-like data
+            'uniform' yields uniform random noise. 
         **kwargs
             Other keyword arguments are passed to the init function for this 
             class.
@@ -213,7 +218,17 @@ class VolumeData(BrainData):
         """
         xfm = db.get_xfm(subject, xfmname)
         shape = xfm.shape
-        return cls(np.random.randn(*shape), subject, xfmname, **kwargs)
+        if random_type == 'uniform':
+            rdata = np.random.randn(*shape)
+        elif random_type == 'low_frequency':
+            if 'falloff_exponent' in kwargs:
+                falloff_exponent = kwargs.pop('falloff_exponent')
+            else:
+                falloff_exponent = -2.0
+            rdata = _low_freq_noise(shape, falloff_exponent=falloff_exponent)
+        else:
+            raise ValueError("random_type must be one of ('low_frequency', 'uniform')")
+        return cls(rdata, subject, xfmname, **kwargs)
 
     def _check_size(self, mask: Union[npt.NDArray, str, None]) -> None:
         if self.data.ndim not in (1, 2, 3, 4):
@@ -400,7 +415,8 @@ class VertexData(BrainData):
         return cls(np.ones((nverts,))*value, subject, **kwargs)
 
     @classmethod
-    def random(cls, subject: str, **kwargs):
+    def random(cls, subject: str, random_type='low_frequency', 
+               **kwargs):
         """
         Create a random-valued VertexData for the given subject.
         Random values are from gaussian distribution with mean 0, s.d. 1.
@@ -410,6 +426,11 @@ class VertexData(BrainData):
         ----------
         subject : str
             Subject identifier. Must exist in the pycortex database.
+        random_type : str, optional
+            type of random data to use. Default: uniform. One of
+            ('low_frequency', 'uniform')
+            'low_frequency' yields blobby, brain-like data
+            'uniform' yields uniform random noise.
         **kwargs
             Other keyword arguments are passed to the init function for this 
             class.
@@ -424,7 +445,23 @@ class VertexData(BrainData):
         except IOError:
             left, right = db.get_surf(subject, "fiducial")
         nverts = len(left[0]) + len(right[0])
-        return cls(np.random.randn(nverts), subject, **kwargs)
+        if random_type == 'uniform':
+            rdata = np.random.randn(nverts)
+        elif random_type == 'low_frequency':
+            # THis may be slow
+            if 'smooth_factor' in kwargs:
+                smooth_factor = kwargs.pop('smooth_factor')
+            else:
+                smooth_factor = 20
+            (lpts, lpolys), (rpts, rpolys) = db.get_surf(subject, 'fiducial', )
+            ldata = polyutils.Surface(lpts, lpolys).smooth(np.random.randn(len(lpts)), factor=smooth_factor)
+            rdata = polyutils.Surface(rpts, rpolys).smooth(np.random.randn(len(rpts)), factor=smooth_factor)
+            rand_data = np.hstack([ldata, rdata]) 
+        else:
+            left, right = db.get_surf(subject, "fiducial")
+            pass # Throw valueerror
+
+        return cls(rand_data, subject, **kwargs)
 
     def _set_data(self, data: npt.NDArray):
         """
@@ -684,3 +721,31 @@ def _hdf_write(h5: Union[h5py.File, h5py.Group], data: npt.NDArray, name: str="d
 
     node[:] = data
     return node
+
+
+# Make low frequency 3d data
+def _low_freq_noise(size, falloff_exponent=-2):
+    """Make low-frequency noise
+    
+    Parameters
+    ----------
+    size : scalar or tuple
+        size of array to generate
+    falloff_exponent: negative scalar
+        factor by which Fourier power falls off (falls off as `x**falloff_exponent`)
+        Higher numbers emphasize low frequencies more strongly.
+    """
+    if isinstance(size, tuple):
+        xd, yd, zd = size
+    else:
+        xd = yd = zd = size
+    x, y, z = np.meshgrid(np.linspace(-1, 1, xd), np.linspace(-1, 1, yd), np.linspace(-1, 1, zd))
+    C = (x**2 + y**2 + z**2)**0.5
+    C[C == 0] = np.min(C[C != 0])
+    r = np.random.rand(yd, xd, zd)
+    f = np.fft.fftshift(np.fft.fftn(r))
+    falloff = C**falloff_exponent - 1
+    falloff = (falloff - falloff.min()) / np.ptp(falloff)
+    fr = f * falloff
+    rr = np.fft.ifftn(np.fft.ifftshift(fr))
+    return rr.real

--- a/cortex/dataset/braindata.py
+++ b/cortex/dataset/braindata.py
@@ -3,7 +3,7 @@ import warnings
 from copy import deepcopy
 import os
 import sys
-from typing import Generic, Optional, TypeVar, Union, cast
+from typing import Generic, Literal, Optional, TypeVar, Union, cast
 if sys.version_info < (3, 11):
     from typing_extensions import Self
 else:
@@ -190,7 +190,10 @@ class VolumeData(BrainData):
         return cls(np.ones(shape)*value, subject, xfmname, **kwargs)
 
     @classmethod
-    def random(cls, subject: str, xfmname: str, random_type='low_frequency', **kwargs) -> Self:
+    def random(cls, subject: str, xfmname: str,
+               random_type: Literal['low_frequency', 'uniform']='low_frequency',
+               falloff_exponent: float=-2.0,
+               **kwargs) -> Self:
         """
         Create a random-valued VolumeData for the given subject and xfmname.
         Random values are from gaussian distribution with mean 0, s.d. 1.
@@ -203,12 +206,16 @@ class VolumeData(BrainData):
         xfmname : str
             Transform name. Must exist in the pycortex database.
         random_type : str, optional
-            type of random data to use. Default: uniform. One of
+            type of random data to use. Default: low_frequency. One of
             ('low_frequency', 'uniform')
             'low_frequency' yields blobby, brain-like data
-            'uniform' yields uniform random noise. 
+            'uniform' yields uniform random noise.
+        falloff_exponent : float, optional
+            Only used when random_type is 'low_frequency'. Factor by which
+            Fourier power falls off. Higher magnitude emphasizes low
+            frequencies more strongly.
         **kwargs
-            Other keyword arguments are passed to the init function for this 
+            Other keyword arguments are passed to the init function for this
             class.
 
         Returns
@@ -221,10 +228,6 @@ class VolumeData(BrainData):
         if random_type == 'uniform':
             rdata = np.random.randn(*shape)
         elif random_type == 'low_frequency':
-            if 'falloff_exponent' in kwargs:
-                falloff_exponent = kwargs.pop('falloff_exponent')
-            else:
-                falloff_exponent = -2.0
             rdata = _low_freq_noise(shape, falloff_exponent=falloff_exponent)
         else:
             raise ValueError("random_type must be one of ('low_frequency', 'uniform')")
@@ -300,7 +303,7 @@ class VolumeData(BrainData):
     def copy(self, data: npt.NDArray) -> Self:
         return super().copy(data, self.subject, self.xfmname, mask=self._mask)
 
-    # TODO: need to include np.ma.MaskedArra in return type?
+    # TODO: need to include np.ma.MaskedArray in return type?
     @property
     def volume(self) -> npt.NDArray:
         """Returns a 3D or 4D volume for this VolumeData, automatically unmasking
@@ -387,7 +390,7 @@ class VertexData(BrainData):
         self._set_data(data)
 
     @classmethod
-    def empty(cls, subject: str, value: float = 0, **kwargs):
+    def empty(cls, subject: str, value: float = 0, **kwargs) -> Self:
         """
         Create a constant-valued VertexData for the given subject.
         Often useful for testing purposes.
@@ -415,8 +418,9 @@ class VertexData(BrainData):
         return cls(np.ones((nverts,))*value, subject, **kwargs)
 
     @classmethod
-    def random(cls, subject: str, random_type='low_frequency', 
-               **kwargs):
+    def random(cls, subject: str, random_type: Literal['low_frequency', 'uniform']='low_frequency',
+               smooth_factor: float=20,
+               **kwargs) -> Self:
         """
         Create a random-valued VertexData for the given subject.
         Random values are from gaussian distribution with mean 0, s.d. 1.
@@ -427,12 +431,16 @@ class VertexData(BrainData):
         subject : str
             Subject identifier. Must exist in the pycortex database.
         random_type : str, optional
-            type of random data to use. Default: uniform. One of
+            type of random data to use. Default: low_frequency. One of
             ('low_frequency', 'uniform')
             'low_frequency' yields blobby, brain-like data
             'uniform' yields uniform random noise.
+        smooth_factor : float, optional
+            Only used when random_type is 'low_frequency'. Amount of
+            smoothing to apply to the underlying random data; larger values
+            smooth more. Passed as `factor` to `polyutils.Surface.smooth`.
         **kwargs
-            Other keyword arguments are passed to the init function for this 
+            Other keyword arguments are passed to the init function for this
             class.
 
         Returns
@@ -440,26 +448,21 @@ class VertexData(BrainData):
         VertexData subclass
             A VertexData subclass object with random data.
         """
-        try:
-            left, right = db.get_surf(subject, "wm")
-        except IOError:
-            left, right = db.get_surf(subject, "fiducial")
-        nverts = len(left[0]) + len(right[0])
         if random_type == 'uniform':
-            rdata = np.random.randn(nverts)
+            try:
+                left, right = db.get_surf(subject, "wm")
+            except IOError:
+                left, right = db.get_surf(subject, "fiducial")
+            nverts = len(left[0]) + len(right[0])
+            rand_data = np.random.randn(nverts)
         elif random_type == 'low_frequency':
-            # THis may be slow
-            if 'smooth_factor' in kwargs:
-                smooth_factor = kwargs.pop('smooth_factor')
-            else:
-                smooth_factor = 20
-            (lpts, lpolys), (rpts, rpolys) = db.get_surf(subject, 'fiducial', )
+            (lpts, lpolys), (rpts, rpolys) = db.get_surf(subject, 'fiducial')
             ldata = polyutils.Surface(lpts, lpolys).smooth(np.random.randn(len(lpts)), factor=smooth_factor)
             rdata = polyutils.Surface(rpts, rpolys).smooth(np.random.randn(len(rpts)), factor=smooth_factor)
-            rand_data = np.hstack([ldata, rdata]) 
+            rand_data = np.hstack([ldata, rdata])
+            rand_data = (rand_data - rand_data.mean()) / rand_data.std()
         else:
-            left, right = db.get_surf(subject, "fiducial")
-            pass # Throw valueerror
+            raise ValueError("random_type must be one of ('low_frequency', 'uniform')")
 
         return cls(rand_data, subject, **kwargs)
 
@@ -724,7 +727,8 @@ def _hdf_write(h5: Union[h5py.File, h5py.Group], data: npt.NDArray, name: str="d
 
 
 # Make low frequency 3d data
-def _low_freq_noise(size, falloff_exponent=-2):
+def _low_freq_noise(size: Union[int, tuple[int, int, int]],
+                     falloff_exponent: float=-2) -> npt.NDArray[np.float64]:
     """Make low-frequency noise
     
     Parameters
@@ -739,13 +743,17 @@ def _low_freq_noise(size, falloff_exponent=-2):
         xd, yd, zd = size
     else:
         xd = yd = zd = size
-    x, y, z = np.meshgrid(np.linspace(-1, 1, xd), np.linspace(-1, 1, yd), np.linspace(-1, 1, zd))
+    x, y, z = np.meshgrid(np.linspace(-1, 1, xd), np.linspace(-1, 1, yd), np.linspace(-1, 1, zd),
+                           indexing='ij')
     C = (x**2 + y**2 + z**2)**0.5
     C[C == 0] = np.min(C[C != 0])
-    r = np.random.rand(yd, xd, zd)
+    r = np.random.randn(xd, yd, zd)
     f = np.fft.fftshift(np.fft.fftn(r))
-    falloff = C**falloff_exponent - 1
+    falloff = C**falloff_exponent
     falloff = (falloff - falloff.min()) / np.ptp(falloff)
+    # Zero out the DC component so it doesn't dominate the (much smaller)
+    # amplitude of the other frequencies once weighted by `falloff`.
+    f[xd // 2, yd // 2, zd // 2] = 0
     fr = f * falloff
-    rr = np.fft.ifftn(np.fft.ifftshift(fr))
-    return rr.real
+    rr = np.fft.ifftn(np.fft.ifftshift(fr)).real
+    return (rr - rr.mean()) / rr.std()

--- a/cortex/tests/test_dataset.py
+++ b/cortex/tests/test_dataset.py
@@ -457,3 +457,19 @@ def test_nan_transparent_volume_raw_alpha_override():
     # Non-NaN positions should reflect the user's alpha
     assert not np.isnan(data[15, 50, 50])
     assert volume[0, 15, 50, 50, 3] > 0
+
+
+@pytest.mark.parametrize("random_type", ["uniform", "low_frequency"])
+def test_vertex_random(random_type):
+    data = cortex.Vertex.random(subj, random_type=random_type)
+    assert data.data.shape == (nverts,)
+    assert np.isclose(data.data.mean(), 0, atol=0.01)
+    assert np.isclose(data.data.std(), 1, atol=0.01)
+
+
+@pytest.mark.parametrize("random_type", ["uniform", "low_frequency"])
+def test_volume_random(random_type):
+    data = cortex.Volume.random(subj, xfmname, random_type=random_type)
+    assert data.data.shape == volshape
+    assert np.isclose(data.data.mean(), 0, atol=0.01)
+    assert np.isclose(data.data.std(), 1, atol=0.01)


### PR DESCRIPTION
make Volume.random() and Vertex.random() yield blobby (but still random) noise. This changes default behavior (to generate low frequency noise, which looks nicer and more like real data) but preserves old behavior if you change a keyword argument. Default can be reset, but part of the intent here is to change how demo data looks in the gallery (this setting should make for nicer looking plots for some gallery demos).