### PR TITLE
CI: allow Claude workflow to run uv commands

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,4 +80,4 @@ jobs:
           # the same environment as run_tests.yml, so `pytest` works out of the box
           # and Claude never needs pip or a bare `python` here.
           claude_args: |
-            --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*)"
+            --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*),Bash(uv:*)"


### PR DESCRIPTION
## Summary
- Adds `Bash(uv:*)` to the Claude Code workflow's `--allowed-tools`, so Claude can run `uv` commands without a prompt (alongside the existing `pytest` allowances).

## Test plan
- N/A — CI config change only.