### PR TITLE
CI: install uv and narrow the Claude workflow allowlist

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,14 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # Cap runaway sessions: without this the job could run for the 6-hour
+    # default, burning runner minutes and API usage.
+    timeout-minutes: 30
+    # One Claude run at a time per issue/PR; extra @claude mentions queue up
+    # instead of running (and pushing) concurrently.
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
     env:
       # Make `uv pip` target the interpreter set up by actions/setup-python
       # instead of looking for a project virtualenv.
@@ -36,6 +44,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          # Don't leave GITHUB_TOKEN in .git/config, where anything pytest
+          # executes (e.g. a PR branch's conftest.py) could read it. The
+          # Claude action authenticates git with its own app token.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -43,11 +55,10 @@ jobs:
           python-version: "3.12"
 
       # setup-uv publishes no floating major tag past v7, so pin the exact
-      # release by commit SHA: this workflow runs with CLAUDE_CODE_OAUTH_TOKEN
-      # in scope, and a mutable tag on a third-party action is a supply-chain
-      # hole. Caching is on by default ("auto") for GitHub-hosted runners.
+      # release tag; dependabot keeps it updated. Caching is on by default
+      # ("auto") for GitHub-hosted runners.
       - name: Set up uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        uses: astral-sh/setup-uv@v10.0.1
 
       - uses: actions/cache@v6
         with:
@@ -102,5 +113,10 @@ jobs:
           # `uv run --with <pkg>` / `uv pip install` pull in arbitrary code first.
           # Only spell out the specific subcommands Claude needs, each with the
           # program to execute already fixed by the prefix.
+          #
+          # WebFetch/WebSearch are disallowed outright: issue and PR text is
+          # untrusted input, and network fetches are the easiest exfiltration
+          # channel for a prompt-injected session.
           claude_args: |
-            --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*),Bash(uv run pytest:*),Bash(uv run python -m pytest:*),Bash(uv run mypy:*),Bash(uv pip list:*),Bash(uv pip show:*),Bash(uv --version)"
+            --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*),Bash(uv run pytest:*),Bash(uv run python -m pytest:*),Bash(uv pip list:*),Bash(uv pip show:*),Bash(uv --version)"
+            --disallowed-tools "WebFetch,WebSearch"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,13 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    env:
+      # Make `uv pip` target the interpreter set up by actions/setup-python
+      # instead of looking for a project virtualenv.
+      UV_SYSTEM_PYTHON: 1
+      # `uv run` would otherwise resolve and build the project from scratch
+      # (there is no uv.lock), discarding the environment installed below.
+      UV_NO_SYNC: 1
     permissions:
       contents: read
       pull-requests: read
@@ -35,6 +42,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      # setup-uv publishes no floating major tag past v7, so pin the exact
+      # release by commit SHA: this workflow runs with CLAUDE_CODE_OAUTH_TOKEN
+      # in scope, and a mutable tag on a third-party action is a supply-chain
+      # hole. Caching is on by default ("auto") for GitHub-hosted runners.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+
       - uses: actions/cache@v6
         with:
           path: ~/.cache/pip
@@ -51,6 +65,9 @@ jobs:
           pip install -e '.[headless]' --no-build-isolation
           pip install -e . --no-build-isolation --group dev
           python -c 'import cortex; print(cortex.__full_version__)'
+          # Combined with UV_NO_SYNC, this makes `uv run <cmd>` execute inside the
+          # environment installed above rather than a throwaway project venv.
+          python -c 'import sys; print(f"UV_PROJECT_ENVIRONMENT={sys.prefix}")' >> "$GITHUB_ENV"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v6
@@ -79,5 +96,11 @@ jobs:
           # Let Claude run the test suite without prompting. The steps above install
           # the same environment as run_tests.yml, so `pytest` works out of the box
           # and Claude never needs pip or a bare `python` here.
+          #
+          # Keep this list narrow. A bare `Bash(uv:*)` is equivalent to allowing
+          # arbitrary shell: `uv run <anything>` executes any command, and
+          # `uv run --with <pkg>` / `uv pip install` pull in arbitrary code first.
+          # Only spell out the specific subcommands Claude needs, each with the
+          # program to execute already fixed by the prefix.
           claude_args: |
-            --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*),Bash(uv:*)"
+            --allowed-tools "Bash(pytest:*),Bash(python -m pytest:*),Bash(uv run pytest:*),Bash(uv run python -m pytest:*),Bash(uv run mypy:*),Bash(uv pip list:*),Bash(uv pip show:*),Bash(uv --version)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,18 @@ on:
 
 jobs:
   claude:
+    # The author_association checks are a cheap pre-filter so drive-by
+    # @claude mentions from non-members fail here instead of after the
+    # multi-minute environment setup. They are not the security boundary:
+    # claude-code-action independently verifies the actor has write access
+    # before running Claude. "assigned" issue events skip the filter because
+    # assigning already requires triage access, and the issue author (whose
+    # association is checked) may be an outside reporter.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.action == 'assigned' || contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)))
     runs-on: ubuntu-latest
     # Cap runaway sessions: without this the job could run for the 6-hour
     # default, burning runner minutes and API usage.


### PR DESCRIPTION
PR #728 added `Bash(uv:*)` to the Claude workflow's `--allowed-tools`, but the runner never had uv installed and the pattern was far too broad: `uv run <anything>` and `uv pip install` are arbitrary code execution in a workflow with `CLAUDE_CODE_OAUTH_TOKEN` in scope.

## Allowlist

- Replaced `Bash(uv:*)` with explicit entries that fix the executed program inside the matched prefix: `pytest`, `python -m pytest`, `uv run pytest`, `uv run python -m pytest`, plus read-only `uv pip list` / `uv pip show` / `uv --version`.
- Disallowed `WebFetch`/`WebSearch`: issue and PR text is untrusted input, and network fetches are the easiest exfiltration channel for a prompt-injected session.

## uv install

- `astral-sh/setup-uv` pinned to the exact release tag (it publishes no floating major tag past v7); dependabot keeps it updated.
- `UV_SYSTEM_PYTHON`, `UV_NO_SYNC`, and `UV_PROJECT_ENVIRONMENT` make `uv run` execute in the environment the workflow installs instead of re-resolving the project (there is no `uv.lock`).

## Workflow hardening

- Author-association pre-filter on the job `if:`, so `@claude` mentions from non-members fail in seconds instead of after the multi-minute environment setup. `assigned` issue events are exempt (assigning already requires triage access). This is a cost filter, not the security boundary — claude-code-action still independently verifies the actor has write access.
- `timeout-minutes: 30` (default was 6 hours).
- `concurrency` group per issue/PR, so extra `@claude` mentions queue instead of running in parallel.
- `persist-credentials: false` on checkout, so `GITHUB_TOKEN` isn't left in `.git/config` where code executed by pytest could read it.

Known residual: allowing pytest at all lets Claude execute the checked-out branch's `conftest.py`. That's inherent to running the test suite and predates #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
