### PR TITLE
CI: let the Claude workflow run the test suite

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,39 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - uses: actions/cache@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install pycortex
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y inkscape --no-install-recommends
+          pip install --upgrade pip
+          pip install wheel setuptools numpy cython
+          pip install -e '.[headless]' --no-build-isolation
+          pip install -e . --no-build-isolation --group dev
+          python -c 'import cortex; print(cortex.__full_version__)'
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Chromium
+        run: playwright install --with-deps --only-shell chromium
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -43,8 +76,8 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
-
+          # Let Claude run the test suite without prompting. The steps above install
+          # the same environment as run_tests.yml, so `pytest` works out of the box
+          # and Claude never needs pip or a bare `python` here.
+          claude_args: |
+            --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*)"


### PR DESCRIPTION
Follow-up to #722. The `claude.yml` workflow added there checks out the repo and runs `claude-code-action` with no setup, so Claude cannot actually run anything Python — `import cortex` fails without the Cython extensions built.

## Changes

**Environment setup before the Claude step**, mirroring `run_tests.yml`:

- `setup-python` (3.12) + pip cache, reusing `run_tests.yml`'s cache key so runs on `main` warm it
- `inkscape` via apt, then `pip install -e '.[headless]'` and `-e . --group dev`
- `python -c 'import cortex'` smoke check, so a broken build fails the job loudly rather than confusing Claude
- Playwright browser cache + `playwright install --with-deps --only-shell chromium`

**A narrow tool allowlist** so the test run doesn't hit a permission prompt (which in Actions means it simply can't proceed):

```yaml
claude_args: |
  --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*)"
```

## Notes

- The allowlist is intentionally just pytest. With the environment pre-installed there's no need to grant `pip` or a bare `python`, and `Bash(python:*)` would be arbitrary code execution in a job holding `CLAUDE_CODE_OAUTH_TOKEN`.
- Pre-installing costs roughly 2-4 min on every `@claude` mention, including ones that never touch Python. The alternative — letting Claude install things itself — can't use `actions/cache`, re-derives the build steps each time, and needs `sudo apt-get` in the allowlist anyway. For a package with compiled extensions the tradeoff seemed worth it, but happy to revisit.
- The Playwright browsers cache; the apt `inkscape` install does not, and is re-downloaded each run (same as `run_tests.yml` today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)